### PR TITLE
Avoid additional rxjs imports to keep bundle size down

### DIFF
--- a/.changeset/eight-tables-applaud.md
+++ b/.changeset/eight-tables-applaud.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Remove rxjs imports to keep bundle size down

--- a/packages/react/src/hooks/internal/useObservableState.ts
+++ b/packages/react/src/hooks/internal/useObservableState.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
 
 /**
  * @internal

--- a/packages/react/src/hooks/internal/useObservableState.ts
+++ b/packages/react/src/hooks/internal/useObservableState.ts
@@ -4,11 +4,11 @@ import { Observable } from 'rxjs';
 /**
  * @internal
  */
-export function useObservableState<T>(observable: Observable<T>, startWith: T) {
+export function useObservableState<T>(observable: Observable<T> | undefined, startWith: T) {
   const [state, setState] = React.useState<T>(startWith);
   React.useEffect(() => {
     // observable state doesn't run in SSR
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined' || !observable) return;
     const subscription = observable.subscribe(setState);
     return () => subscription.unsubscribe();
   }, [observable]);

--- a/packages/react/src/prefabs/Chat.tsx
+++ b/packages/react/src/prefabs/Chat.tsx
@@ -1,6 +1,5 @@
 import { setupChat, ChatMessage, ReceivedChatMessage } from '@livekit/components-core';
 import * as React from 'react';
-import { from, of } from 'rxjs';
 import { useRoomContext } from '../context';
 import { useObservableState } from '../hooks/internal/useObservableState';
 import { cloneSingleChild } from '../utils';
@@ -15,8 +14,8 @@ export interface ChatProps extends React.HTMLAttributes<HTMLDivElement> {
 export function useChat() {
   const room = useRoomContext();
   const [setup, setSetup] = React.useState<ReturnType<typeof setupChat>>();
-  const isSending = useObservableState(setup?.isSendingObservable ?? of(false), false);
-  const chatMessages = useObservableState(setup?.messageObservable ?? from([]), []);
+  const isSending = useObservableState(setup?.isSendingObservable, false);
+  const chatMessages = useObservableState(setup?.messageObservable, []);
 
   React.useEffect(() => {
     const setupChatReturn = setupChat(room);


### PR DESCRIPTION
we'll want to avoid importing rxjs related stuff (apart from types) directly in one of the framework implementations. If needed, they should only be imported as part of the core package. 