### PR TITLE
Return all tracks from `useTracks` by default

### DIFF
--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -1,4 +1,13 @@
-import { Participant, Room, RoomEvent, Track, TrackEvent, TrackPublication } from 'livekit-client';
+import {
+  LocalTrackPublication,
+  Participant,
+  RemoteTrackPublication,
+  Room,
+  RoomEvent,
+  Track,
+  TrackEvent,
+  TrackPublication,
+} from 'livekit-client';
 import { map, Observable, startWith } from 'rxjs';
 import { allParticipantRoomEvents } from '../helper';
 import log from '../logger';
@@ -54,25 +63,29 @@ function getTrackReferences(
 
   allParticipants.forEach((participant) => {
     sources.forEach((source) => {
-      const publication = participant.getTrack(source);
-      if (publication) {
-        if (publication.track) {
-          // Include subscribed `TrackPublications`.
-          trackReferences.push({
-            participant,
-            publication,
-            track: publication.track,
-          });
-        } else if (!onlySubscribedTracks) {
-          // Include also `TrackPublications` that are not subscribed.
-          trackReferences.push({ participant, publication });
+      const publications = Array.from<RemoteTrackPublication | LocalTrackPublication>(
+        participant.tracks.values(),
+      ).filter((track) => track.source === source);
+      publications.forEach((publication) => {
+        if (publication) {
+          if (publication.track) {
+            // Include subscribed `TrackPublications`.
+            trackReferences.push({
+              participant,
+              publication,
+              track: publication.track,
+            });
+          } else if (!onlySubscribedTracks) {
+            // Include also `TrackPublications` that are not subscribed.
+            trackReferences.push({ participant, publication });
+          }
         }
-      }
-      log.debug(
-        `getting participant ${participant.identity}, source ${source}, exists: ${
-          publication !== undefined
-        }, subscribed: ${publication?.track !== undefined} `,
-      );
+        log.debug(
+          `getting participant ${participant.identity}, source ${source}, exists: ${
+            publication !== undefined
+          }, subscribed: ${publication?.track !== undefined} `,
+        );
+      });
     });
   });
 

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -63,29 +63,24 @@ function getTrackReferences(
 
   allParticipants.forEach((participant) => {
     sources.forEach((source) => {
-      const publications = Array.from<RemoteTrackPublication | LocalTrackPublication>(
+      const sourceReferences = Array.from<RemoteTrackPublication | LocalTrackPublication>(
         participant.tracks.values(),
-      ).filter((track) => track.source === source);
-      publications.forEach((publication) => {
-        if (publication) {
-          if (publication.track) {
-            // Include subscribed `TrackPublications`.
-            trackReferences.push({
-              participant,
-              publication,
-              track: publication.track,
-            });
-          } else if (!onlySubscribedTracks) {
-            // Include also `TrackPublications` that are not subscribed.
-            trackReferences.push({ participant, publication });
-          }
-        }
-        log.debug(
-          `getting participant ${participant.identity}, source ${source}, exists: ${
-            publication !== undefined
-          }, subscribed: ${publication?.track !== undefined} `,
-        );
-      });
+      )
+        .filter(
+          (track) =>
+            track.source === source &&
+            // either return all or only the ones that are subscribed
+            (!onlySubscribedTracks || track.track),
+        )
+        .map((track) => {
+          return {
+            participant: participant,
+            publication: track,
+            track: track.track,
+          };
+        });
+
+      trackReferences.push(...sourceReferences);
     });
   });
 

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -12,6 +12,7 @@ import {
 import { Participant, RoomEvent, Track } from 'livekit-client';
 import * as React from 'react';
 import { useRoomContext } from '../context';
+import { useObservableState } from './internal';
 
 type UseTracksOptions = {
   updateOnlyOn?: RoomEvent[];
@@ -37,8 +38,14 @@ type UseTracksHookReturnType<T> = T extends Track.Source[]
  * const trackReferencesWithPlaceholders = useTracks(sources: [{source: Track.Source.Camera, withPlaceholder: true}])
  * ```
  */
-export function useTracks<T extends SourcesArray = SourcesArray>(
-  sources: T,
+export function useTracks<T extends SourcesArray = Track.Source[]>(
+  sources: T = [
+    Track.Source.Camera,
+    Track.Source.Microphone,
+    Track.Source.ScreenShare,
+    Track.Source.ScreenShareAudio,
+    Track.Source.Unknown,
+  ] as T,
   options: UseTracksOptions = {},
 ): UseTracksHookReturnType<T> {
   const room = useRoomContext();

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -12,7 +12,6 @@ import {
 import { Participant, RoomEvent, Track } from 'livekit-client';
 import * as React from 'react';
 import { useRoomContext } from '../context';
-import { useObservableState } from './internal';
 
 type UseTracksOptions = {
   updateOnlyOn?: RoomEvent[];


### PR DESCRIPTION
also support multiple tracks of same source being returned in core (e.g. important for multiple Unknown sources)