### PR TITLE
Enable trackReferences to be used on audio/video track

### DIFF
--- a/.changeset/clean-beers-work.md
+++ b/.changeset/clean-beers-work.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Enable trackReferences to be used on audio/video track

--- a/packages/core/src/observables/participant.ts
+++ b/packages/core/src/observables/participant.ts
@@ -12,6 +12,7 @@ import { observeRoomEvents } from './room';
 import { ParticipantEventCallbacks } from 'livekit-client/dist/src/room/participant/Participant';
 import { allParticipantEvents, allParticipantRoomEvents } from '../helper/eventGroups';
 import { TrackIdentifier } from '../types';
+import { getTrackByIdentifier } from '../components/mediaTrack';
 
 export function observeParticipantEvents<T extends Participant>(
   participant: T,
@@ -83,10 +84,7 @@ export function observeParticipantMedia<T extends Participant>(participant: T) {
 export function createTrackObserver(participant: Participant, options: TrackIdentifier) {
   return observeParticipantMedia(participant).pipe(
     map((media) => {
-      const publication = options.source
-        ? media.participant.getTrack(options.source)
-        : media.participant.getTrackByName(options.name);
-      return { publication };
+      return { publication: getTrackByIdentifier(media.participant, options) };
     }),
   );
 }

--- a/packages/core/src/observables/participant.ts
+++ b/packages/core/src/observables/participant.ts
@@ -11,7 +11,7 @@ import { map, switchMap, Observable, startWith, Subscriber } from 'rxjs';
 import { observeRoomEvents } from './room';
 import { ParticipantEventCallbacks } from 'livekit-client/dist/src/room/participant/Participant';
 import { allParticipantEvents, allParticipantRoomEvents } from '../helper/eventGroups';
-import { TrackObserverOptions } from '../types';
+import { TrackIdentifier } from '../types';
 
 export function observeParticipantEvents<T extends Participant>(
   participant: T,
@@ -80,7 +80,7 @@ export function observeParticipantMedia<T extends Participant>(participant: T) {
   return participantObserver;
 }
 
-export function createTrackObserver(participant: Participant, options: TrackObserverOptions) {
+export function createTrackObserver(participant: Participant, options: TrackIdentifier) {
   return observeParticipantMedia(participant).pipe(
     map((media) => {
       const publication = options.source

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -29,9 +29,7 @@ export type TrackReferenceWithPlaceholder =
   | TrackReferencePlaceholder;
 
 // ### TrackReference Type Predicates
-export function isTrackReference(
-  trackReference: TrackReferenceWithPlaceholder,
-): trackReference is TrackReference {
+export function isTrackReference(trackReference: unknown): trackReference is TrackReference {
   return (
     isTrackReferenceSubscribed(trackReference as TrackReference) ||
     isTrackReferencePublished(trackReference as TrackReference)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,12 +38,17 @@ export interface ParticipantClickEvent {
   track?: TrackPublication;
 }
 
-export type TrackObserverOptions =
-  | { source: Track.Source; name?: undefined }
-  | { source?: undefined; name: string };
+export type TrackSource<T extends Track.Source> = RequireAtLeastOne<
+  { source: T; name: string },
+  'name' | 'source'
+>;
+
+export type TrackIdentifier<T extends Track.Source = Track.Source> =
+  | TrackSource<T>
+  | TrackReference;
 
 // ## Util Types
-export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
   {
     [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
   }[Keys];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,7 +45,7 @@ export type TrackSource<T extends Track.Source> = RequireAtLeastOne<
 
 /**
  * The TrackIdentifier type is used to select Tracks either based on
- * - Track.Source and/or name of the track
+ * - Track.Source and/or name of the track, e.g. `{source: Track.Source.Camera}` or `{name: "my-track"}`
  * - TrackReference (participant and publication)
  */
 export type TrackIdentifier<T extends Track.Source = Track.Source> =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,6 +43,11 @@ export type TrackSource<T extends Track.Source> = RequireAtLeastOne<
   'name' | 'source'
 >;
 
+/**
+ * The TrackIdentifier type is used to select Tracks either based on
+ * - Track.Source and/or name of the track
+ * - TrackReference (participant and publication)
+ */
 export type TrackIdentifier<T extends Track.Source = Track.Source> =
   | TrackSource<T>
   | TrackReference;

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -74,6 +74,11 @@ export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivEleme
    * make sure to set the options directly on the room instance itself.
    */
   room?: Room;
+  /**
+   * room reference
+   */
+  ref?: React.RefObject<Room>;
+
   simulateParticipants?: number | undefined;
 }
 

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -74,10 +74,6 @@ export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivEleme
    * make sure to set the options directly on the room instance itself.
    */
   room?: Room;
-  /**
-   * room reference
-   */
-  ref?: React.RefObject<Room>;
 
   simulateParticipants?: number | undefined;
 }

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -1,8 +1,8 @@
-import { RemoteParticipant, Track } from 'livekit-client';
+import { isLocal } from '@livekit/components-core';
+import { Track } from 'livekit-client';
 import * as React from 'react';
 import { useTracks } from '../hooks';
 import { AudioTrack } from './participant/AudioTrack';
-import { TrackLoop } from './TrackLoop';
 
 /**
  * The RoomAudioRenderer component is a drop-in solution for adding audio to your LiveKit app.
@@ -16,17 +16,15 @@ import { TrackLoop } from './TrackLoop';
  * ```
  */
 export const RoomAudioRenderer = () => {
-  const trackReferences = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio]);
+  const trackReferences = useTracks([
+    Track.Source.Microphone,
+    Track.Source.ScreenShareAudio,
+  ]).filter((ref) => !isLocal(ref.participant));
   return (
     <div style={{ display: 'none' }}>
-      <TrackLoop
-        trackReferences={trackReferences.filter(({ participant }) => {
-          return participant instanceof RemoteParticipant;
-        })}
-      >
-        {/* TODO: How to handle screen share audio? Currently it is rendered as microphone source.         */}
-        <AudioTrack source={Track.Source.Microphone} />
-      </TrackLoop>
+      {trackReferences.map((trackRef) => (
+        <AudioTrack key={trackRef.publication.trackSid} trackReference={trackRef} />
+      ))}
     </div>
   );
 };

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -16,10 +16,9 @@ import { AudioTrack } from './participant/AudioTrack';
  * ```
  */
 export const RoomAudioRenderer = () => {
-  const trackReferences = useTracks([
-    Track.Source.Microphone,
-    Track.Source.ScreenShareAudio,
-  ]).filter((ref) => !isLocal(ref.participant));
+  const trackReferences = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio], {
+    updateOnlyOn: [],
+  }).filter((ref) => !isLocal(ref.participant));
   return (
     <div style={{ display: 'none' }}>
       {trackReferences.map((trackRef) => (

--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -36,7 +36,7 @@ export function useMediaTrackBySourceOrName(
 
   const { className, trackObserver } = React.useMemo(() => {
     return setupMediaTrack(participant, observerOptions);
-  }, [participant, JSON.stringify(observerOptions)]);
+  }, [participant, observerOptions]);
 
   React.useEffect(() => {
     const subscription = trackObserver.subscribe((publication) => {

--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -1,4 +1,10 @@
-import { TrackObserverOptions, setupMediaTrack, log, isLocal } from '@livekit/components-core';
+import {
+  TrackIdentifier,
+  setupMediaTrack,
+  log,
+  isLocal,
+  getTrackByIdentifier,
+} from '@livekit/components-core';
 import { Participant, Track } from 'livekit-client';
 import React from 'react';
 import { useEnsureParticipant } from '../context';
@@ -14,13 +20,14 @@ export interface UseMediaTrackOptions {
  * @internal
  */
 export function useMediaTrackBySourceOrName(
-  { source, name }: TrackObserverOptions,
+  observerOptions: TrackIdentifier,
   options: UseMediaTrackOptions = {},
 ) {
   const participant = useEnsureParticipant(options.participant);
   const [publication, setPublication] = React.useState(
-    source ? participant.getTrack(source) : participant.getTrackByName(name),
+    getTrackByIdentifier(participant, observerOptions),
   );
+
   const [isMuted, setMuted] = React.useState(publication?.isMuted);
   const [isSubscribed, setSubscribed] = React.useState(publication?.isSubscribed);
   const [track, setTrack] = React.useState(publication?.track);
@@ -28,8 +35,8 @@ export function useMediaTrackBySourceOrName(
   const previousElement = React.useRef<HTMLMediaElement | undefined | null>();
 
   const { className, trackObserver } = React.useMemo(() => {
-    return setupMediaTrack(participant, source ? { source } : { name });
-  }, [participant, source, name]);
+    return setupMediaTrack(participant, observerOptions);
+  }, [participant, JSON.stringify(observerOptions)]);
 
   React.useEffect(() => {
     const subscription = trackObserver.subscribe((publication) => {
@@ -80,8 +87,9 @@ export function useMediaTrackBySourceOrName(
     elementProps: mergeProps(options.props, {
       className,
       'data-lk-local-participant': participant.isLocal,
-      'data-lk-source': source,
-      ...(source === Track.Source.Camera || source === Track.Source.ScreenShare
+      'data-lk-source': publication?.source,
+      ...(publication?.source === Track.Source.Camera ||
+      publication?.source === Track.Source.ScreenShare
         ? { 'data-lk-orientation': orientation }
         : {}),
     }),


### PR DESCRIPTION
allows for usage of `Audio/VideoTrack` like this:

```tsx

export const AllMicRenderer = () => {

  const trackReferences = useTracks([Track.Source.Microphone]);

  return (
    <div style={{ display: 'none' }}>
      {trackReferences.map((trackRef) => (
        <AudioTrack key={trackRef.publication.trackSid} trackReference={trackRef} />
      ))}
    </div>
  );
};

```