### PR TITLE
use PropsWithChildren for typing

### DIFF
--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -74,7 +74,6 @@ export type LiveKitRoomProps = {
    * make sure to set the options directly on the room instance itself.
    */
   room?: Room;
-  children?: React.ReactNode | React.ReactNode[];
   simulateParticipants?: number | undefined;
 };
 
@@ -197,7 +196,7 @@ export function useLiveKitRoom(props: LiveKitRoomProps) {
  * </LiveKitRoom>
  * ```
  */
-export function LiveKitRoom(props: LiveKitRoomProps) {
+export function LiveKitRoom(props: React.PropsWithChildren<LiveKitRoomProps>) {
   const room = useLiveKitRoom(props);
   return (
     <RoomContext.Provider value={room}>

--- a/packages/react/src/components/ParticipantsLoop.tsx
+++ b/packages/react/src/components/ParticipantsLoop.tsx
@@ -6,7 +6,6 @@ import { cloneSingleChild } from '../utils';
 import { ParticipantView } from './participant/ParticipantView';
 
 type ParticipantsLoopProps = {
-  children: React.ReactNode | React.ReactNode[];
   filterDependencies?: Array<unknown>;
   filter?: (participants: Array<Participant>) => Array<Participant>;
 };
@@ -35,7 +34,7 @@ export const ParticipantsLoop = ({
   children,
   filter,
   filterDependencies,
-}: ParticipantsLoopProps) => {
+}: React.PropsWithChildren<ParticipantsLoopProps>) => {
   const participants = useParticipants({ filter, filterDependencies });
   return (
     <>

--- a/packages/react/src/components/PinContextProvider.tsx
+++ b/packages/react/src/components/PinContextProvider.tsx
@@ -20,12 +20,14 @@ function pinReducer(state: PinState, action: PinAction): PinState {
 }
 
 type PinContextProviderProps = {
-  children?: React.ReactNode | React.ReactNode[];
   onChange?: (pinState: PinState) => void;
 };
 
 // TODO: Remove the screen sharing handling from this component to separate things.
-export function PinContextProvider({ onChange, children }: PinContextProviderProps) {
+export function PinContextProvider({
+  onChange,
+  children,
+}: React.PropsWithChildren<PinContextProviderProps>) {
   const room = useRoomContext();
   const pinDefaultValue: PinState = { pinnedParticipant: undefined, pinnedSource: undefined };
   const [pinState, pinDispatch] = React.useReducer(pinReducer, pinDefaultValue);

--- a/packages/react/src/components/ScreenShareRenderer.tsx
+++ b/packages/react/src/components/ScreenShareRenderer.tsx
@@ -103,19 +103,17 @@ export const ScreenShareView = ({
   });
 
   return (
-    <>
-      <div {...htmlProps}>
-        <video
-          ref={screenEl}
-          style={{
-            width: '100%',
-            height: '100%',
-            display: hasActiveScreenShare ? 'block' : 'none',
-          }}
-        ></video>
-        <audio ref={audioEl}></audio>
-        {children}
-      </div>
-    </>
+    <div {...htmlProps}>
+      <video
+        ref={screenEl}
+        style={{
+          width: '100%',
+          height: '100%',
+          display: hasActiveScreenShare ? 'block' : 'none',
+        }}
+      ></video>
+      <audio ref={audioEl}></audio>
+      {children}
+    </div>
   );
 };

--- a/packages/react/src/components/participant/ParticipantView.tsx
+++ b/packages/react/src/components/participant/ParticipantView.tsx
@@ -50,10 +50,11 @@ function useParticipantView<T extends React.HTMLAttributes<HTMLElement>>({
   };
 }
 
-function ParticipantContextIfNeeded(props: {
-  children?: React.ReactNode | React.ReactNode[];
-  participant?: Participant;
-}) {
+function ParticipantContextIfNeeded(
+  props: React.PropsWithChildren<{
+    participant?: Participant;
+  }>,
+) {
   const hasContext = !!useMaybeParticipantContext();
   return props.participant && !hasContext ? (
     <ParticipantContext.Provider value={props.participant}>


### PR DESCRIPTION
Use the official React.PropsWithChildren to create props that also accept children.
Currently, only a subset of the possible child types was handled.