### PR TITLE
Focus layout styling revision

### DIFF
--- a/packages/react/src/components/layout/CarouselView.tsx
+++ b/packages/react/src/components/layout/CarouselView.tsx
@@ -55,7 +55,7 @@ export function CarouselView({
 
   const sortedTiles = useVisualStableUpdate(filteredTiles, maxVisibleTiles);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (asideEl.current) {
       asideEl.current.dataset.lkOrientation = carouselOrientation;
       asideEl.current.style.setProperty('--lk-max-visible-tiles', maxVisibleTiles.toString());

--- a/packages/react/src/components/layout/FocusLayout.tsx
+++ b/packages/react/src/components/layout/FocusLayout.tsx
@@ -20,16 +20,14 @@ export function FocusLayoutContainer({ trackBundle, ...props }: FocusLayoutConta
   }, [pinContext]);
 
   return (
-    <>
-      <div {...elementProps}>
-        {props.children ?? (
-          <>
-            <CarouselView />
-            {(hasFocus || trackBundle) && <FocusLayout trackBundle={trackBundle} />}
-          </>
-        )}
-      </div>
-    </>
+    <div {...elementProps}>
+      {props.children ?? (
+        <>
+          <CarouselView />
+          {(hasFocus || trackBundle) && <FocusLayout trackBundle={trackBundle} />}
+        </>
+      )}
+    </div>
   );
 }
 

--- a/packages/react/src/components/layout/FocusLayout.tsx
+++ b/packages/react/src/components/layout/FocusLayout.tsx
@@ -39,25 +39,21 @@ export interface FocusLayoutProps extends React.HTMLAttributes<HTMLElement> {
 export function FocusLayout({ trackBundle, ...props }: FocusLayoutProps) {
   const layoutContext = useMaybeLayoutContext();
 
-  const trackBundle_: TrackBundle | null = React.useMemo(() => {
+  const trackBundleInFocus: TrackBundle | undefined = React.useMemo(() => {
     if (trackBundle) {
       return trackBundle;
     }
     if (layoutContext?.pin.state !== undefined && layoutContext.pin.state.length >= 1) {
       return layoutContext.pin.state[0];
     }
-    return null;
+    return undefined;
   }, [layoutContext, trackBundle]);
 
   return (
-    <>
-      {trackBundle_ && trackBundle_.publication && (
-        <ParticipantTile
-          {...props}
-          participant={trackBundle_.participant}
-          trackSource={trackBundle_.publication.source}
-        />
-      )}
-    </>
+    <ParticipantTile
+      {...props}
+      participant={trackBundleInFocus?.participant}
+      trackSource={trackBundleInFocus?.publication.source}
+    />
   );
 }

--- a/packages/styles/scss/components/layout/_carousel-view.scss
+++ b/packages/styles/scss/components/layout/_carousel-view.scss
@@ -24,10 +24,15 @@
 
   &[data-orientation='horizontal'] {
     scroll-snap-type: x mandatory;
+    writing-mode: vertical-rl; // trick css to think this is vertical text in order to apply the scrollbar gutter horizontally
+    flex-direction: column; // this is needed because of the vertical hack above
+    scrollbar-gutter: stable;
     overflow-y: hidden;
     overflow-x: auto;
 
     > * {
+      writing-mode: horizontal-tb; // reset text orientation hack
+
       --width-minus-gaps: calc(100% - var(--grid-gap) * (var(--max-visible-tiles) - 1));
       width: calc(var(--width-minus-gaps) / var(--max-visible-tiles));
     }

--- a/packages/styles/scss/components/layout/_focus-layout.scss
+++ b/packages/styles/scss/components/layout/_focus-layout.scss
@@ -18,7 +18,6 @@
   // Prevent screenshare from expanding out of bounds
   > div {
     width: 100%;
-    max-height: calc(100% - var(--control-bar-height) - (var(--grid-gap) * 2));
   }
 }
 

--- a/packages/styles/scss/components/layout/_focus-layout.scss
+++ b/packages/styles/scss/components/layout/_focus-layout.scss
@@ -14,11 +14,6 @@
   width: 100%;
   max-height: 100%;
   padding: var(--grid-gap);
-
-  // Prevent screenshare from expanding out of bounds
-  > div {
-    width: 100%;
-  }
 }
 
 .focused-participant {


### PR DESCRIPTION
- Fix for empty space under the focused tile.
- Fixes a bug that causes the focused video to become huge when switching from a wide to a narrow viewport.