### PR TITLE
fix TileLoop template not respecting provided template for mainSource

### DIFF
--- a/.changeset/ninety-shoes-taste.md
+++ b/.changeset/ninety-shoes-taste.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Fix TileLoop child (template) not used for main source.

--- a/packages/react/src/components/TileLoop.tsx
+++ b/packages/react/src/components/TileLoop.tsx
@@ -80,17 +80,34 @@ export function TileLoop({
       {filteredParticipants.map((participant) => (
         <ParticipantContext.Provider value={participant} key={participant.identity}>
           {(!excludePinnedTracks ||
-            !isParticipantSourcePinned(participant, mainSource, layoutContext?.pin.state)) && (
-            <ParticipantTile trackSource={mainSource} />
-          )}
+            !isParticipantSourcePinned(participant, mainSource, layoutContext?.pin.state)) &&
+            (props.children ? (
+              cloneSingleChild(
+                props.children,
+                { trackSource: mainSource },
+                `${participant.identity}-${mainSource}-main`,
+              )
+            ) : (
+              <ParticipantTile
+                key={`${participant.identity}-${mainSource}-main`}
+                trackSource={mainSource}
+              />
+            ))}
 
           {filteredSecondaryPairs
             .filter(({ participant: p }) => p.identity === participant.identity)
-            .map(({ track }, index) =>
+            .map(({ track }) =>
               props.children ? (
-                cloneSingleChild(props.children, { trackSource: track.source }, index)
+                cloneSingleChild(
+                  props.children,
+                  { trackSource: track.source },
+                  `${participant.identity}-${track.source}-secondary`,
+                )
               ) : (
-                <ParticipantTile key={index} trackSource={track.source} />
+                <ParticipantTile
+                  key={`${participant.identity}-${track.source}-secondary`}
+                  trackSource={track.source}
+                />
               ),
             )}
         </ParticipantContext.Provider>


### PR DESCRIPTION
When providing a child component to the TileLoop, we expect this template to be used for main and secondary sources. Currently, this was not the case as it was only used for secondary sources.