### PR TITLE
Use explicit aspect ratio in focus-aside

### DIFF
--- a/.changeset/slimy-parents-think.md
+++ b/.changeset/slimy-parents-think.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-styles": patch
+---
+
+Use explicit aspect ratio in focus-aside

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -19,7 +19,7 @@
       "types": "./dist/types_unprefixed/styles.scss.d.ts"
     }
   },
-  "main": "dist/styles.css",
+  "main": "dist/general/styles.css",
   "files": [
     "dist",
     "icons",

--- a/packages/styles/scss/components/layout/_focus-layout.scss
+++ b/packages/styles/scss/components/layout/_focus-layout.scss
@@ -24,6 +24,7 @@
 
     .participant-tile {
       flex-shrink: 0;
+      aspect-ratio: 16 / 10;
     }
   }
 

--- a/packages/styles/scss/prefab-components/_participant-tile.scss
+++ b/packages/styles/scss/prefab-components/_participant-tile.scss
@@ -7,7 +7,6 @@
   overflow: hidden;
   border: var(--speaking-indicator-width) solid transparent;
   border-radius: var(--border-radius);
-
   transition-property: border-color;
   transition-timing-function: ease-in-out;
   // When participant stops talking the transition longer and starts with a delay.


### PR DESCRIPTION
also fixes the `yarn link` bug for the css package. 