### PR TITLE
Jonas/lk-2368-use-absolute-links-in-readme

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,8 +4,9 @@
   "license": "Apache-2.0",
   "author": "LiveKit",
   "repository": {
-    "url": "https://github.com/livekit/components-js",
-    "type": "git"
+    "type": "git",
+    "url": "https://github.com/livekit/components-js.git",
+    "directory": "/packages/core"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.4",
   "license": "Apache-2.0",
   "author": "LiveKit",
+  "repository": {
+    "url": "https://github.com/livekit/components-js",
+    "type": "git"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,8 +4,9 @@
   "license": "Apache-2.0",
   "author": "LiveKit",
   "repository": {
-    "url": "https://github.com/livekit/components-js",
-    "type": "git"
+    "type": "git",
+    "url": "https://github.com/livekit/components-js.git",
+    "directory": "/packages/react"
   },
   "exports": {
     ".": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,10 @@
   "version": "0.2.4",
   "license": "Apache-2.0",
   "author": "LiveKit",
+  "repository": {
+    "url": "https://github.com/livekit/components-js",
+    "type": "git"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.13",
   "license": "Apache-2.0",
   "author": "LiveKit",
+  "repository": {
+    "url": "https://github.com/livekit/components-js",
+    "type": "git"
+  },
   "exports": {
     ".": {
       "types": "./dist/types/general/styles.css.d.ts",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -4,8 +4,9 @@
   "license": "Apache-2.0",
   "author": "LiveKit",
   "repository": {
-    "url": "https://github.com/livekit/components-js",
-    "type": "git"
+    "type": "git",
+    "url": "https://github.com/livekit/components-js.git",
+    "directory": "/packages/styles"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Hopefully this should fix the dead links in the [README](https://www.npmjs.com/package/@livekit/components-react) on npm.

Source: 
- https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository
- https://stackoverflow.com/questions/62575382/relative-link-from-readme-md-to-another-file-in-package-rendered-in-npmjs
