### PR TITLE
Remove observer polyfill

### DIFF
--- a/.changeset/tasty-jars-greet.md
+++ b/.changeset/tasty-jars-greet.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Remove ResizeObserver polyfill dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.15.1",
     "@livekit/components-core": "0.2.0",
-    "@react-hook/resize-observer": "^1.2.6",
+    "@react-hook/latest": "^1.0.3",
     "clsx": "^1.2.1",
     "email-regex": "^5.0.0",
     "url-regex": "^5.0.0"

--- a/packages/react/src/components/ConnectionState.tsx
+++ b/packages/react/src/components/ConnectionState.tsx
@@ -2,7 +2,7 @@ import { connectionStateObserver } from '@livekit/components-core';
 import type { Room } from 'livekit-client';
 import * as React from 'react';
 import { useEnsureRoom } from '../context';
-import { useObservableState } from '../utils';
+import { useObservableState } from '../hooks/utiltity-hooks';
 
 export interface ConnectionStatusProps extends React.HTMLAttributes<HTMLDivElement> {
   /**

--- a/packages/react/src/components/RoomName.tsx
+++ b/packages/react/src/components/RoomName.tsx
@@ -3,7 +3,7 @@ import { Room } from 'livekit-client';
 import * as React from 'react';
 
 import { useRoomContext } from '../context';
-import { useObservableState } from '../utils';
+import { useObservableState } from '../hooks/utiltity-hooks';
 
 export function useRoomInfo({ room }: { room: Room }) {
   const infoObserver = React.useMemo(() => roomInfoObserver(room), [room]);

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { useMaybeRoomContext } from '../../context';
 import { setupDeviceSelector, createMediaDeviceObserver } from '@livekit/components-core';
-import { mergeProps, useObservableState } from '../../utils';
+import { mergeProps } from '../../utils';
 import { Room } from 'livekit-client';
+import { useObservableState } from '../../hooks/utiltity-hooks';
 
 export function useMediaDevices({ kind }: { kind: MediaDeviceKind }) {
   const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -2,7 +2,8 @@ import { setupStartAudio } from '@livekit/components-core';
 import { Room } from 'livekit-client';
 import * as React from 'react';
 import { useRoomContext } from '../../context';
-import { mergeProps, useObservableState } from '../../utils';
+import { useObservableState } from '../../hooks/utiltity-hooks';
+import { mergeProps } from '../../utils';
 
 interface UseStartAudioProps {
   room: Room;

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -3,8 +3,8 @@ import { Track } from 'livekit-client';
 import * as React from 'react';
 import { mergeProps } from '../../mergeProps';
 import { useMaybeRoomContext } from '../../context';
-import { useObservableState } from '../../utils';
 import { getSourceIcon } from '../../assets/icons/util';
+import { useObservableState } from '../../hooks/utiltity-hooks';
 
 export type TrackToggleProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> & {
   source: Track.Source;

--- a/packages/react/src/components/layout/GridLayout.tsx
+++ b/packages/react/src/components/layout/GridLayout.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { TileLoop } from '../TileLoop';
 import { ParticipantFilter, useParticipants } from '../../hooks';
-import { mergeProps, useSize } from '../../utils';
+import { mergeProps } from '../../utils';
+import { useSize } from '../../hooks/utiltity-hooks';
 
 export interface GridLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
   /**

--- a/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
+++ b/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { setupConnectionQualityIndicator } from '@livekit/components-core';
 import { useEnsureParticipant } from '../../context';
 import { ConnectionQuality, Participant } from 'livekit-client';
-import { mergeProps, useObservableState } from '../../utils';
+import { mergeProps } from '../../utils';
 import { getConnectionQualityIcon } from '../../assets/icons/util';
+import { useObservableState } from '../../hooks/utiltity-hooks';
 
 export interface ConnectionQualityIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
   participant?: Participant;

--- a/packages/react/src/components/participant/ParticipantName.tsx
+++ b/packages/react/src/components/participant/ParticipantName.tsx
@@ -2,7 +2,8 @@ import { participantInfoObserver, setupParticipantName } from '@livekit/componen
 import { Participant } from 'livekit-client';
 import * as React from 'react';
 import { useEnsureParticipant } from '../../context';
-import { mergeProps, useObservableState } from '../../utils';
+import { useObservableState } from '../../hooks/utiltity-hooks';
+import { mergeProps } from '../../utils';
 
 export function useParticipantInfo({ participant }: ParticipantInfoProps) {
   const p = useEnsureParticipant(participant);

--- a/packages/react/src/components/participant/TrackMutedIndicator.tsx
+++ b/packages/react/src/components/participant/TrackMutedIndicator.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { mergeProps, useObservableState } from '../../utils';
+import { mergeProps } from '../../utils';
 import { setupTrackMutedIndicator } from '@livekit/components-core';
 import { Participant, Track } from 'livekit-client';
 import { useEnsureParticipant } from '../../context';
 import { getSourceIcon } from '../../assets/icons/util';
+import { useObservableState } from '../../hooks/utiltity-hooks';
 
 export interface TrackMutedIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
   source: Track.Source;

--- a/packages/react/src/hooks/participant-hooks.ts
+++ b/packages/react/src/hooks/participant-hooks.ts
@@ -9,7 +9,7 @@ import {
   ParticipantMedia,
   observeParticipantMedia,
 } from '@livekit/components-core';
-import { useObservableState } from '../utils';
+import { useObservableState } from '../hooks/utiltity-hooks';
 import { useEnsureParticipant, useRoomContext } from '../context';
 
 export type ParticipantFilter = Parameters<Participant[]['filter']>['0'];

--- a/packages/react/src/hooks/utiltity-hooks.ts
+++ b/packages/react/src/hooks/utiltity-hooks.ts
@@ -1,5 +1,6 @@
 // Utility hooks are not meant to be exposed to the user, that's why this file doesn't get included in hooks/index.tsx
-import { useEffect, useState } from 'react';
+import * as React from 'react';
+import useLatest from '@react-hook/latest';
 
 /**
  * Implementation used from https://github.com/juliencrn/usehooks-ts
@@ -13,13 +14,13 @@ export function useMediaQuery(query: string): boolean {
     return false;
   };
 
-  const [matches, setMatches] = useState<boolean>(getMatches(query));
+  const [matches, setMatches] = React.useState<boolean>(getMatches(query));
 
   function handleChange() {
     setMatches(getMatches(query));
   }
 
-  useEffect(() => {
+  React.useEffect(() => {
     const matchMedia = window.matchMedia(query);
 
     // Triggered at the first client-side load and if query changes
@@ -44,3 +45,96 @@ export function useMediaQuery(query: string): boolean {
 
   return matches;
 }
+
+/* eslint-disable no-return-assign */
+/* eslint-disable no-underscore-dangle */
+
+/**
+ * A React hook that fires a callback whenever ResizeObserver detects a change to its size
+ * code extracted from https://github.com/jaredLunde/react-hook/blob/master/packages/resize-observer/src/index.tsx in order to not include the polyfill for resize-observer
+ *
+ *   the `target` resizes
+ */
+export function useResizeObserver<T extends HTMLElement>(
+  target: React.RefObject<T> | T | null,
+  callback: UseResizeObserverCallback,
+) {
+  const resizeObserver = getResizeObserver();
+  const storedCallback = useLatest(callback);
+
+  React.useLayoutEffect(() => {
+    let didUnsubscribe = false;
+    const targetEl = target && 'current' in target ? target.current : target;
+    if (!targetEl) return;
+
+    function cb(entry: ResizeObserverEntry, observer: ResizeObserver) {
+      if (didUnsubscribe) return;
+      storedCallback.current(entry, observer);
+    }
+
+    resizeObserver.subscribe(targetEl as HTMLElement, cb);
+
+    return () => {
+      didUnsubscribe = true;
+      resizeObserver.unsubscribe(targetEl as HTMLElement, cb);
+    };
+  }, [target, resizeObserver, storedCallback]);
+
+  return resizeObserver.observer;
+}
+
+function createResizeObserver() {
+  let ticking = false;
+  let allEntries: ResizeObserverEntry[] = [];
+
+  const callbacks: Map<unknown, Array<UseResizeObserverCallback>> = new Map();
+
+  const observer = new ResizeObserver((entries: ResizeObserverEntry[], obs: ResizeObserver) => {
+    allEntries = allEntries.concat(entries);
+    if (!ticking) {
+      window.requestAnimationFrame(() => {
+        const triggered = new Set<Element>();
+        for (let i = 0; i < allEntries.length; i++) {
+          if (triggered.has(allEntries[i].target)) continue;
+          triggered.add(allEntries[i].target);
+          const cbs = callbacks.get(allEntries[i].target);
+          cbs?.forEach((cb) => cb(allEntries[i], obs));
+        }
+        allEntries = [];
+        ticking = false;
+      });
+    }
+    ticking = true;
+  });
+
+  return {
+    observer,
+    subscribe(target: HTMLElement, callback: UseResizeObserverCallback) {
+      observer.observe(target);
+      const cbs = callbacks.get(target) ?? [];
+      cbs.push(callback);
+      callbacks.set(target, cbs);
+    },
+    unsubscribe(target: HTMLElement, callback: UseResizeObserverCallback) {
+      const cbs = callbacks.get(target) ?? [];
+      if (cbs.length === 1) {
+        observer.unobserve(target);
+        callbacks.delete(target);
+        return;
+      }
+      const cbIndex = cbs.indexOf(callback);
+      if (cbIndex !== -1) cbs.splice(cbIndex, 1);
+      callbacks.set(target, cbs);
+    },
+  };
+}
+
+let _resizeObserver: ReturnType<typeof createResizeObserver>;
+
+const getResizeObserver = () =>
+  !_resizeObserver ? (_resizeObserver = createResizeObserver()) : _resizeObserver;
+
+export type UseResizeObserverCallback = (
+  entry: ResizeObserverEntry,
+  observer: ResizeObserver,
+) => unknown;

--- a/packages/react/src/prefabs/Chat.tsx
+++ b/packages/react/src/prefabs/Chat.tsx
@@ -1,7 +1,8 @@
 import { setupChat } from '@livekit/components-core';
 import * as React from 'react';
 import { useRoomContext } from '../context';
-import { cloneSingleChild, useObservableState } from '../utils';
+import { useObservableState } from '../hooks/utiltity-hooks';
+import { cloneSingleChild } from '../utils';
 import { ChatEntry, MessageFormatter } from './ChatEntry';
 
 export interface ChatProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { mergeProps as mergePropsReactAria } from './mergeProps';
-import { Observable } from 'rxjs';
-import useResizeObserver from '@react-hook/resize-observer';
 
 export type LKComponentAttributes<T extends HTMLElement> = React.HTMLAttributes<T>;
 
@@ -27,24 +25,6 @@ export function mergeProps<
 /**
  * @internal
  */
-export function useObservableState<T>(
-  observable: Observable<T>,
-  startWith: T,
-  dependencies: Array<any> = [observable],
-) {
-  const [state, setState] = React.useState<T>(startWith);
-  React.useEffect(() => {
-    // observable state doesn't run in SSR
-    if (typeof window === 'undefined') return;
-    const subscription = observable.subscribe(setState);
-    return () => subscription.unsubscribe();
-  }, dependencies);
-  return state;
-}
-
-/**
- * @internal
- */
 export function cloneSingleChild(
   children: React.ReactNode | React.ReactNode[],
   props?: Record<string, any>,
@@ -59,17 +39,3 @@ export function cloneSingleChild(
     return child;
   });
 }
