### PR TITLE
UPDATE: Make useDataChannel hook except generic string types instead …

### DIFF
--- a/packages/react/src/hooks/dataChannel-hooks.ts
+++ b/packages/react/src/hooks/dataChannel-hooks.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useRoomContext } from '../context';
 import { useObservableState } from '../helper';
 
-export function useDataChannel(topic?: string) {
+export function useDataChannel<T extends string>(topic?: T) {
   const room = useRoomContext();
   const { send, messageObservable, isSendingObservable } = React.useMemo(
     () => setupDataMessageHandler(room, topic),


### PR DESCRIPTION
Make useDataChannel hook except generic string types instead of just string. This way we can add type safety to our message topics. We can use `useDataChannel` like this as well:
```js
type ChannelMessageType = 'SAY_HI' | 'SAY_BYE';

// works
const { isSending } = useDataChannel<ChannelMessageType>('SAY_HI'); 
// TS warns us 
const { isSending } = useDataChannel<ChannelMessageType>('SAYY_HI');
```