### PR TITLE
Only populate room in useEffect to avoid strict mode disconnecting

### DIFF
--- a/.changeset/tall-tips-guess.md
+++ b/.changeset/tall-tips-guess.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Only populate room in useEffect to avoid strict mode disconnecting


### PR DESCRIPTION
@brkcrdk reported this in #260 earlier already, but wasn't able to reproduce. 
He debugged it further (thanks!) and it turns out in the combination of 
- react strict mode enabled and
- token is passed as a constant

react strict mode triggers the "unmount" of the useEffect which in turn issues a disconnect call on the room, because we want the component to auto-disconnect on onmount. But in this scenario we never even try to reconnect.
We didn't see it before because all examples are using the useToken hook which isn't populated on first render. 

The fix here now populates the `room` only in a useEffect call. This means on first render there's no room yet, and children will only be rendered once the room is available (in order to avoid context access issues). 
Would be happy about a nicer solution, but fwiw that's the same workaround I previously used for the legacy components. 
