### PR TITLE
rename TrackParticipantPair to TrackBundle

### DIFF
--- a/docs/storybook/.storybook/lk-decorators/LayoutContext.tsx
+++ b/docs/storybook/.storybook/lk-decorators/LayoutContext.tsx
@@ -39,7 +39,10 @@ const ContextWrapper = ({
         const participant = participants[0];
         if (participant) {
           const track = participant.getTrack(Track.Source.Camera)!;
-          dispatch({ msg: 'set_pin', trackParticipantPair: { participant, track } });
+          dispatch({
+            msg: 'set_pin',
+            trackBundle: { participant, source: track.source, publication: track },
+          });
         }
       } else {
         dispatch({ msg: 'clear_pin' });

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -89,7 +89,7 @@ export function trackBundlesObservable(
   options: TrackBundlesObservableOptions,
 ): Observable<{ trackBundles: TrackBundle[]; participants: Participant[] }> {
   const additionalRoomEvents = options.additionalRoomEvents ?? allRemoteParticipantRoomEvents;
-  const onlySubscribedTracks: boolean = options.onlySubscribed ?? false;
+  const onlySubscribedTracks: boolean = options.onlySubscribed ?? true;
   const roomEventSubscriptions: Subscription[] = [];
 
   const observable = new Observable<{

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -10,7 +10,7 @@ import {
 import { Observable, startWith, Subscription } from 'rxjs';
 import { allRemoteParticipantRoomEvents } from '../helper';
 import log from '../logger';
-import { TrackParticipantPair } from '../types';
+import { TrackBundle } from '../types';
 import { roomEventSelector } from './room';
 
 export function trackObservable(track: TrackPublication) {
@@ -54,10 +54,10 @@ export function observeTrackEvents(track: TrackPublication, ...events: TrackEven
 function getTrackParticipantPairs(
   room: Room,
   sources: Track.Source[],
-): { trackBundles: TrackParticipantPair[]; participants: Participant[] } {
+): { trackBundles: TrackBundle[]; participants: Participant[] } {
   const localParticipant = room.localParticipant;
   const allParticipants = [localParticipant, ...Array.from(room.participants.values())];
-  const pairs: TrackParticipantPair[] = [];
+  const pairs: TrackBundle[] = [];
 
   allParticipants.forEach((participant) => {
     sources.forEach((source) => {
@@ -79,11 +79,11 @@ export function trackParticipantPairsObservable(
   room: Room,
   sources: Track.Source[],
   options: TrackParticipantPairsObservableOptions,
-): Observable<{ trackBundles: TrackParticipantPair[]; participants: Participant[] }> {
+): Observable<{ trackBundles: TrackBundle[]; participants: Participant[] }> {
   const roomEventSubscriptions: Subscription[] = [];
 
   const observable = new Observable<{
-    trackBundles: TrackParticipantPair[];
+    trackBundles: TrackBundle[];
     participants: Participant[];
   }>((subscribe) => {
     // Get and emit initial values.

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -62,14 +62,19 @@ function getTrackBundles(
 
   allParticipants.forEach((participant) => {
     sources.forEach((source) => {
-      const track = participant.getTrack(source);
-      if (track) {
-        if (track.isSubscribed || track instanceof LocalTrackPublication) {
+      const publication = participant.getTrack(source);
+      if (publication) {
+        if (publication.isSubscribed || publication instanceof LocalTrackPublication) {
           // Include subscribed `TrackPublications`.
-          trackBundles.push({ participant, source, publication: track, track: track });
+          trackBundles.push({
+            participant,
+            source,
+            publication,
+            track: publication.track,
+          });
         } else if (!onlySubscribedTracks) {
           // Include also `TrackPublications` that are not subscribed.
-          trackBundles.push({ participant, source, publication: track });
+          trackBundles.push({ participant, source, publication });
         }
       }
     });

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -68,13 +68,12 @@ function getTrackBundles(
           // Include subscribed `TrackPublications`.
           trackBundles.push({
             participant,
-            source,
             publication,
             track: publication.track,
           });
         } else if (!onlySubscribedTracks) {
           // Include also `TrackPublications` that are not subscribed.
-          trackBundles.push({ participant, source, publication });
+          trackBundles.push({ participant, publication });
         }
       }
     });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,7 +16,7 @@ export type TrackBundleSubscribed = {
   participant: Participant;
   source: Track.Source;
   publication: TrackPublication;
-  track: TrackPublication;
+  track: NonNullable<TrackPublication['track']>;
 };
 
 export type TrackBundlePublished = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 import type { Participant, Track, TrackPublication } from 'livekit-client';
 
 // ## PinState Type
-export type PinState = Array<TrackParticipantPair>;
+export type PinState = Array<TrackBundle>;
 export const PIN_DEFAULT_STATE: PinState = [];
 
 // ## WidgetState Types
@@ -10,8 +10,8 @@ export type WidgetState = {
 };
 export const WIDGET_DEFAULT_STATE: WidgetState = { showChat: false };
 
-// ## TrackParticipantPair Types
-export type TrackParticipantPair = {
+// ## TrackBundle Types
+export type TrackBundle = {
   track: TrackPublication;
   participant: Participant;
 };
@@ -25,12 +25,10 @@ export type TrackParticipantPlaceholder = {
   source: Track.Source;
   participant: Participant;
 };
-export type MaybeTrackParticipantPair = TrackParticipantPair | TrackParticipantPlaceholder;
+export type MaybeTrackParticipantPair = TrackBundle | TrackParticipantPlaceholder;
 
-// ### TrackParticipantPair Type Predicates
-export function isTrackParticipantPair(
-  item: MaybeTrackParticipantPair,
-): item is TrackParticipantPair {
+// ### TrackBundle Type Predicates
+export function isTrackParticipantPair(item: MaybeTrackParticipantPair): item is TrackBundle {
   return item.track !== undefined;
 }
 
@@ -58,7 +56,7 @@ export function isSourcesWithOptions(sources: SourcesArray): sources is TrackSou
 }
 
 // ## Loop Filter Types
-export type TrackFilter = Parameters<TrackParticipantPair[]['filter']>['0'];
+export type TrackFilter = Parameters<TrackBundle[]['filter']>['0'];
 export type ParticipantFilter = Parameters<Participant[]['filter']>['0'];
 export type TileFilter = Parameters<MaybeTrackParticipantPair[]['filter']>['0'];
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,14 +14,12 @@ export const WIDGET_DEFAULT_STATE: WidgetState = { showChat: false };
 
 export type TrackBundleSubscribed = {
   participant: Participant;
-  source: Track.Source;
   publication: TrackPublication;
   track: NonNullable<TrackPublication['track']>;
 };
 
 export type TrackBundlePublished = {
   participant: Participant;
-  source: Track.Source;
   publication: TrackPublication;
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 import type { Participant, Track, TrackPublication } from 'livekit-client';
 
 // ## PinState Type
-export type PinState = Array<TrackBundle>;
+export type PinState = TrackBundle[];
 export const PIN_DEFAULT_STATE: PinState = [];
 
 // ## WidgetState Types
@@ -11,31 +11,55 @@ export type WidgetState = {
 export const WIDGET_DEFAULT_STATE: WidgetState = { showChat: false };
 
 // ## TrackBundle Types
-export type TrackBundle = {
-  track: TrackPublication;
+
+export type TrackBundleSubscribed = {
   participant: Participant;
-};
-/**
- * A participant with no published tracks.
- * @remarks
- * Useful if you want to have a representation for participants without a published track.
- */
-export type TrackParticipantPlaceholder = {
-  track: undefined;
   source: Track.Source;
-  participant: Participant;
+  publication: TrackPublication;
+  track: TrackPublication;
 };
-export type MaybeTrackParticipantPair = TrackBundle | TrackParticipantPlaceholder;
+
+export type TrackBundlePublished = {
+  participant: Participant;
+  source: Track.Source;
+  publication: TrackPublication;
+};
+
+export type TrackBundlePlaceholder = {
+  participant: Participant;
+  source: Track.Source;
+};
+
+export type TrackBundle = TrackBundleSubscribed | TrackBundlePublished;
+export type TrackBundleWithPlaceholder =
+  | TrackBundleSubscribed
+  | TrackBundlePublished
+  | TrackBundlePlaceholder;
 
 // ### TrackBundle Type Predicates
-export function isTrackParticipantPair(item: MaybeTrackParticipantPair): item is TrackBundle {
-  return item.track !== undefined;
+export function isTrackBundle(bundle: TrackBundleWithPlaceholder): bundle is TrackBundle {
+  return (
+    isTrackBundleSubscribed(bundle as TrackBundle) || isTrackBundlePublished(bundle as TrackBundle)
+  );
 }
 
-export function isTrackParticipantPlaceholder(
-  item: MaybeTrackParticipantPair,
-): item is TrackParticipantPlaceholder {
-  return item.track === undefined && item.hasOwnProperty('source');
+export function isTrackBundleSubscribed(bundle: TrackBundle): bundle is TrackBundleSubscribed {
+  return bundle.hasOwnProperty('track');
+}
+
+export function isTrackBundlePublished(bundle: TrackBundle): bundle is TrackBundlePublished {
+  return bundle.hasOwnProperty('publication') && !bundle.hasOwnProperty('track');
+}
+
+export function isTrackBundlePlaceholder(
+  bundle: TrackBundleWithPlaceholder,
+): bundle is TrackBundlePlaceholder {
+  return (
+    bundle.hasOwnProperty('participant') &&
+    bundle.hasOwnProperty('source') &&
+    !bundle.hasOwnProperty('publication') &&
+    !bundle.hasOwnProperty('track')
+  );
 }
 
 // ## Track Source Types
@@ -56,9 +80,8 @@ export function isSourcesWithOptions(sources: SourcesArray): sources is TrackSou
 }
 
 // ## Loop Filter Types
-export type TrackFilter = Parameters<TrackBundle[]['filter']>['0'];
+export type TrackBundleFilter = Parameters<TrackBundleWithPlaceholder[]['filter']>['0'];
 export type ParticipantFilter = Parameters<Participant[]['filter']>['0'];
-export type TileFilter = Parameters<MaybeTrackParticipantPair[]['filter']>['0'];
 
 // ## Other Types
 export interface ParticipantClickEvent {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,11 +41,11 @@ export function isTrackBundle(bundle: TrackBundleWithPlaceholder): bundle is Tra
   );
 }
 
-export function isTrackBundleSubscribed(bundle: TrackBundle): bundle is TrackBundleSubscribed {
+function isTrackBundleSubscribed(bundle: TrackBundle): bundle is TrackBundleSubscribed {
   return bundle.hasOwnProperty('track');
 }
 
-export function isTrackBundlePublished(bundle: TrackBundle): bundle is TrackBundlePublished {
+function isTrackBundlePublished(bundle: TrackBundle): bundle is TrackBundlePublished {
   return bundle.hasOwnProperty('publication') && !bundle.hasOwnProperty('track');
 }
 

--- a/packages/core/src/utilis.test.ts
+++ b/packages/core/src/utilis.test.ts
@@ -1,33 +1,45 @@
 import { Participant, Track, TrackPublication } from 'livekit-client';
 import { describe, it, expect } from 'vitest';
-import { PinState, TrackBundle } from './types';
-import { isParticipantTrackPinned } from './utils';
+import { PinState } from './types';
+import { isTrackBundlePinned } from './utils';
 
-describe('Test isParticipantTrackPinned', () => {
+describe('Test isTrackBundlePinned', () => {
   const participantA = new Participant('dummy-participant', 'A_id', 'track_A_name');
   const trackA = new TrackPublication(Track.Kind.Video, 'track_A_id', 'track_A_name');
   const participantB = new Participant('participant_B', 'B_id', 'B_name');
   const trackB = new TrackPublication(Track.Kind.Video, 'track_B_id', 'track_B_name');
-  const pairA: TrackBundle = { participant: participantA, track: trackA };
-  const pairB: TrackBundle = { participant: participantB, track: trackB };
-  const pairC: TrackBundle = { participant: participantB, track: trackA };
+  const trackBundleA = {
+    participant: participantA,
+    source: Track.Source.Camera,
+    publication: trackA,
+  };
+  const trackBundleB = {
+    participant: participantB,
+    source: Track.Source.Camera,
+    publication: trackB,
+  };
+  const trackBundleC = {
+    participant: participantB,
+    source: Track.Source.Camera,
+    publication: trackA,
+  };
 
-  it('If the pair is in the pin state the function should always return true.', () => {
-    const pinState: PinState = [pairA];
-    expect(isParticipantTrackPinned(pairA, pinState)).toBe(true);
+  it('If the TrackBundle is in the pin state the function should always return true.', () => {
+    const pinState: PinState = [trackBundleA];
+    expect(isTrackBundlePinned(trackBundleA, pinState)).toBe(true);
 
-    const pinState2: PinState = [pairA, pairB, pairC];
-    expect(isParticipantTrackPinned(pairA, pinState2)).toBe(true);
+    const pinState2: PinState = [trackBundleA, trackBundleB, trackBundleC];
+    expect(isTrackBundlePinned(trackBundleA, pinState2)).toBe(true);
   });
 
-  it('If the pair is not in the pin state the function should return false.', () => {
-    const pinState: PinState = [pairB, pairC];
-    expect(isParticipantTrackPinned(pairA, pinState)).toBe(false);
+  it('If the TrackBundle is not in the pin state the function should return false.', () => {
+    const pinState: PinState = [trackBundleB, trackBundleC];
+    expect(isTrackBundlePinned(trackBundleA, pinState)).toBe(false);
   });
 
   it('Empty pin state should always return false.', () => {
     const pinState: PinState = [];
-    expect(isParticipantTrackPinned(pairA, pinState)).toBe(false);
-    expect(isParticipantTrackPinned(pairB, pinState)).toBe(false);
+    expect(isTrackBundlePinned(trackBundleA, pinState)).toBe(false);
+    expect(isTrackBundlePinned(trackBundleB, pinState)).toBe(false);
   });
 });

--- a/packages/core/src/utilis.test.ts
+++ b/packages/core/src/utilis.test.ts
@@ -1,6 +1,6 @@
 import { Participant, Track, TrackPublication } from 'livekit-client';
 import { describe, it, expect } from 'vitest';
-import { PinState, TrackParticipantPair } from './types';
+import { PinState, TrackBundle } from './types';
 import { isParticipantTrackPinned } from './utils';
 
 describe('Test isParticipantTrackPinned', () => {
@@ -8,9 +8,9 @@ describe('Test isParticipantTrackPinned', () => {
   const trackA = new TrackPublication(Track.Kind.Video, 'track_A_id', 'track_A_name');
   const participantB = new Participant('participant_B', 'B_id', 'B_name');
   const trackB = new TrackPublication(Track.Kind.Video, 'track_B_id', 'track_B_name');
-  const pairA: TrackParticipantPair = { participant: participantA, track: trackA };
-  const pairB: TrackParticipantPair = { participant: participantB, track: trackB };
-  const pairC: TrackParticipantPair = { participant: participantB, track: trackA };
+  const pairA: TrackBundle = { participant: participantA, track: trackA };
+  const pairB: TrackBundle = { participant: participantB, track: trackB };
+  const pairC: TrackBundle = { participant: participantB, track: trackA };
 
   it('If the pair is in the pin state the function should always return true.', () => {
     const pinState: PinState = [pairA];

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,7 +5,12 @@ import {
   Track,
   TrackPublication,
 } from 'livekit-client';
-import { PinState, TrackBundle } from './types';
+import {
+  isTrackBundle,
+  isTrackBundlePlaceholder,
+  PinState,
+  TrackBundleWithPlaceholder,
+} from './types';
 
 export function isLocal(p: Participant) {
   return p instanceof LocalParticipant;
@@ -31,23 +36,31 @@ export const attachIfSubscribed = (
 };
 
 /**
- * Check if the participant track is pinned.
+ * Check if the `TrackBundle` is pinned.
  */
-export function isParticipantTrackPinned(
-  trackParticipantPair: TrackBundle,
+export function isTrackBundlePinned(
+  trackBundle: TrackBundleWithPlaceholder,
   pinState: PinState | undefined,
 ): boolean {
   if (pinState === undefined) {
     return false;
   }
-
-  const { track, participant } = trackParticipantPair;
-
-  return pinState.some(
-    ({ track: pinnedTrack, participant: pinnedParticipant }) =>
-      pinnedTrack.trackSid === track.trackSid &&
-      pinnedParticipant.identity === participant.identity,
-  );
+  if (isTrackBundle(trackBundle)) {
+    return pinState.some(
+      (pinnedTrackBundle) =>
+        pinnedTrackBundle.participant.identity === trackBundle.participant.identity &&
+        pinnedTrackBundle.source === trackBundle.source &&
+        pinnedTrackBundle.publication.trackSid === trackBundle.publication.trackSid,
+    );
+  } else if (isTrackBundlePlaceholder(trackBundle)) {
+    return pinState.some(
+      (pinnedTrackBundle) =>
+        pinnedTrackBundle.participant.identity === trackBundle.participant.identity &&
+        pinnedTrackBundle.source === trackBundle.source,
+    );
+  } else {
+    return false;
+  }
 }
 
 /**
@@ -63,7 +76,7 @@ export function isParticipantSourcePinned(
   }
 
   return pinState.some(
-    ({ track: pinnedTrack, participant: pinnedParticipant }) =>
+    ({ publication: pinnedTrack, participant: pinnedParticipant }) =>
       pinnedTrack.source === source && pinnedParticipant.identity === participant.identity,
   );
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -49,13 +49,13 @@ export function isTrackBundlePinned(
     return pinState.some(
       (pinnedTrackBundle) =>
         pinnedTrackBundle.participant.identity === trackBundle.participant.identity &&
-        pinnedTrackBundle.source === trackBundle.source &&
         pinnedTrackBundle.publication.trackSid === trackBundle.publication.trackSid,
     );
   } else if (isTrackBundlePlaceholder(trackBundle)) {
     return pinState.some(
       (pinnedTrackBundle) =>
         pinnedTrackBundle.participant.identity === trackBundle.participant.identity &&
+        isTrackBundlePlaceholder(pinnedTrackBundle) &&
         pinnedTrackBundle.source === trackBundle.source,
     );
   } else {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,7 +5,7 @@ import {
   Track,
   TrackPublication,
 } from 'livekit-client';
-import { PinState, TrackParticipantPair } from './types';
+import { PinState, TrackBundle } from './types';
 
 export function isLocal(p: Participant) {
   return p instanceof LocalParticipant;
@@ -34,7 +34,7 @@ export const attachIfSubscribed = (
  * Check if the participant track is pinned.
  */
 export function isParticipantTrackPinned(
-  trackParticipantPair: TrackParticipantPair,
+  trackParticipantPair: TrackBundle,
   pinState: PinState | undefined,
 ): boolean {
   if (pinState === undefined) {

--- a/packages/react/src/components/LayoutContextProvider.tsx
+++ b/packages/react/src/components/LayoutContextProvider.tsx
@@ -51,7 +51,11 @@ export function LayoutContextProvider({
     if (screenShareParticipant && screenShareTrack) {
       pinDispatch({
         msg: 'set_pin',
-        trackParticipantPair: { track: screenShareTrack, participant: screenShareParticipant },
+        trackBundle: {
+          participant: screenShareParticipant,
+          source: screenShareTrack.source,
+          publication: screenShareTrack,
+        },
       });
     } else {
       pinDispatch({ msg: 'clear_pin' });

--- a/packages/react/src/components/LayoutContextProvider.tsx
+++ b/packages/react/src/components/LayoutContextProvider.tsx
@@ -53,7 +53,6 @@ export function LayoutContextProvider({
         msg: 'set_pin',
         trackBundle: {
           participant: screenShareParticipant,
-          source: screenShareTrack.source,
           publication: screenShareTrack,
         },
       });

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -16,11 +16,11 @@ import { TrackLoop } from './TrackLoop';
  * ```
  */
 export const RoomAudioRenderer = () => {
-  const pairs = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio]);
+  const trackBundles = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio]);
   return (
     <div style={{ display: 'none' }}>
       <TrackLoop
-        pairs={pairs.filter(({ participant }) => {
+        trackBundles={trackBundles.filter(({ participant }) => {
           return participant instanceof RemoteParticipant;
         })}
       >

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -1,4 +1,4 @@
-import { TrackBundle, TrackBundleWithPlaceholder } from '@livekit/components-core';
+import { isTrackBundle, TrackBundle, TrackBundleWithPlaceholder } from '@livekit/components-core';
 import * as React from 'react';
 import { ParticipantContext } from '../context';
 import { ParticipantTile } from '../prefabs';
@@ -24,7 +24,9 @@ export const TrackLoop = ({ trackBundles, ...props }: React.PropsWithChildren<Tr
   return (
     <>
       {trackBundles.map((trackBundle) => {
-        const trackSource = trackBundle.source;
+        const trackSource = isTrackBundle(trackBundle)
+          ? trackBundle.publication.source
+          : trackBundle.source;
         return (
           <ParticipantContext.Provider
             value={trackBundle.participant}

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -1,11 +1,11 @@
-import { isTrackParticipantPair, MaybeTrackParticipantPair } from '@livekit/components-core';
+import { TrackBundle, TrackBundleWithPlaceholder } from '@livekit/components-core';
 import * as React from 'react';
 import { ParticipantContext } from '../context';
 import { ParticipantTile } from '../prefabs';
 import { cloneSingleChild } from '../utils';
 
 type TrackLoopProps = {
-  pairs: MaybeTrackParticipantPair[];
+  trackBundles: TrackBundle[] | TrackBundleWithPlaceholder[];
 };
 
 /**
@@ -16,19 +16,19 @@ type TrackLoopProps = {
  * @example
  * ```tsx
  * const trackBundles = useTracks([Track.Source.Camera]);
- * <TrackLoop pairs={trackBundles} >
+ * <TrackLoop trackBundles={trackBundles} >
  * <TrackLoop />
  * ```
  */
-export const TrackLoop = ({ pairs, ...props }: React.PropsWithChildren<TrackLoopProps>) => {
+export const TrackLoop = ({ trackBundles, ...props }: React.PropsWithChildren<TrackLoopProps>) => {
   return (
     <>
-      {pairs.map((pair) => {
-        const trackSource = isTrackParticipantPair(pair) ? pair.track.source : pair.source;
+      {trackBundles.map((trackBundle) => {
+        const trackSource = trackBundle.source;
         return (
           <ParticipantContext.Provider
-            value={pair.participant}
-            key={`${pair.participant.identity}_${trackSource}`}
+            value={trackBundle.participant}
+            key={`${trackBundle.participant.identity}_${trackSource}`}
           >
             {props.children ? (
               cloneSingleChild(props.children)

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -48,7 +48,6 @@ function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps
                 msg: 'set_pin',
                 trackBundle: {
                   participant: p,
-                  source: track.source,
                   publication: track,
                 },
               });

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -1,4 +1,4 @@
-import { isParticipantTrackPinned, setupFocusToggle } from '@livekit/components-core';
+import { isTrackBundlePinned, setupFocusToggle } from '@livekit/components-core';
 import { Participant, Track } from 'livekit-client';
 import * as React from 'react';
 import { LayoutContext, useEnsureParticipant, useMaybeLayoutContext } from '../../context';
@@ -19,7 +19,10 @@ function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps
   const inFocus: boolean = React.useMemo(() => {
     const track = p.getTrack(trackSource);
     if (layoutContext?.pin.state && track) {
-      return isParticipantTrackPinned({ participant: p, track: track }, layoutContext.pin.state);
+      return isTrackBundlePinned(
+        { participant: p, source: trackSource, publication: track },
+        layoutContext.pin.state,
+      );
     } else {
       return false;
     }
@@ -43,9 +46,10 @@ function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps
             } else {
               layoutContext.pin.dispatch({
                 msg: 'set_pin',
-                trackParticipantPair: {
+                trackBundle: {
                   participant: p,
-                  track,
+                  source: track.source,
+                  publication: track,
                 },
               });
             }

--- a/packages/react/src/components/layout/FocusLayout.tsx
+++ b/packages/react/src/components/layout/FocusLayout.tsx
@@ -6,7 +6,7 @@ import {
   isParticipantTrackPinned,
   isTrackParticipantPair,
   TileFilter,
-  TrackParticipantPair,
+  TrackBundle,
 } from '@livekit/components-core';
 import { ParticipantTile } from '../../prefabs/ParticipantTile';
 import { ParticipantClickEvent } from '@livekit/components-core';
@@ -14,7 +14,7 @@ import { useTracks } from '../../hooks';
 import { TrackLoop } from '../TrackLoop';
 
 export interface FocusLayoutContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  trackParticipantPair?: TrackParticipantPair;
+  trackParticipantPair?: TrackBundle;
   participants?: Array<Participant>;
 }
 
@@ -45,14 +45,14 @@ export function FocusLayoutContainer({
 }
 
 export interface FocusLayoutProps extends React.HTMLAttributes<HTMLElement> {
-  trackParticipantPair?: TrackParticipantPair;
+  trackParticipantPair?: TrackBundle;
   onParticipantClick?: (evt: ParticipantClickEvent) => void;
 }
 
 export function FocusLayout({ trackParticipantPair, ...props }: FocusLayoutProps) {
   const layoutContext = useMaybeLayoutContext();
 
-  const pair: TrackParticipantPair | null = React.useMemo(() => {
+  const pair: TrackBundle | null = React.useMemo(() => {
     if (trackParticipantPair) {
       return trackParticipantPair;
     }

--- a/packages/react/src/components/layout/FocusLayout.tsx
+++ b/packages/react/src/components/layout/FocusLayout.tsx
@@ -2,26 +2,18 @@ import { Participant, Track } from 'livekit-client';
 import * as React from 'react';
 import { useMaybeLayoutContext, useLayoutContext } from '../../context';
 import { mergeProps } from '../../utils';
-import {
-  isParticipantTrackPinned,
-  isTrackParticipantPair,
-  TileFilter,
-  TrackBundle,
-} from '@livekit/components-core';
+import { isTrackBundlePinned, TrackBundleFilter, TrackBundle } from '@livekit/components-core';
 import { ParticipantTile } from '../../prefabs/ParticipantTile';
 import { ParticipantClickEvent } from '@livekit/components-core';
 import { useTracks } from '../../hooks';
 import { TrackLoop } from '../TrackLoop';
 
 export interface FocusLayoutContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  trackParticipantPair?: TrackBundle;
+  trackBundle?: TrackBundle;
   participants?: Array<Participant>;
 }
 
-export function FocusLayoutContainer({
-  trackParticipantPair,
-  ...props
-}: FocusLayoutContainerProps) {
+export function FocusLayoutContainer({ trackBundle, ...props }: FocusLayoutContainerProps) {
   const elementProps = mergeProps(props, { className: 'lk-focus-layout' });
   const pinContext = useLayoutContext().pin;
   const hasFocus = React.useMemo(() => {
@@ -34,9 +26,7 @@ export function FocusLayoutContainer({
         {props.children ?? (
           <>
             <CarouselView />
-            {(hasFocus || trackParticipantPair) && (
-              <FocusLayout trackParticipantPair={trackParticipantPair} />
-            )}
+            {(hasFocus || trackBundle) && <FocusLayout trackBundle={trackBundle} />}
           </>
         )}
       </div>
@@ -45,30 +35,30 @@ export function FocusLayoutContainer({
 }
 
 export interface FocusLayoutProps extends React.HTMLAttributes<HTMLElement> {
-  trackParticipantPair?: TrackBundle;
+  trackBundle?: TrackBundle;
   onParticipantClick?: (evt: ParticipantClickEvent) => void;
 }
 
-export function FocusLayout({ trackParticipantPair, ...props }: FocusLayoutProps) {
+export function FocusLayout({ trackBundle, ...props }: FocusLayoutProps) {
   const layoutContext = useMaybeLayoutContext();
 
-  const pair: TrackBundle | null = React.useMemo(() => {
-    if (trackParticipantPair) {
-      return trackParticipantPair;
+  const trackBundle_: TrackBundle | null = React.useMemo(() => {
+    if (trackBundle) {
+      return trackBundle;
     }
     if (layoutContext?.pin.state !== undefined && layoutContext.pin.state.length >= 1) {
       return layoutContext.pin.state[0];
     }
     return null;
-  }, [layoutContext, trackParticipantPair]);
+  }, [layoutContext, trackBundle]);
 
   return (
     <>
-      {pair && pair.track && (
+      {trackBundle_ && trackBundle_.publication && (
         <ParticipantTile
           {...props}
-          participant={pair.participant}
-          trackSource={pair.track.source}
+          participant={trackBundle_.participant}
+          trackSource={trackBundle_.publication.source}
         />
       )}
     </>
@@ -76,25 +66,22 @@ export function FocusLayout({ trackParticipantPair, ...props }: FocusLayoutProps
 }
 
 export interface CarouselViewProps extends React.HTMLAttributes<HTMLMediaElement> {
-  filter?: TileFilter;
+  filter?: TrackBundleFilter;
   filterDependencies?: [];
 }
 
 export function CarouselView({ filter, filterDependencies = [], ...props }: CarouselViewProps) {
   const layoutContext = useMaybeLayoutContext();
-  const tiles = useTracks([
+  const trackBundles = useTracks([
     { source: Track.Source.Camera, withPlaceholder: true },
     { source: Track.Source.ScreenShare, withPlaceholder: false },
   ]);
   const filteredTiles = React.useMemo(() => {
-    const tilesWithoutPinned = tiles.filter(
-      (tile) =>
-        !layoutContext?.pin.state ||
-        !isTrackParticipantPair(tile) ||
-        !isParticipantTrackPinned(tile, layoutContext.pin.state),
+    const tilesWithoutPinned = trackBundles.filter(
+      (tile) => !layoutContext?.pin.state || !isTrackBundlePinned(tile, layoutContext.pin.state),
     );
     return filter ? tilesWithoutPinned.filter(filter) : tilesWithoutPinned;
-  }, [filter, layoutContext?.pin.state, tiles, ...filterDependencies]);
+  }, [filter, layoutContext?.pin.state, trackBundles, ...filterDependencies]);
 
-  return <aside {...props}>{props.children ?? <TrackLoop pairs={filteredTiles} />}</aside>;
+  return <aside {...props}>{props.children ?? <TrackLoop trackBundles={filteredTiles} />}</aside>;
 }

--- a/packages/react/src/components/layout/GridLayout.tsx
+++ b/packages/react/src/components/layout/GridLayout.tsx
@@ -4,9 +4,9 @@ import { useParticipants, UseParticipantsOptions } from '../../hooks';
 import { mergeProps } from '../../utils';
 import { useSize } from '../../helper/resizeObserver';
 import {
-  // isParticipantTrackPinned,
+  // isTrackBundlePinned,
   // isTrackParticipantPair,
-  TileFilter,
+  TrackBundleFilter,
 } from '@livekit/components-core';
 // import { Track } from 'livekit-client';
 // import { useMaybeLayoutContext } from '../../context';
@@ -18,7 +18,7 @@ export interface GridLayoutProps
    * The grid shows all room participants. If only a subset of the participants
    * should be visible, they can be filtered.
    */
-  filter?: TileFilter;
+  filter?: TrackBundleFilter;
   filterDependencies?: [];
   // TODO maxVisibleParticipants
 }

--- a/packages/react/src/context/pin-context.ts
+++ b/packages/react/src/context/pin-context.ts
@@ -1,10 +1,10 @@
-import { PinState, TrackParticipantPair } from '@livekit/components-core';
+import { PinState, TrackBundle } from '@livekit/components-core';
 import * as React from 'react';
 
 export type PinAction =
   | {
       msg: 'set_pin';
-      trackParticipantPair: TrackParticipantPair;
+      trackParticipantPair: TrackBundle;
     }
   | { msg: 'clear_pin' };
 

--- a/packages/react/src/context/pin-context.ts
+++ b/packages/react/src/context/pin-context.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 export type PinAction =
   | {
       msg: 'set_pin';
-      trackParticipantPair: TrackBundle;
+      trackBundle: TrackBundle;
     }
   | { msg: 'clear_pin' };
 
@@ -19,7 +19,7 @@ export type PinContextType = {
 
 export function pinReducer(state: PinState, action: PinAction): PinState {
   if (action.msg === 'set_pin') {
-    return [action.trackParticipantPair];
+    return [action.trackBundle];
   } else if (action.msg === 'clear_pin') {
     return [];
   } else {

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -4,7 +4,7 @@ import {
   log,
   MaybeTrackParticipantPair,
   SourcesArray,
-  TrackParticipantPair,
+  TrackBundle,
   trackParticipantPairsObservable,
   TrackSourceWithOptions,
 } from '@livekit/components-core';
@@ -17,15 +17,14 @@ type UseTracksOptions = {
 };
 
 type UseTracksHookReturnType<T> = T extends Track.Source[]
-  ? TrackParticipantPair[]
+  ? TrackBundle[]
   : T extends TrackSourceWithOptions[]
   ? MaybeTrackParticipantPair[]
   : never;
 
 /**
- * The `useTracks` hook returns an array of TrackParticipantPairs which combine the participant, publication and a track.
+ * The `useTracks` hook returns an array of `TrackBundle` which combine the participant, trackSource, publication and a track.
  * Only tracks with a the same source specified via the sources property get included in the loop.
- * This hook can also return placeholders alongside `TrackParticipantPair`'s, so they can appear as tiles even without a subscribed track.
  *
  * @example
  * ```ts
@@ -41,7 +40,7 @@ export function useTracks<T extends SourcesArray>(
   options: UseTracksOptions = {},
 ): UseTracksHookReturnType<T> {
   const room = useRoomContext();
-  const [pairs, setPairs] = React.useState<TrackParticipantPair[]>([]);
+  const [pairs, setPairs] = React.useState<TrackBundle[]>([]);
   const [participants, setParticipants] = React.useState<Participant[]>([]);
 
   const sources_ = React.useMemo(() => {

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -14,6 +14,7 @@ import { useRoomContext } from '../context';
 
 type UseTracksOptions = {
   updateOnlyOn?: RoomEvent[];
+  onlySubscribed?: boolean;
 };
 
 type UseTracksHookReturnType<T> = T extends Track.Source[]
@@ -50,6 +51,7 @@ export function useTracks<T extends SourcesArray>(
   React.useEffect(() => {
     const subscription = trackBundlesObservable(room, sources_, {
       additionalRoomEvents: options.updateOnlyOn,
+      onlySubscribed: options.onlySubscribed,
     }).subscribe(({ trackBundles, participants }) => {
       setTrackBundles(trackBundles);
       setParticipants(participants);

--- a/packages/react/src/prefabs/AudioConference.tsx
+++ b/packages/react/src/prefabs/AudioConference.tsx
@@ -36,7 +36,7 @@ export function AudioConference({ ...props }: AudioConferenceProps) {
     setLayout(pinState.length >= 1 ? 'focus' : 'grid');
   };
 
-  const pairs = useTracks([Track.Source.Microphone]);
+  const trackBundles = useTracks([Track.Source.Microphone]);
 
   return (
     <div className="lk-audio-conference" {...props}>
@@ -44,7 +44,7 @@ export function AudioConference({ ...props }: AudioConferenceProps) {
         <div className="lk-audio-conference-stage">
           {layout === 'grid' ? (
             <GridLayout>
-              <TrackLoop pairs={pairs}>
+              <TrackLoop trackBundles={trackBundles}>
                 <ParticipantAudioTile />
               </TrackLoop>
             </GridLayout>


### PR DESCRIPTION
This PR includes two things.
## Renaming
Everything related to `TrackParticipantPair` is now called `TrackBundle`. It is no longer a pair because we have made some additions that allow us to combine published, subscribed and placeholder tracks into the same logic.

So we moved from this:
```ts
type TrackParticipantPair = {
  track: TrackPublication;
  participant: Participant;
};
```
to this:
```ts
type TrackBundleSubscribed = {
  participant: Participant;
  publication: TrackPublication;
  track: TrackPublication;
};

type TrackBundlePublished = {
  participant: Participant;
  publication: TrackPublication;
};

type TrackBundlePlaceholder = {
  participant: Participant;
  source: Track.Source;
};

export type TrackBundle = TrackBundleSubscribed | TrackBundlePublished;
export type TrackBundleWithPlaceholder =
  | TrackBundleSubscribed
  | TrackBundlePublished
  | TrackBundlePlaceholder;
```

## useTracks() revision
`useTracks()` can now return all publications, not just subscribed ones. 
```ts
const tracks = useTracks([Track.Source.Camera], {onlySubscribed: false})
```

 