### PR TITLE
fix speaking indicator

### DIFF
--- a/packages/styles/scss/components/_participant-media.scss
+++ b/packages/styles/scss/components/_participant-media.scss
@@ -5,17 +5,10 @@
   object-position: center;
   aspect-ratio: 16 / 10;
   background-color: #000;
-  border-radius: var(--border-radius);
-  box-shadow: 0 0 0 1px var(--bg), 0 0 0 4px transparent;
-  transition: box-shadow 0.2s ease-in-out;
 
   // Flip the local participant camera video.
   &[data-local-participant='true'][data-source='camera'] {
     transform: rotateY(180deg);
-  }
-
-  [data-speaking='true'] > & {
-    box-shadow: 0 0 0 1px var(--bg), 0 0 0 3px var(--accent-bg);
   }
 
   &[data-orientation='landscape'] {

--- a/packages/styles/scss/components/_participant-tile.scss
+++ b/packages/styles/scss/components/_participant-tile.scss
@@ -3,6 +3,17 @@
   display: flex;
   flex-direction: column;
   gap: 0.375rem;
+  border-radius: var(--border-radius);
+  overflow: hidden;
+
+  // Speaking indicator
+  border: 2px solid transparent;
+  transition: border-color 0.2s ease-in-out;
+  transition-delay: 1s;
+  &[data-speaking='true'] {
+    border: 2px solid var(--accent-bg);
+    transition-delay: 0s;
+  }
 
   .focus-toggle-button {
     position: absolute;


### PR DESCRIPTION
This PR moves the speaking indicator to the participant tile instead of displaying directly on the participant video.
As always, @mdo, feel free to do your magic and re-design as you see fit. 🪄
I worked with a `transition-delay` when going from `isSpeaking` `true` to `false` to mitigate high freequenzie jitter.