### PR TITLE
use trackReference.participant as fallback for rendering track

### DIFF
--- a/.changeset/brave-carpets-draw.md
+++ b/.changeset/brave-carpets-draw.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Use trackReference.participant as fallback for rendering track

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -34,7 +34,7 @@ export type AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement> =
 export function AudioTrack({ onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps) {
   const { source, name, trackReference } = props;
   const mediaEl = React.useRef<HTMLAudioElement>(null);
-  const participant = useEnsureParticipant(props.participant);
+  const participant = useEnsureParticipant(props.participant || trackReference?.participant);
 
   const { elementProps, isSubscribed, track } = useMediaTrackBySourceOrName(
     // @ts-expect-error this is an exhaustive check for AudioTrackProps, but typescript doesn't pick it up

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -42,7 +42,7 @@ export function VideoTrack({
   ...props
 }: VideoTrackProps) {
   const mediaEl = React.useRef<HTMLVideoElement>(null);
-  const participant = useEnsureParticipant(props.participant);
+  const participant = useEnsureParticipant(props.participant || trackReference?.participant);
   const { elementProps, publication, isSubscribed } = useMediaTrackBySourceOrName(
     // @ts-expect-error this is an exhaustive check for VideoTrackProps, but typescript doesn't pick it up
     source || name ? { source, name } : trackReference,


### PR DESCRIPTION
fixes  #376

this bug surfaced because `RoomAudioRenderer` wasn't explicitly creating a `ParticipantContext` anymore.