### PR TITLE
Remove changesets for storybook, docs-gen

### DIFF
--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -1,9 +1,5 @@
 {
   "name": "@livekit/component-docs-storybook",
-<<<<<<< Updated upstream
-  "version": "1.0.11",
-=======
->>>>>>> Stashed changes
   "main": "index.js",
   "private": true,
   "license": "MIT",

--- a/tooling/docs-gen/package.json
+++ b/tooling/docs-gen/package.json
@@ -1,9 +1,5 @@
 {
   "name": "@livekit/components-docs-gen",
-<<<<<<< Updated upstream
-  "version": "0.0.10",
-=======
->>>>>>> Stashed changes
   "description": "Generate component docs.",
   "keywords": [
     "docs",


### PR DESCRIPTION
this will ignore storybook and docs-gen in `releases` as they don't have a version number any more. 
we can do this for all packages that aren't dependencies of others.