-
-export const useSize = (target: React.RefObject<HTMLDivElement>) => {
-  const [size, setSize] = React.useState({ width: 0, height: 0 });
-  React.useLayoutEffect(() => {
-    if (target?.current) {
-      const { width, height } = target.current.getBoundingClientRect();
-      setSize({ width, height });
-    }
-  }, [target.current]);
-
-  // Where the magic happens
-  useResizeObserver(target, (entry) => setSize(entry.contentRect));
-  return size;
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,11 +1582,6 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@juggle/resize-observer@^3.3.1":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
-  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
-
 "@livekit/changesets-changelog-github@^0.0.3":
   version "0.0.3"
   resolved "https://registry.npmjs.org/@livekit/changesets-changelog-github/-/changesets-changelog-github-0.0.3.tgz"
@@ -1811,24 +1806,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@react-hook/latest@^1.0.2":
+"@react-hook/latest@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"
   integrity sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==
-
-"@react-hook/passive-layout-effect@^1.2.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
-  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
-
-"@react-hook/resize-observer@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@react-hook/resize-observer/-/resize-observer-1.2.6.tgz#9a8cf4c5abb09becd60d1d65f6bf10eec211e291"
-  integrity sha512-DlBXtLSW0DqYYTW3Ft1/GQFZlTdKY5VAFIC4+km6IK5NiPPDFchGbEJm1j6pSgMqPRHbUQgHJX7RaR76ic1LWA==
-  dependencies:
-    "@juggle/resize-observer" "^3.3.1"
-    "@react-hook/latest" "^1.0.2"
-    "@react-hook/passive-layout-effect" "^1.2.0"
 
 "@rollup/pluginutils@^4.2.0":
   version "4.2.1"


### PR DESCRIPTION
When installing the `@react-hook/resize-observer` hook, I didn't realise that it includes a rather large polyfill that's currently impossible to opt out of. 
IMO polyfill should be provided on the implementation side if needed, but not by default without the option to opt out. That's why I copied the source code - without the polyfill into the utility hooks.