### PR TITLE
Add import assertion for json import

### DIFF
--- a/.changeset/swift-lamps-protect.md
+++ b/.changeset/swift-lamps-protect.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-core': patch
+---
+
+Add import assertion to support recent nodeJS versions

--- a/.changeset/swift-lamps-protect.md
+++ b/.changeset/swift-lamps-protect.md
@@ -2,4 +2,4 @@
 '@livekit/components-core': patch
 ---
 
-Add import assertion to support recent nodeJS versions
+Replace tlds dependency with global-tld-list in order to avoid having to deal with JSON imports

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "vitest": "^0.26.3"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "rxjs": "^7.8.0",
     "email-regex": "^5.0.0",
     "ip-regex": "^5.0.0",
-    "tlds": "^1.236.0"
+    "global-tld-list": "^0.0.995"
   },
   "peerDependencies": {
     "livekit-client": "^1.6.2"

--- a/packages/core/src/helper/urlRegex.ts
+++ b/packages/core/src/helper/urlRegex.ts
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 import ipRegex from 'ip-regex';
-import tlds from 'tlds';
+import tlds from 'tlds' assert { type: 'json' };
 
 interface RegExOptions {
   /**

--- a/packages/core/src/helper/urlRegex.ts
+++ b/packages/core/src/helper/urlRegex.ts
@@ -21,8 +21,7 @@
 // THE SOFTWARE.
 
 import ipRegex from 'ip-regex';
-import tlds from 'tlds' assert { type: 'json' };
-
+import { TLDs } from 'global-tld-list';
 interface RegExOptions {
   /**
 		Only match an exact string. Useful with `RegExp#test` to check if a string is a URL.
@@ -51,7 +50,7 @@ export const createUrlRegExp = (options: RegExOptions) => {
   const tld = `(?:\\.${
     options.strict
       ? '(?:[a-z\\u00a1-\\uffff]{2,})'
-      : `(?:${tlds.sort((a, b) => b.length - a.length).join('|')})`
+      : `(?:${TLDs.sort((a, b) => b.length - a.length).join('|')})`
   })\\.?`;
   const port = '(?::\\d{2,5})?';
   const path = '(?:[/?#][^\\s"]*)?';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,7 +61,7 @@
     "typescript": "^4.9.4"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -49,7 +49,7 @@
     "vitest": "^0.28.1"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6459,6 +6459,11 @@ glob@^8.0.0, glob@^8.0.3, glob@^8.1.0:
     minimatch "^5.0.1"
     once "^1.3.0"
 
+global-tld-list@^0.0.995:
+  version "0.0.995"
+  resolved "https://registry.yarnpkg.com/global-tld-list/-/global-tld-list-0.0.995.tgz#8fdb70ee00e37e747c469f3cf8e6a2390207df3f"
+  integrity sha512-9XkQgCi748sER/Opllw71Q85qjNpFv+ILBiURoEnFMQYfNmBO/xstBLhTYft9ArbLAV1DVDpVxmsXQ3xED42Dw==
+
 global@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
@@ -10209,11 +10214,6 @@ tinyspy@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz"
   integrity sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==
-
-tlds@^1.236.0:
-  version "1.236.0"
-  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.236.0.tgz#a118eebe33261c577e3a3025144faeabb7dd813c"
-  integrity sha512-oP2PZ3KeGlgpHgsEfrtva3/K9kzsJUNliQSbCfrJ7JMCWFoCdtG+9YMq/g2AnADQ1v5tVlbtvKJZ4KLpy/P6MA==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
The lack of the assertion was causing crashes on nodeJS versions > 17.5 due to import assertions being mandatory https://nodejs.org/api/esm.html#import-assertions

First attempt to fix was to just add the `assert {type: 'json'}`. In order to maximise support across nodejs environments for the packages I then just replaced the dependency with a different one that's not using JSON as an export format.