### PR TITLE
CSS tweaks

### DIFF
--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -78,7 +78,7 @@ export const MediaDeviceMenu = ({
   }, [handleClickOutside, setUpdateRequired]);
 
   return (
-    <span style={{ position: 'relative', flexShrink: 0 }}>
+    <>
       <button
         className="lk-button lk-button-menu"
         aria-pressed={isOpen}
@@ -118,6 +118,6 @@ export const MediaDeviceMenu = ({
           </>
         )}
       </div>
-    </span>
+    </>
   );
 };

--- a/packages/styles/scss/_preflight.scss
+++ b/packages/styles/scss/_preflight.scss
@@ -8,7 +8,7 @@
   font-family: var(--font-family);
   color: var(--fg);
 
-  .button,
+  button,
   input {
     font: inherit;
     line-height: inherit;

--- a/packages/styles/scss/_preflight.scss
+++ b/packages/styles/scss/_preflight.scss
@@ -10,7 +10,8 @@
 
   .button,
   input {
-    line-height: var(--line-height);
+    font: inherit;
+    line-height: inherit;
   }
 
   .button {
@@ -25,7 +26,7 @@
 
   .form-control {
     font-family: var(--font-family);
-    padding: 0.375rem 0.75rem;
+    padding: 0.625rem 1rem;
     background-color: var(--control-bg);
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);

--- a/packages/styles/scss/_root.scss
+++ b/packages/styles/scss/_root.scss
@@ -32,16 +32,12 @@ $accent: #1f8cf9;
 
   --danger-fg: #fff;
   --danger: #f91f31;
-  // --danger-text: #6d0311;
-  // --danger-bg: #fecdd4;
   --danger2: #{color.adjust($danger, $lightness: 4%)};
   --danger3: #{color.adjust($danger, $lightness: 8%)};
   --danger4: #{color.adjust($danger, $lightness: 12%)};
 
   --success-fg: #fff;
   --success: #1ff968;
-  // --success-text: #036d26;
-  // --success-bg: #cdfedd;
   --success2: #{color.adjust($success, $lightness: 4%)};
   --success3: #{color.adjust($success, $lightness: 8%)};
   --success4: #{color.adjust($success, $lightness: 12%)};

--- a/packages/styles/scss/_root.scss
+++ b/packages/styles/scss/_root.scss
@@ -54,9 +54,9 @@ $accent: #1f8cf9;
 
   --font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji';
-  --font-size: 14px;
+  --font-size: 16px;
   --line-height: 1.5;
-  --border-radius: 0.375rem;
+  --border-radius: 0.5rem;
   --box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.15);
 
   --grid-gap: 0.5rem;

--- a/packages/styles/scss/components/controls/_button.scss
+++ b/packages/styles/scss/components/controls/_button.scss
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.875rem;
+  padding: 0.625rem 1rem;
   color: var(--control-fg);
   background-image: none;
   background-color: var(--control-bg);
@@ -51,6 +51,7 @@
 
 .button-group-menu {
   position: relative;
+  flex-shrink: 0;
 
   .button {
     height: 100%;

--- a/packages/styles/scss/components/controls/_button.scss
+++ b/packages/styles/scss/components/controls/_button.scss
@@ -53,7 +53,7 @@
   position: relative;
   flex-shrink: 0;
 
-  .button {
+  > .button {
     height: 100%;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/packages/styles/scss/components/controls/_media-device-select.scss
+++ b/packages/styles/scss/components/controls/_media-device-select.scss
@@ -7,35 +7,29 @@
 
   li {
     &:not(:last-child) {
-      margin-bottom: 0.125rem;
+      margin-bottom: 0.25rem;
     }
 
-    > button {
-      display: flex;
+    > .button {
       width: 100%;
-      align-items: center;
-      padding: 0.375rem 0.5rem;
-
-      border: 0;
-      background: none;
-      border-radius: var(--border-radius);
-      color: var(--fg);
+      justify-content: start;
+      padding-block: 0.5rem;
     }
 
-    &:not([data-active='true']) > button:hover {
+    &:not([data-active='true']) > .button:not(:disabled):hover {
       background-color: var(--bg3);
     }
   }
 
   [data-active='false'] {
-    > button:hover {
+    > .button:hover {
       cursor: pointer;
       background-color: rgba(0, 0, 0, 0.05);
     }
   }
 
   [data-active='true'] {
-    > button {
+    > .button {
       color: var(--accent-fg);
       background-color: var(--accent-bg);
     }
@@ -51,11 +45,10 @@
   min-width: 10rem;
   padding: 0.5rem;
   margin-bottom: 0.25rem;
-  font-size: 0.875rem;
   white-space: nowrap;
   background-color: var(--bg2);
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   box-shadow: var(--box-shadow);
 }
 


### PR DESCRIPTION
- Resets base `font-size` to 16px instead of 14px.
- Increases the padding on all inputs and buttons for larger tap targets, especially helpful on mobile devices.
- Smooths out some global styles for inputs and buttons from Preflight—the selectors and font styles weren't right there and so everything was getting some browser defaults.
- Fine-tunes the styling of our media device selector menus where `border-radius` and `:hover` styles were out of whack.