### PR TITLE
Make trackReferences required for layout comps

### DIFF
--- a/.changeset/ninety-pianos-own.md
+++ b/.changeset/ninety-pianos-own.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": minor
+"@livekit/components-react": minor
+---
+
+Make trackReferences required for layout comps

--- a/docs/storybook/stories/layout-components/GridLayout.stories.tsx
+++ b/docs/storybook/stories/layout-components/GridLayout.stories.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 
-import { GridLayout, GridLayoutProps } from '@livekit/components-react';
+import { GridLayout, GridLayoutProps, useTracks } from '@livekit/components-react';
 import { LkRoomContext } from '../../.storybook/lk-decorators';
+import { Track } from 'livekit-client';
 
 export default {
   component: GridLayout,
   decorators: [LkRoomContext],
-  render: (args: GridLayoutProps) => <GridLayout {...args} />,
+  render: (args: Omit<GridLayoutProps, 'tracks'>) => {
+    const tracks = useTracks([{ source: Track.Source.Camera, withPlaceholder: true }]);
+    return <GridLayout tracks={tracks} {...args} />;
+  },
   argTypes: {},
 };
 

--- a/examples/nextjs/pages/clubhouse.tsx
+++ b/examples/nextjs/pages/clubhouse.tsx
@@ -9,6 +9,7 @@ import {
   useIsSpeaking,
   useParticipantContext,
   useToken,
+  useTracks,
 } from '@livekit/components-react';
 import styles from '../styles/Clubhouse.module.scss';
 import { Track } from 'livekit-client';
@@ -59,14 +60,23 @@ const Clubhouse = () => {
           <h1>
             <RoomName></RoomName>
           </h1>
-          <GridLayout className={styles.grid}>
-            <ParticipantLoop>
-              <CustomParticipantTile></CustomParticipantTile>
-            </ParticipantLoop>
-          </GridLayout>
+          <Stage />
           <ControlBar></ControlBar>
         </div>
       </LiveKitRoom>
+    </div>
+  );
+};
+
+const Stage = () => {
+  return (
+    <div
+      className="lk-grid-layout-wrapper"
+      style={{ display: 'grid', gridTemplateColumns: '4', gridTemplateRows: '4' }}
+    >
+      <ParticipantLoop>
+        <CustomParticipantTile></CustomParticipantTile>
+      </ParticipantLoop>
     </div>
   );
 };

--- a/examples/nextjs/pages/clubhouse.tsx
+++ b/examples/nextjs/pages/clubhouse.tsx
@@ -70,13 +70,12 @@ const Clubhouse = () => {
 
 const Stage = () => {
   return (
-    <div
-      className="lk-grid-layout-wrapper"
-      style={{ display: 'grid', gridTemplateColumns: '4', gridTemplateRows: '4' }}
-    >
-      <ParticipantLoop>
-        <CustomParticipantTile></CustomParticipantTile>
-      </ParticipantLoop>
+    <div className="lk-grid-layout-wrapper">
+      <div className={styles.stageGrid}>
+        <ParticipantLoop>
+          <CustomParticipantTile></CustomParticipantTile>
+        </ParticipantLoop>
+      </div>
     </div>
   );
 };

--- a/examples/nextjs/pages/huddle.tsx
+++ b/examples/nextjs/pages/huddle.tsx
@@ -136,7 +136,7 @@ const CustomScreenShareView = () => {
     <ParticipantTile
       participant={participant}
       className={styles.participantView}
-      trackSource={Track.Source.ScreenShare}
+      source={Track.Source.ScreenShare}
     >
       <VideoTrack source={Track.Source.ScreenShare} className={styles.video}></VideoTrack>
       <div className={styles.screenShareBanner}>

--- a/examples/nextjs/pages/simple.tsx
+++ b/examples/nextjs/pages/simple.tsx
@@ -7,7 +7,12 @@ import {
   useToken,
   ControlBar,
   GridLayout,
+  useTracks,
+  VideoTrack,
+  TrackLoop,
+  ParticipantTile,
 } from '@livekit/components-react';
+import { Track } from 'livekit-client';
 import type { NextPage } from 'next';
 import { useState } from 'react';
 import styles from '../styles/Simple.module.css';
@@ -54,17 +59,24 @@ const SimpleExample: NextPage = () => {
           <RoomName />
           <ConnectionState />
           <RoomAudioRenderer />
-          {isConnected && (
-            <>
-              <ScreenShareView />
-              <GridLayout />
-            </>
-          )}
+          {isConnected && <Stage />}
           <ControlBar />
         </LiveKitRoom>
       </main>
     </div>
   );
 };
+
+function Stage() {
+  const cameraTracks = useTracks([Track.Source.Camera]);
+  const screenShareTrack = useTracks([Track.Source.ScreenShare])[0];
+
+  return (
+    <>
+      <ParticipantTile {...screenShareTrack} />
+      <GridLayout tracks={cameraTracks} />
+    </>
+  );
+}
 
 export default SimpleExample;

--- a/examples/nextjs/pages/simple.tsx
+++ b/examples/nextjs/pages/simple.tsx
@@ -58,7 +58,7 @@ const SimpleExample: NextPage = () => {
         >
           <RoomName />
           <ConnectionState />
-          <RoomAudioRenderer />
+          {/* <RoomAudioRenderer /> */}
           {isConnected && <Stage />}
           <ControlBar />
         </LiveKitRoom>
@@ -73,7 +73,7 @@ function Stage() {
 
   return (
     <>
-      <ParticipantTile {...screenShareTrack} />
+      {screenShareTrack && <ParticipantTile {...screenShareTrack} />}
       <GridLayout tracks={cameraTracks} />
     </>
   );

--- a/examples/nextjs/styles/Clubhouse.module.scss
+++ b/examples/nextjs/styles/Clubhouse.module.scss
@@ -13,6 +13,15 @@
   justify-content: unset;
 }
 
+.stageGrid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: auto;
+  height: 100%;
+  width: 100%;
+  justify-items: center;
+}
+
 .slider {
   position: absolute;
   bottom: 0;

--- a/packages/core/src/components/mediaTrack.ts
+++ b/packages/core/src/components/mediaTrack.ts
@@ -1,5 +1,6 @@
 import { Track } from 'livekit-client';
 import { map, startWith } from 'rxjs';
+import log from '../logger';
 import { observeParticipantMedia } from '../observables/participant';
 import { prefixClass } from '../styles-interface';
 import { isTrackReference } from '../track-reference/track-reference.types';
@@ -22,18 +23,17 @@ export function setupMediaTrack(trackIdentifier: TrackIdentifier) {
 }
 
 export function getTrackByIdentifier(options: TrackIdentifier) {
+  log.debug('get track by', options);
   if (isTrackReference(options)) {
     return options.publication;
   } else {
-    const { source, name } = options;
+    const { source, name, participant } = options;
     if (source && name) {
-      return options.participant
-        .getTracks()
-        .find((pub) => pub.source === source && pub.trackName === name);
+      return participant.getTracks().find((pub) => pub.source === source && pub.trackName === name);
     } else if (name) {
-      return options.participant.getTrackByName(name);
+      return participant.getTrackByName(name);
     } else if (source) {
-      return options.participant.getTrack(source);
+      return participant.getTrack(source);
     } else {
       throw new Error('At least one of source and name needs to be defined');
     }

--- a/packages/core/src/components/mediaTrack.ts
+++ b/packages/core/src/components/mediaTrack.ts
@@ -1,6 +1,5 @@
 import { Track } from 'livekit-client';
 import { map, startWith } from 'rxjs';
-import log from '../logger';
 import { observeParticipantMedia } from '../observables/participant';
 import { prefixClass } from '../styles-interface';
 import { isTrackReference } from '../track-reference/track-reference.types';
@@ -23,7 +22,6 @@ export function setupMediaTrack(trackIdentifier: TrackIdentifier) {
 }
 
 export function getTrackByIdentifier(options: TrackIdentifier) {
-  log.debug('get track by', options);
   if (isTrackReference(options)) {
     return options.publication;
   } else {

--- a/packages/core/src/components/mediaTrack.ts
+++ b/packages/core/src/components/mediaTrack.ts
@@ -1,15 +1,15 @@
-import { Participant, Track } from 'livekit-client';
+import { Track } from 'livekit-client';
 import { map, startWith } from 'rxjs';
 import { observeParticipantMedia } from '../observables/participant';
 import { prefixClass } from '../styles-interface';
 import { isTrackReference } from '../track-reference/track-reference.types';
 import { TrackIdentifier } from '../types';
 
-export function setupMediaTrack(participant: Participant, trackIdentifier: TrackIdentifier) {
-  const initialPub = getTrackByIdentifier(participant, trackIdentifier);
-  const trackObserver = observeParticipantMedia(participant).pipe(
-    map((media) => {
-      return getTrackByIdentifier(media.participant, trackIdentifier);
+export function setupMediaTrack(trackIdentifier: TrackIdentifier) {
+  const initialPub = getTrackByIdentifier(trackIdentifier);
+  const trackObserver = observeParticipantMedia(trackIdentifier.participant).pipe(
+    map(() => {
+      return getTrackByIdentifier(trackIdentifier);
     }),
     startWith(initialPub),
   );
@@ -21,17 +21,19 @@ export function setupMediaTrack(participant: Participant, trackIdentifier: Track
   return { className, trackObserver };
 }
 
-export function getTrackByIdentifier(participant: Participant, options: TrackIdentifier) {
+export function getTrackByIdentifier(options: TrackIdentifier) {
   if (isTrackReference(options)) {
     return options.publication;
   } else {
     const { source, name } = options;
     if (source && name) {
-      return participant.getTracks().find((pub) => pub.source === source && pub.trackName === name);
+      return options.participant
+        .getTracks()
+        .find((pub) => pub.source === source && pub.trackName === name);
     } else if (name) {
-      return participant.getTrackByName(name);
+      return options.participant.getTrackByName(name);
     } else if (source) {
-      return participant.getTrack(source);
+      return options.participant.getTrack(source);
     } else {
       throw new Error('At least one of source and name needs to be defined');
     }

--- a/packages/core/src/components/trackMutedIndicator.ts
+++ b/packages/core/src/components/trackMutedIndicator.ts
@@ -1,4 +1,4 @@
-import { Styles } from '@livekit/components-styles/dist/types_unprefixed/styles.scss';
+import type { Styles } from '@livekit/components-styles/dist/types_unprefixed/styles.scss';
 import { Participant, Track } from 'livekit-client';
 import { mutedObserver } from '../observables/participant';
 import { prefixClass } from '../styles-interface';

--- a/packages/core/src/observables/participant.ts
+++ b/packages/core/src/observables/participant.ts
@@ -83,8 +83,8 @@ export function observeParticipantMedia<T extends Participant>(participant: T) {
 
 export function createTrackObserver(participant: Participant, options: TrackIdentifier) {
   return observeParticipantMedia(participant).pipe(
-    map((media) => {
-      return { publication: getTrackByIdentifier(media.participant, options) };
+    map(() => {
+      return { publication: getTrackByIdentifier(options) };
     }),
   );
 }

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -62,10 +62,11 @@ function getTrackReferences(
             participant,
             publication,
             track: publication.track,
+            source: publication.source,
           });
         } else if (!onlySubscribedTracks) {
           // Include also `TrackPublications` that are not subscribed.
-          trackReferences.push({ participant, publication });
+          trackReferences.push({ participant, publication, source: publication.source });
         }
       }
       log.debug(

--- a/packages/core/src/sorting/base-sort-functions.ts
+++ b/packages/core/src/sorting/base-sort-functions.ts
@@ -2,7 +2,7 @@ import { Participant, Track } from 'livekit-client';
 import {
   getTrackReferenceSource,
   isTrackReference,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
 } from '../track-reference';
 
 export function sortParticipantsByAudioLevel(
@@ -42,8 +42,8 @@ export function sortParticipantsByJoinedAt(
 }
 
 export function sortTrackReferencesByType(
-  a: TrackReferenceWithPlaceholder,
-  b: TrackReferenceWithPlaceholder,
+  a: TrackReferenceOrPlaceholder,
+  b: TrackReferenceOrPlaceholder,
 ) {
   if (isTrackReference(a)) {
     if (isTrackReference(b)) {
@@ -60,8 +60,8 @@ export function sortTrackReferencesByType(
 
 /** TrackReference with screen share source goes first. */
 export function sortTrackReferencesByScreenShare(
-  a: TrackReferenceWithPlaceholder,
-  b: TrackReferenceWithPlaceholder,
+  a: TrackReferenceOrPlaceholder,
+  b: TrackReferenceOrPlaceholder,
 ): number {
   const sourceA = getTrackReferenceSource(a);
   const sourceB = getTrackReferenceSource(b);

--- a/packages/core/src/sorting/sort-track-bundles.ts
+++ b/packages/core/src/sorting/sort-track-bundles.ts
@@ -2,7 +2,7 @@ import { Track } from 'livekit-client';
 import {
   getTrackReferenceSource,
   isTrackReference,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
 } from '../track-reference';
 import {
   sortParticipantsByAudioLevel,
@@ -27,8 +27,8 @@ import {
  * 8. remote tracks sorted by joinedAt
  */
 export function sortTrackReferences(
-  trackReferences: TrackReferenceWithPlaceholder[],
-): TrackReferenceWithPlaceholder[] {
+  trackReferences: TrackReferenceOrPlaceholder[],
+): TrackReferenceOrPlaceholder[] {
   const trackReferences_ = [...trackReferences];
   trackReferences_.sort((a, b) => {
     // Local camera TrackReference before remote.

--- a/packages/core/src/sorting/sort-track-bundles.ts
+++ b/packages/core/src/sorting/sort-track-bundles.ts
@@ -27,10 +27,10 @@ import {
  * 8. remote tracks sorted by joinedAt
  */
 export function sortTrackReferences(
-  trackReferences: TrackReferenceOrPlaceholder[],
+  tracks: TrackReferenceOrPlaceholder[],
 ): TrackReferenceOrPlaceholder[] {
-  const trackReferences_ = [...trackReferences];
-  trackReferences_.sort((a, b) => {
+  const trackReferences = [...tracks];
+  trackReferences.sort((a, b) => {
     // Local camera TrackReference before remote.
     if (
       (a.participant.isLocal && getTrackReferenceSource(a) === Track.Source.Camera) ||
@@ -85,5 +85,5 @@ export function sortTrackReferences(
     return sortParticipantsByJoinedAt(a.participant, b.participant);
   });
 
-  return trackReferences_;
+  return trackReferences;
 }

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -1,6 +1,6 @@
 import { chunk, zip, differenceBy, remove } from 'lodash';
 import log from '../logger';
-import { getTrackReferenceId, TrackReferenceWithPlaceholder } from '../track-reference';
+import { getTrackReferenceId, TrackReferenceOrPlaceholder } from '../track-reference';
 import { flatTrackReferenceArray } from '../track-reference/test-utils';
 
 type VisualChanges<T> = {
@@ -8,7 +8,7 @@ type VisualChanges<T> = {
   added: T[];
 };
 
-export type UpdatableItem = TrackReferenceWithPlaceholder | number;
+export type UpdatableItem = TrackReferenceOrPlaceholder | number;
 
 /** Check if something visually change on the page. */
 export function visualPageChange<T extends UpdatableItem>(state: T[], next: T[]): VisualChanges<T> {

--- a/packages/core/src/track-reference/test-utils.ts
+++ b/packages/core/src/track-reference/test-utils.ts
@@ -31,6 +31,7 @@ export const mockTrackReferencePublished = (
   return {
     participant: new Participant(`${id}`, `${id}`),
     publication: new TrackPublication(kind, `${id}`, `${id}`),
+    source: source,
   };
 };
 
@@ -56,6 +57,7 @@ export const mockTrackReferenceSubscribed = (
       ? (mockTrackPublication(id, kind, source) as TrackPublication)
       : new TrackPublication(kind, `${id}`, `${id}`),
     track: {} as Track,
+    source,
   };
 };
 

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -29,7 +29,7 @@ export type TrackReferenceOrPlaceholder = TrackReference | TrackReferencePlaceho
 
 // ### TrackReference Type Predicates
 export function isTrackReference(trackReference: unknown): trackReference is TrackReference {
-  if (!trackReference) {
+  if (typeof trackReference === 'undefined') {
     return false;
   }
   return isTrackReferenceSubscribed(trackReference) || isTrackReferencePublished(trackReference);
@@ -57,7 +57,7 @@ function isTrackReferencePublished(trackReference: any): trackReference is Track
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
     trackReference.hasOwnProperty('publication') &&
-    typeof trackReference.track !== 'undefined'
+    typeof trackReference.publication !== 'undefined'
   );
 }
 

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -30,27 +30,36 @@ export type TrackReferenceOrPlaceholder =
 
 // ### TrackReference Type Predicates
 export function isTrackReference(trackReference: unknown): trackReference is TrackReference {
-  return (
-    isTrackReferenceSubscribed(trackReference as TrackReference) ||
-    isTrackReferencePublished(trackReference as TrackReference)
-  );
+  if (!trackReference) {
+    return false;
+  }
+  return isTrackReferenceSubscribed(trackReference) || isTrackReferencePublished(trackReference);
 }
 
 function isTrackReferenceSubscribed(
-  trackReference: TrackReference,
+  trackReference: unknown,
 ): trackReference is TrackReferenceSubscribed {
+  if (!trackReference) {
+    return false;
+  }
   return trackReference.hasOwnProperty('track');
 }
 
 function isTrackReferencePublished(
-  trackReference: TrackReference,
+  trackReference: unknown,
 ): trackReference is TrackReferencePublished {
+  if (!trackReference) {
+    return false;
+  }
   return trackReference.hasOwnProperty('publication') && !trackReference.hasOwnProperty('track');
 }
 
 export function isTrackReferencePlaceholder(
-  trackReference: TrackReferenceOrPlaceholder,
+  trackReference: unknown,
 ): trackReference is TrackReferencePlaceholder {
+  if (!trackReference) {
+    return false;
+  }
   return (
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -10,11 +10,13 @@ export type TrackReferenceSubscribed = {
   participant: Participant;
   publication: TrackPublication;
   track: NonNullable<TrackPublication['track']>;
+  source: Track.Source;
 };
 
 export type TrackReferencePublished = {
   participant: Participant;
   publication: TrackPublication;
+  source: Track.Source;
 };
 
 export type TrackReferencePlaceholder = {

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -23,7 +23,7 @@ export type TrackReferencePlaceholder = {
 };
 
 export type TrackReference = TrackReferenceSubscribed | TrackReferencePublished;
-export type TrackReferenceWithPlaceholder =
+export type TrackReferenceOrPlaceholder =
   | TrackReferenceSubscribed
   | TrackReferencePublished
   | TrackReferencePlaceholder;
@@ -49,7 +49,7 @@ function isTrackReferencePublished(
 }
 
 export function isTrackReferencePlaceholder(
-  trackReference: TrackReferenceWithPlaceholder,
+  trackReference: TrackReferenceOrPlaceholder,
 ): trackReference is TrackReferencePlaceholder {
   return (
     trackReference.hasOwnProperty('participant') &&

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -25,10 +25,7 @@ export type TrackReferencePlaceholder = {
 };
 
 export type TrackReference = TrackReferenceSubscribed | TrackReferencePublished;
-export type TrackReferenceOrPlaceholder =
-  | TrackReferenceSubscribed
-  | TrackReferencePublished
-  | TrackReferencePlaceholder;
+export type TrackReferenceOrPlaceholder = TrackReference | TrackReferencePlaceholder;
 
 // ### TrackReference Type Predicates
 export function isTrackReference(trackReference: unknown): trackReference is TrackReference {
@@ -44,7 +41,11 @@ function isTrackReferenceSubscribed(
   if (!trackReference) {
     return false;
   }
-  return trackReference.hasOwnProperty('track');
+  return (
+    trackReference.hasOwnProperty('participant') &&
+    trackReference.hasOwnProperty('source') &&
+    trackReference.hasOwnProperty('track')
+  );
 }
 
 function isTrackReferencePublished(
@@ -53,7 +54,12 @@ function isTrackReferencePublished(
   if (!trackReference) {
     return false;
   }
-  return trackReference.hasOwnProperty('publication') && !trackReference.hasOwnProperty('track');
+  return (
+    trackReference.hasOwnProperty('participant') &&
+    trackReference.hasOwnProperty('source') &&
+    trackReference.hasOwnProperty('publication') &&
+    !trackReference.hasOwnProperty('track')
+  );
 }
 
 export function isTrackReferencePlaceholder(

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -36,7 +36,7 @@ export function isTrackReference(trackReference: unknown): trackReference is Tra
 }
 
 function isTrackReferenceSubscribed(
-  trackReference: unknown,
+  trackReference: any,
 ): trackReference is TrackReferenceSubscribed {
   if (!trackReference) {
     return false;
@@ -45,15 +45,11 @@ function isTrackReferenceSubscribed(
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
     trackReference.hasOwnProperty('track') &&
-    // @ts-ignore
-
-    trackReference.track
+    typeof trackReference.track !== 'undefined'
   );
 }
 
-function isTrackReferencePublished(
-  trackReference: unknown,
-): trackReference is TrackReferencePublished {
+function isTrackReferencePublished(trackReference: any): trackReference is TrackReferencePublished {
   if (!trackReference) {
     return false;
   }
@@ -61,13 +57,12 @@ function isTrackReferencePublished(
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
     trackReference.hasOwnProperty('publication') &&
-    // @ts-ignore
-    !trackReference.track
+    typeof trackReference.track !== 'undefined'
   );
 }
 
 export function isTrackReferencePlaceholder(
-  trackReference: unknown,
+  trackReference: any,
 ): trackReference is TrackReferencePlaceholder {
   if (!trackReference) {
     return false;
@@ -75,9 +70,7 @@ export function isTrackReferencePlaceholder(
   return (
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
-    // @ts-ignore
-    !trackReference.publication &&
-    // @ts-ignore
-    !trackReference.track
+    typeof trackReference.publication !== 'undefined' &&
+    typeof trackReference.track !== 'undefined'
   );
 }

--- a/packages/core/src/track-reference/track-reference.types.ts
+++ b/packages/core/src/track-reference/track-reference.types.ts
@@ -44,7 +44,10 @@ function isTrackReferenceSubscribed(
   return (
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
-    trackReference.hasOwnProperty('track')
+    trackReference.hasOwnProperty('track') &&
+    // @ts-ignore
+
+    trackReference.track
   );
 }
 
@@ -58,7 +61,8 @@ function isTrackReferencePublished(
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
     trackReference.hasOwnProperty('publication') &&
-    !trackReference.hasOwnProperty('track')
+    // @ts-ignore
+    !trackReference.track
   );
 }
 
@@ -71,7 +75,9 @@ export function isTrackReferencePlaceholder(
   return (
     trackReference.hasOwnProperty('participant') &&
     trackReference.hasOwnProperty('source') &&
-    !trackReference.hasOwnProperty('publication') &&
-    !trackReference.hasOwnProperty('track')
+    // @ts-ignore
+    !trackReference.publication &&
+    // @ts-ignore
+    !trackReference.track
   );
 }

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -1,10 +1,8 @@
 import { Track } from 'livekit-client';
-import { isTrackReference, TrackReferenceWithPlaceholder } from './track-reference.types';
+import { isTrackReference, TrackReferenceOrPlaceholder } from './track-reference.types';
 
 /** Returns a id to identify the `TrackReference` based on participant and source. */
-export function getTrackReferenceId(
-  trackReference: TrackReferenceWithPlaceholder | number,
-): string {
+export function getTrackReferenceId(trackReference: TrackReferenceOrPlaceholder | number): string {
   if (typeof trackReference === 'string' || typeof trackReference === 'number') {
     return `${trackReference}`;
   } else if (isTrackReference(trackReference)) {
@@ -15,9 +13,7 @@ export function getTrackReferenceId(
 }
 
 /** Returns the Source of the TrackReference. */
-export function getTrackReferenceSource(
-  trackReference: TrackReferenceWithPlaceholder,
-): Track.Source {
+export function getTrackReferenceSource(trackReference: TrackReferenceOrPlaceholder): Track.Source {
   if (isTrackReference(trackReference)) {
     return trackReference.publication.source;
   } else {

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -45,7 +45,7 @@ export function isTrackReferencePinned(
   trackReference: TrackReferenceOrPlaceholder,
   pinState: PinState | undefined,
 ): boolean {
-  if (pinState === undefined) {
+  if (typeof pinState === 'undefined') {
     return false;
   }
   if (isTrackReference(trackReference)) {

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -1,5 +1,10 @@
 import { Track } from 'livekit-client';
-import { isTrackReference, TrackReferenceOrPlaceholder } from './track-reference.types';
+import { PinState } from '../types';
+import {
+  isTrackReference,
+  isTrackReferencePlaceholder,
+  TrackReferenceOrPlaceholder,
+} from './track-reference.types';
 
 /** Returns a id to identify the `TrackReference` based on participant and source. */
 export function getTrackReferenceId(trackReference: TrackReferenceOrPlaceholder | number): string {
@@ -18,5 +23,45 @@ export function getTrackReferenceSource(trackReference: TrackReferenceOrPlacehol
     return trackReference.publication.source;
   } else {
     return trackReference.source;
+  }
+}
+
+export function isEqualTrackRef(
+  a?: TrackReferenceOrPlaceholder,
+  b?: TrackReferenceOrPlaceholder,
+): boolean {
+  if (isTrackReference(a) && isTrackReference(b)) {
+    return a.publication.trackSid === b.publication.trackSid;
+  } else if (isTrackReferencePlaceholder(a) && isTrackReferencePlaceholder(b)) {
+    return a.participant.identity === b.participant.identity && a.source === b.source;
+  }
+  return false;
+}
+
+/**
+ * Check if the `TrackReference` is pinned.
+ */
+export function isTrackReferencePinned(
+  trackReference: TrackReferenceOrPlaceholder,
+  pinState: PinState | undefined,
+): boolean {
+  if (pinState === undefined) {
+    return false;
+  }
+  if (isTrackReference(trackReference)) {
+    return pinState.some(
+      (pinnedTrackReference) =>
+        pinnedTrackReference.participant.identity === trackReference.participant.identity &&
+        pinnedTrackReference.publication.trackSid === trackReference.publication.trackSid,
+    );
+  } else if (isTrackReferencePlaceholder(trackReference)) {
+    return pinState.some(
+      (pinnedTrackReference) =>
+        pinnedTrackReference.participant.identity === trackReference.participant.identity &&
+        isTrackReferencePlaceholder(pinnedTrackReference) &&
+        pinnedTrackReference.source === trackReference.source,
+    );
+  } else {
+    return false;
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
 import type { Participant, Track, TrackPublication } from 'livekit-client';
-import { TrackReference, TrackReferenceWithPlaceholder } from './track-reference';
+import { TrackReference, TrackReferenceOrPlaceholder } from './track-reference';
 
 // ## PinState Type
 export type PinState = TrackReference[];
@@ -29,7 +29,7 @@ export function isSourcesWithOptions(sources: SourcesArray): sources is TrackSou
 }
 
 // ## Loop Filter Types
-export type TrackReferenceFilter = Parameters<TrackReferenceWithPlaceholder[]['filter']>['0'];
+export type TrackReferenceFilter = Parameters<TrackReferenceOrPlaceholder[]['filter']>['0'];
 export type ParticipantFilter = Parameters<Participant[]['filter']>['0'];
 
 // ## Other Types

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,7 +39,7 @@ export interface ParticipantClickEvent {
 }
 
 export type TrackSource<T extends Track.Source> = RequireAtLeastOne<
-  { source: T; name: string },
+  { source: T; name: string; participant: Participant },
   'name' | 'source'
 >;
 

--- a/packages/core/src/utilis.test.ts
+++ b/packages/core/src/utilis.test.ts
@@ -1,7 +1,7 @@
 import { Participant, Track, TrackPublication } from 'livekit-client';
 import { describe, it, expect } from 'vitest';
+import { isTrackReferencePinned } from './track-reference';
 import { PinState } from './types';
-import { isTrackReferencePinned } from './utils';
 
 describe('Test isTrackReferencePinned', () => {
   const participantA = new Participant('dummy-participant', 'A_id', 'track_A_name');

--- a/packages/core/src/utilis.test.ts
+++ b/packages/core/src/utilis.test.ts
@@ -6,8 +6,10 @@ import { PinState } from './types';
 describe('Test isTrackReferencePinned', () => {
   const participantA = new Participant('dummy-participant', 'A_id', 'track_A_name');
   const trackA = new TrackPublication(Track.Kind.Video, 'track_A_id', 'track_A_name');
+  trackA.trackSid = 'track_a_sid';
   const participantB = new Participant('participant_B', 'B_id', 'B_name');
   const trackB = new TrackPublication(Track.Kind.Video, 'track_B_id', 'track_B_name');
+  trackB.trackSid = 'track_b_sid';
   const trackReferenceA = {
     participant: participantA,
     source: Track.Source.Camera,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -8,7 +8,7 @@ import {
 import {
   isTrackReference,
   isTrackReferencePlaceholder,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
 } from './track-reference';
 import { PinState } from './types';
 
@@ -39,7 +39,7 @@ export const attachIfSubscribed = (
  * Check if the `TrackReference` is pinned.
  */
 export function isTrackReferencePinned(
-  trackReference: TrackReferenceWithPlaceholder,
+  trackReference: TrackReferenceOrPlaceholder,
   pinState: PinState | undefined,
 ): boolean {
   if (pinState === undefined) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -35,6 +35,18 @@ export const attachIfSubscribed = (
   }
 };
 
+export function isEqualTrackRef(
+  a?: TrackReferenceOrPlaceholder,
+  b?: TrackReferenceOrPlaceholder,
+): boolean {
+  if (isTrackReference(a) && isTrackReference(b)) {
+    return a.publication.trackSid === b.publication.trackSid;
+  } else if (isTrackReferencePlaceholder(a) && isTrackReferencePlaceholder(b)) {
+    return a.participant.identity === b.participant.identity && a.source === b.source;
+  }
+  return false;
+}
+
 /**
  * Check if the `TrackReference` is pinned.
  */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,11 +5,7 @@ import {
   Track,
   TrackPublication,
 } from 'livekit-client';
-import {
-  isTrackReference,
-  isTrackReferencePlaceholder,
-  TrackReferenceOrPlaceholder,
-} from './track-reference';
+
 import { PinState } from './types';
 
 export function isLocal(p: Participant) {
@@ -34,46 +30,6 @@ export const attachIfSubscribed = (
     }
   }
 };
-
-export function isEqualTrackRef(
-  a?: TrackReferenceOrPlaceholder,
-  b?: TrackReferenceOrPlaceholder,
-): boolean {
-  if (isTrackReference(a) && isTrackReference(b)) {
-    return a.publication.trackSid === b.publication.trackSid;
-  } else if (isTrackReferencePlaceholder(a) && isTrackReferencePlaceholder(b)) {
-    return a.participant.identity === b.participant.identity && a.source === b.source;
-  }
-  return false;
-}
-
-/**
- * Check if the `TrackReference` is pinned.
- */
-export function isTrackReferencePinned(
-  trackReference: TrackReferenceOrPlaceholder,
-  pinState: PinState | undefined,
-): boolean {
-  if (pinState === undefined) {
-    return false;
-  }
-  if (isTrackReference(trackReference)) {
-    return pinState.some(
-      (pinnedTrackReference) =>
-        pinnedTrackReference.participant.identity === trackReference.participant.identity &&
-        pinnedTrackReference.publication.trackSid === trackReference.publication.trackSid,
-    );
-  } else if (isTrackReferencePlaceholder(trackReference)) {
-    return pinState.some(
-      (pinnedTrackReference) =>
-        pinnedTrackReference.participant.identity === trackReference.participant.identity &&
-        isTrackReferencePlaceholder(pinnedTrackReference) &&
-        pinnedTrackReference.source === trackReference.source,
-    );
-  } else {
-    return false;
-  }
-}
 
 /**
  * Check if the participant track source is pinned.

--- a/packages/react/src/components/ParticipantLoop.tsx
+++ b/packages/react/src/components/ParticipantLoop.tsx
@@ -66,7 +66,7 @@ export const ParticipantLoop = ({
           {props.children ? (
             cloneSingleChild(props.children)
           ) : (
-            <ParticipantTile trackSource={Track.Source.Camera} />
+            <ParticipantTile source={Track.Source.Camera} />
           )}
         </ParticipantContext.Provider>
       ))}

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -16,12 +16,12 @@ import { AudioTrack } from './participant/AudioTrack';
  * ```
  */
 export const RoomAudioRenderer = () => {
-  const trackReferences = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio], {
+  const tracks = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio], {
     updateOnlyOn: [],
   }).filter((ref) => !isLocal(ref.participant));
   return (
     <div style={{ display: 'none' }}>
-      {trackReferences.map((trackRef) => (
+      {tracks.map((trackRef) => (
         <AudioTrack key={trackRef.publication.trackSid} trackReference={trackRef} />
       ))}
     </div>

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -22,7 +22,7 @@ export const RoomAudioRenderer = () => {
   return (
     <div style={{ display: 'none' }}>
       {tracks.map((trackRef) => (
-        <AudioTrack key={trackRef.publication.trackSid} trackReference={trackRef} />
+        <AudioTrack key={trackRef.publication.trackSid} {...trackRef} />
       ))}
     </div>
   );

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -15,12 +15,16 @@ type TrackLoopProps = {
 /**
  * The TrackLoop component loops over tracks. It is for example a easy way to loop over all participant camera and screen share tracks.
  * Only tracks with a the same source specified via the sources property get included in the loop.
- * Further narrowing the loop items is possible by providing a filter function to the component.
+ * TrackLoop creates a TrackContext for each track that you can use to e.g. render the track.
+ * Further narrowing the loop items is possible by simply filtering the returned array.
  *
  * @example
  * ```tsx
  * const tracks = useTracks([Track.Source.Camera]);
  * <TrackLoop tracks={tracks} >
+ *  <TrackContext.Consumer>
+ *    {(track) => track && <VideoTrack {...track}/>}
+ *  </TrackContext.Consumer>
  * <TrackLoop />
  * ```
  */

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -9,7 +9,7 @@ import { ParticipantTile } from '../prefabs';
 import { cloneSingleChild } from '../utils';
 
 type TrackLoopProps = {
-  trackReferences: TrackReference[] | TrackReferenceOrPlaceholder[];
+  tracks: TrackReference[] | TrackReferenceOrPlaceholder[];
 };
 
 /**
@@ -19,18 +19,15 @@ type TrackLoopProps = {
  *
  * @example
  * ```tsx
- * const trackReferences = useTracks([Track.Source.Camera]);
- * <TrackLoop trackReferences={trackReferences} >
+ * const tracks = useTracks([Track.Source.Camera]);
+ * <TrackLoop tracks={tracks} >
  * <TrackLoop />
  * ```
  */
-export const TrackLoop = ({
-  trackReferences,
-  ...props
-}: React.PropsWithChildren<TrackLoopProps>) => {
+export const TrackLoop = ({ tracks, ...props }: React.PropsWithChildren<TrackLoopProps>) => {
   return (
     <>
-      {trackReferences.map((trackReference) => {
+      {tracks.map((trackReference) => {
         const trackSource = isTrackReference(trackReference)
           ? trackReference.publication.source
           : trackReference.source;

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -1,7 +1,7 @@
 import {
   isTrackReference,
   TrackReference,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
 } from '@livekit/components-core';
 import * as React from 'react';
 import { ParticipantContext } from '../context';
@@ -9,7 +9,7 @@ import { ParticipantTile } from '../prefabs';
 import { cloneSingleChild } from '../utils';
 
 type TrackLoopProps = {
-  trackReferences: TrackReference[] | TrackReferenceWithPlaceholder[];
+  trackReferences: TrackReference[] | TrackReferenceOrPlaceholder[];
 };
 
 /**

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -4,7 +4,7 @@ import {
   TrackReferenceOrPlaceholder,
 } from '@livekit/components-core';
 import * as React from 'react';
-import { ParticipantContext } from '../context';
+import { TrackContext } from '../context/track-context';
 import { ParticipantTile } from '../prefabs';
 import { cloneSingleChild } from '../utils';
 
@@ -32,16 +32,16 @@ export const TrackLoop = ({ tracks, ...props }: React.PropsWithChildren<TrackLoo
           ? trackReference.publication.source
           : trackReference.source;
         return (
-          <ParticipantContext.Provider
-            value={trackReference.participant}
+          <TrackContext.Provider
+            value={trackReference}
             key={`${trackReference.participant.identity}_${trackSource}`}
           >
             {props.children ? (
               cloneSingleChild(props.children)
             ) : (
-              <ParticipantTile trackSource={trackSource} />
+              <ParticipantTile source={trackSource} />
             )}
-          </ParticipantContext.Provider>
+          </TrackContext.Provider>
         );
       })}
     </>

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -39,7 +39,7 @@ export const TrackLoop = ({ tracks, ...props }: React.PropsWithChildren<TrackLoo
             {props.children ? (
               cloneSingleChild(props.children)
             ) : (
-              <ParticipantTile source={trackSource} />
+              <ParticipantTile {...trackReference} />
             )}
           </TrackContext.Provider>
         );

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -49,6 +49,7 @@ function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps
                 trackReference: {
                   participant: p,
                   publication: track,
+                  source: track.source,
                 },
               });
             }

--- a/packages/react/src/components/layout/CarouselView.tsx
+++ b/packages/react/src/components/layout/CarouselView.tsx
@@ -1,9 +1,7 @@
-import { isTrackReferencePinned, TrackReferenceFilter } from '@livekit/components-core';
-import { Track } from 'livekit-client';
+import { TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import * as React from 'react';
-import { useMaybeLayoutContext } from '../../context';
 import { useSize } from '../../hooks/internal';
-import { useTracks, useVisualStableUpdate } from '../../hooks';
+import { useVisualStableUpdate } from '../../hooks';
 import { TrackLoop } from '../TrackLoop';
 
 const MIN_HEIGHT = 130;
@@ -13,31 +11,15 @@ const ASPECT_RATIO = 16 / 10;
 const ASPECT_RATIO_INVERT = (1 - ASPECT_RATIO) * -1;
 
 export interface CarouselViewProps extends React.HTMLAttributes<HTMLMediaElement> {
-  filter?: TrackReferenceFilter;
-  filterDependencies?: [];
+  tracks: TrackReferenceOrPlaceholder[];
+
   /** Place the tiles vertically or horizontally next to each other.
    * If undefined orientation is guessed by the dimensions of the container. */
   orientation?: 'vertical' | 'horizontal';
 }
 
-export function CarouselView({
-  filter,
-  filterDependencies = [],
-  orientation,
-  ...props
-}: CarouselViewProps) {
+export function CarouselView({ tracks, orientation, ...props }: CarouselViewProps) {
   const asideEl = React.useRef<HTMLDivElement>(null);
-  const layoutContext = useMaybeLayoutContext();
-  const trackReferences = useTracks([
-    { source: Track.Source.Camera, withPlaceholder: true },
-    { source: Track.Source.ScreenShare, withPlaceholder: false },
-  ]);
-  const filteredTiles = React.useMemo(() => {
-    const tilesWithoutPinned = trackReferences.filter(
-      (tile) => !layoutContext?.pin.state || !isTrackReferencePinned(tile, layoutContext.pin.state),
-    );
-    return filter ? tilesWithoutPinned.filter(filter) : tilesWithoutPinned;
-  }, [filter, layoutContext?.pin.state, trackReferences, ...filterDependencies]);
 
   const { width, height } = useSize(asideEl);
   const carouselOrientation = orientation
@@ -53,7 +35,7 @@ export function CarouselView({
       ? Math.max(Math.floor(height / tileHeight), MIN_VISIBLE_TILES)
       : Math.max(Math.floor(width / tileWidth), MIN_VISIBLE_TILES);
 
-  const sortedTiles = useVisualStableUpdate(filteredTiles, maxVisibleTiles);
+  const sortedTiles = useVisualStableUpdate(tracks, maxVisibleTiles);
 
   React.useLayoutEffect(() => {
     if (asideEl.current) {

--- a/packages/react/src/components/layout/CarouselView.tsx
+++ b/packages/react/src/components/layout/CarouselView.tsx
@@ -46,7 +46,7 @@ export function CarouselView({ tracks, orientation, ...props }: CarouselViewProp
 
   return (
     <aside key={carouselOrientation} className="lk-carousel" ref={asideEl} {...props}>
-      {props.children ?? <TrackLoop trackReferences={sortedTiles} />}
+      {props.children ?? <TrackLoop tracks={sortedTiles} />}
     </aside>
   );
 }

--- a/packages/react/src/components/layout/FocusLayout.tsx
+++ b/packages/react/src/components/layout/FocusLayout.tsx
@@ -1,59 +1,32 @@
 import { Participant } from 'livekit-client';
 import * as React from 'react';
-import { useMaybeLayoutContext, useLayoutContext } from '../../context';
 import { mergeProps } from '../../utils';
 import { TrackReference } from '@livekit/components-core';
 import { ParticipantTile } from '../participant/ParticipantTile';
 import { ParticipantClickEvent } from '@livekit/components-core';
-import { CarouselView } from './CarouselView';
 
 export interface FocusLayoutContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  trackReference?: TrackReference;
+  focusTrack?: TrackReference;
   participants?: Array<Participant>;
 }
 
-export function FocusLayoutContainer({ trackReference, ...props }: FocusLayoutContainerProps) {
+export function FocusLayoutContainer(props: FocusLayoutContainerProps) {
   const elementProps = mergeProps(props, { className: 'lk-focus-layout' });
-  const pinContext = useLayoutContext().pin;
-  const hasFocus = React.useMemo(() => {
-    return pinContext.state && pinContext.state.length >= 1;
-  }, [pinContext]);
 
-  return (
-    <div {...elementProps}>
-      {props.children ?? (
-        <>
-          <CarouselView />
-          {(hasFocus || trackReference) && <FocusLayout trackReference={trackReference} />}
-        </>
-      )}
-    </div>
-  );
+  return <div {...elementProps}>{props.children}</div>;
 }
 
 export interface FocusLayoutProps extends React.HTMLAttributes<HTMLElement> {
-  trackReference?: TrackReference;
+  track?: TrackReference;
   onParticipantClick?: (evt: ParticipantClickEvent) => void;
 }
 
-export function FocusLayout({ trackReference, ...props }: FocusLayoutProps) {
-  const layoutContext = useMaybeLayoutContext();
-
-  const trackReferenceInFocus: TrackReference | undefined = React.useMemo(() => {
-    if (trackReference) {
-      return trackReference;
-    }
-    if (layoutContext?.pin.state !== undefined && layoutContext.pin.state.length >= 1) {
-      return layoutContext.pin.state[0];
-    }
-    return undefined;
-  }, [layoutContext, trackReference]);
-
+export function FocusLayout({ track, ...props }: FocusLayoutProps) {
   return (
     <ParticipantTile
       {...props}
-      participant={trackReferenceInFocus?.participant}
-      trackSource={trackReferenceInFocus?.publication.source}
+      participant={track?.participant}
+      trackSource={track?.publication.source}
     />
   );
 }

--- a/packages/react/src/components/layout/FocusLayout.tsx
+++ b/packages/react/src/components/layout/FocusLayout.tsx
@@ -21,12 +21,6 @@ export interface FocusLayoutProps extends React.HTMLAttributes<HTMLElement> {
   onParticipantClick?: (evt: ParticipantClickEvent) => void;
 }
 
-export function FocusLayout({ track, ...props }: FocusLayoutProps) {
-  return (
-    <ParticipantTile
-      {...props}
-      participant={track?.participant}
-      trackSource={track?.publication.source}
-    />
-  );
+export function FocusLayout(props: FocusLayoutProps) {
+  return <ParticipantTile {...props} />;
 }

--- a/packages/react/src/components/layout/GridLayout.tsx
+++ b/packages/react/src/components/layout/GridLayout.tsx
@@ -17,7 +17,7 @@ export interface GridLayoutProps
  * @example
  * ```tsx
  * <LiveKitRoom>
- *   <GridLayout />
+ *   <GridLayout track={tracks} />
  * <LiveKitRoom>
  * ```
  */

--- a/packages/react/src/components/layout/GridLayout.tsx
+++ b/packages/react/src/components/layout/GridLayout.tsx
@@ -45,10 +45,7 @@ export function GridLayout({ tracks, ...props }: GridLayoutProps) {
     <div className="lk-grid-layout-wrapper" data-lk-user-interaction={interactive}>
       <div ref={gridEl} {...elementProps}>
         <TrackLoop
-          trackReferences={trackReferences.slice(
-            pagination.firstItemIndex,
-            pagination.lastItemIndex,
-          )}
+          tracks={trackReferences.slice(pagination.firstItemIndex, pagination.lastItemIndex)}
         >
           {props.children}
         </TrackLoop>

--- a/packages/react/src/components/layout/GridLayout.tsx
+++ b/packages/react/src/components/layout/GridLayout.tsx
@@ -1,20 +1,14 @@
 import * as React from 'react';
-import { useGridLayout, usePagination, UseParticipantsOptions, useTracks } from '../../hooks';
+import { useGridLayout, usePagination, UseParticipantsOptions } from '../../hooks';
 import { mergeProps } from '../../utils';
-import { TrackReferenceFilter, createInteractingObservable } from '@livekit/components-core';
-import { Track } from 'livekit-client';
+import { createInteractingObservable, TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import { TrackLoop } from '../TrackLoop';
 import { PaginationControl } from '../controls/PaginationControl';
 
 export interface GridLayoutProps
   extends React.HTMLAttributes<HTMLDivElement>,
     Pick<UseParticipantsOptions, 'updateOnlyOn'> {
-  /**
-   * The grid shows all room participants. If only a subset of the participants
-   * should be visible, they can be filtered.
-   */
-  filter?: TrackReferenceFilter;
-  filterDependencies?: [];
+  tracks: TrackReferenceOrPlaceholder[];
 }
 
 /**
@@ -27,32 +21,14 @@ export interface GridLayoutProps
  * <LiveKitRoom>
  * ```
  */
-export function GridLayout({
-  filter,
-  updateOnlyOn,
-  filterDependencies = [],
-  ...props
-}: GridLayoutProps) {
+export function GridLayout({ tracks, ...props }: GridLayoutProps) {
   const gridEl = React.createRef<HTMLDivElement>();
-  const rawTrackReferences = useTracks(
-    [
-      { source: Track.Source.Camera, withPlaceholder: true },
-      { source: Track.Source.ScreenShare, withPlaceholder: false },
-    ],
-    { updateOnlyOn: updateOnlyOn ? updateOnlyOn : undefined },
-  );
 
   const elementProps = React.useMemo(
     () => mergeProps(props, { className: 'lk-grid-layout' }),
     [props],
   );
-
-  const filteredTrackReferences = React.useMemo(
-    () => (filter ? rawTrackReferences.filter(filter) : rawTrackReferences),
-    [filter, rawTrackReferences, ...filterDependencies],
-  );
-
-  const { layout, trackReferences } = useGridLayout(gridEl, filteredTrackReferences);
+  const { layout, trackReferences } = useGridLayout(gridEl, tracks);
   const pagination = usePagination(layout.maxParticipants, trackReferences.length);
 
   const [interactive, setInteractive] = React.useState(false);
@@ -68,23 +44,15 @@ export function GridLayout({
   return (
     <div className="lk-grid-layout-wrapper" data-lk-user-interaction={interactive}>
       <div ref={gridEl} {...elementProps}>
-        {props.children ?? (
-          <>
-            {props.children ?? (
-              <>
-                <TrackLoop
-                  trackReferences={trackReferences.slice(
-                    pagination.firstItemIndex,
-                    pagination.lastItemIndex,
-                  )}
-                />
-                {trackReferences.length > layout.maxParticipants && (
-                  <PaginationControl {...pagination} />
-                )}
-              </>
-            )}
-          </>
-        )}
+        <TrackLoop
+          trackReferences={trackReferences.slice(
+            pagination.firstItemIndex,
+            pagination.lastItemIndex,
+          )}
+        >
+          {props.children}
+        </TrackLoop>
+        {trackReferences.length > layout.maxParticipants && <PaginationControl {...pagination} />}
       </div>
     </div>
   );

--- a/packages/react/src/components/layout/LayoutContextProvider.tsx
+++ b/packages/react/src/components/layout/LayoutContextProvider.tsx
@@ -6,14 +6,7 @@ import {
   log,
 } from '@livekit/components-core';
 import * as React from 'react';
-import {
-  LayoutContext,
-  LayoutContextType,
-  chatReducer,
-  pinReducer,
-  useRoomContext,
-} from '../../context';
-import { useScreenShare } from '../participant/ScreenShareRenderer';
+import { LayoutContext, LayoutContextType, chatReducer, pinReducer } from '../../context';
 
 type LayoutContextProviderProps = {
   value?: LayoutContextType;
@@ -36,9 +29,6 @@ export function LayoutContextProvider({
   onWidgetChange,
   children,
 }: React.PropsWithChildren<LayoutContextProviderProps>) {
-  const room = useRoomContext();
-  const { screenShareParticipant, screenShareTrack } = useScreenShare({ room });
-
   const [pinState, pinDispatch] = React.useReducer(pinReducer, PIN_DEFAULT_STATE);
   const [widgetState, widgetDispatch] = React.useReducer(chatReducer, WIDGET_DEFAULT_STATE);
 
@@ -60,22 +50,6 @@ export function LayoutContextProvider({
     log.debug('Widget Updated', { widgetState });
     if (onWidgetChange) onWidgetChange(widgetState);
   }, [onWidgetChange, widgetState]);
-
-  React.useEffect(() => {
-    // FIXME: This logic clears the focus if the screenShareParticipant is false.
-    // This is also the case when the hook is executed for the first time and then a unwanted clear_focus message is sent.
-    if (screenShareParticipant && screenShareTrack) {
-      pinDispatch({
-        msg: 'set_pin',
-        trackReference: {
-          participant: screenShareParticipant,
-          publication: screenShareTrack,
-        },
-      });
-    } else {
-      pinDispatch({ msg: 'clear_pin' });
-    }
-  }, [screenShareParticipant, screenShareTrack]);
 
   return <LayoutContext.Provider value={layoutContextValue}>{children}</LayoutContext.Provider>;
 }

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -1,22 +1,20 @@
-import { Participant } from 'livekit-client';
+import { Participant, Track, TrackPublication } from 'livekit-client';
 import * as React from 'react';
 import { useMediaTrackBySourceOrName } from '../../hooks/useMediaTrackBySourceOrName';
-import { AudioSource, log, TrackReference, TrackSource } from '@livekit/components-core';
+import { log } from '@livekit/components-core';
 import { useEnsureParticipant } from '../../context';
 import { RemoteAudioTrack } from 'livekit-client';
 
-type AudioTrackSource =
-  | (TrackSource<AudioSource> & { trackReference?: undefined })
-  | { source?: undefined; name?: undefined; trackReference: TrackReference };
-
 export type AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement> =
-  React.HTMLAttributes<T> &
-    AudioTrackSource & {
-      participant?: Participant;
-      onSubscriptionStatusChanged?: (subscribed: boolean) => void;
-      /** by the default the range is between 0 and 1 */
-      volume?: number;
-    };
+  React.HTMLAttributes<T> & {
+    source: Track.Source;
+    name?: string;
+    participant?: Participant;
+    publication?: TrackPublication;
+    onSubscriptionStatusChanged?: (subscribed: boolean) => void;
+    /** by the default the range is between 0 and 1 */
+    volume?: number;
+  };
 
 /**
  * The AudioTrack component is responsible for rendering participant audio tracks.
@@ -32,15 +30,13 @@ export type AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement> =
  * @see `ParticipantTile` component
  */
 export function AudioTrack({ onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps) {
-  const { source, name, trackReference } = props;
+  const { source, name, publication } = props;
   const mediaEl = React.useRef<HTMLAudioElement>(null);
-  const participant = useEnsureParticipant(props.participant || trackReference?.participant);
+  const participant = useEnsureParticipant(props.participant);
 
   const { elementProps, isSubscribed, track } = useMediaTrackBySourceOrName(
-    // @ts-expect-error this is an exhaustive check for AudioTrackProps, but typescript doesn't pick it up
-    source || name ? { source, name } : trackReference,
+    { source, name, participant, publication },
     {
-      participant,
       element: mediaEl,
       props,
     },

--- a/packages/react/src/components/participant/AudioVisualizer.tsx
+++ b/packages/react/src/components/participant/AudioVisualizer.tsx
@@ -22,7 +22,7 @@ export function AudioVisualizer({ participant, ...props }: AudioVisualizerProps)
   const volMultiplier = 50;
   const barCount = 7;
 
-  const { track } = useMediaTrack(Track.Source.Microphone, { participant });
+  const { track } = useMediaTrack(Track.Source.Microphone, participant);
 
   React.useEffect(() => {
     if (!track || !(track instanceof LocalAudioTrack || track instanceof RemoteAudioTrack)) {

--- a/packages/react/src/components/participant/ParticipantAudioTile.tsx
+++ b/packages/react/src/components/participant/ParticipantAudioTile.tsx
@@ -32,6 +32,7 @@ import { AudioTrack } from './AudioTrack';
 export const ParticipantAudioTile = ({
   participant,
   children,
+  publication,
   onParticipantClick,
   ...htmlProps
 }: ParticipantTileProps) => {
@@ -39,7 +40,8 @@ export const ParticipantAudioTile = ({
   const { elementProps } = useParticipantTile({
     participant: p,
     props: htmlProps,
-    trackSource: Track.Source.Microphone,
+    source: Track.Source.Microphone,
+    publication,
     onParticipantClick,
   });
 

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -108,13 +108,12 @@ export const ParticipantTile = ({
   publication,
   ...htmlProps
 }: ParticipantTileProps) => {
-  const trackSource_ = source;
   const p = useEnsureParticipant(participant);
 
   const { elementProps } = useParticipantTile({
     participant: p,
     props: htmlProps,
-    source: trackSource_,
+    source,
     publication,
     onParticipantClick,
   });
@@ -138,17 +137,22 @@ export const ParticipantTile = ({
 
   return (
     <div style={{ position: 'relative' }} {...elementProps}>
-      <ParticipantContextIfNeeded participant={participant}>
+      <ParticipantContextIfNeeded participant={p}>
         {children ?? (
           <>
             {/** TODO remove MediaTrack in favor of the equivalent Audio/Video Track. need to figure out how to differentiate here */}
-            <MediaTrack source={trackSource_} onSubscriptionStatusChanged={handleSubscribe} />
+            <MediaTrack
+              source={source}
+              publication={publication}
+              participant={participant}
+              onSubscriptionStatusChanged={handleSubscribe}
+            />
             <div className="lk-participant-placeholder">
               <ParticipantPlaceholder />
             </div>
             <div className="lk-participant-metadata">
               <div className="lk-participant-metadata-item">
-                {trackSource_ === Track.Source.Camera ? (
+                {source === Track.Source.Camera ? (
                   <>
                     <TrackMutedIndicator
                       source={Track.Source.Microphone}
@@ -167,7 +171,7 @@ export const ParticipantTile = ({
             </div>
           </>
         )}
-        <FocusToggle trackSource={trackSource_} />
+        <FocusToggle trackSource={source} />
       </ParticipantContextIfNeeded>
     </div>
   );

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Participant, Track } from 'livekit-client';
+import { Participant, Track, TrackPublication } from 'livekit-client';
 import {
   isParticipantSourcePinned,
   ParticipantClickEvent,
@@ -23,18 +23,21 @@ import { ScreenShareIcon } from '../../assets/icons';
 
 export type ParticipantTileProps = React.HTMLAttributes<HTMLDivElement> & {
   participant?: Participant;
-  trackSource?: Track.Source;
+  source?: Track.Source;
+  publication?: TrackPublication;
   onParticipantClick?: (event: ParticipantClickEvent) => void;
 };
 
 export function useParticipantTile<T extends React.HTMLAttributes<HTMLElement>>({
   participant,
-  trackSource,
+  source,
+  publication,
   onParticipantClick,
   props,
 }: {
   participant: Participant;
-  trackSource: Track.Source;
+  source: Track.Source;
+  publication?: TrackPublication;
   onParticipantClick?: (event: ParticipantClickEvent) => void;
   props: T;
 }) {
@@ -46,12 +49,12 @@ export function useParticipantTile<T extends React.HTMLAttributes<HTMLElement>>(
       onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
         props.onClick?.(event);
         if (typeof onParticipantClick === 'function') {
-          const track = p.getTrack(trackSource);
+          const track = publication ?? p.getTrack(source);
           onParticipantClick({ participant: p, track });
         }
       },
     });
-  }, [props]);
+  }, [props, source, onParticipantClick, p, publication]);
   const isVideoMuted = useIsMuted(Track.Source.Camera, { participant });
   const isAudioMuted = useIsMuted(Track.Source.Microphone, { participant });
   const isSpeaking = useIsSpeaking(participant);
@@ -61,7 +64,7 @@ export function useParticipantTile<T extends React.HTMLAttributes<HTMLElement>>(
       'data-lk-video-muted': isVideoMuted,
       'data-lk-speaking': isSpeaking,
       'data-lk-local-participant': participant.isLocal,
-      'data-lk-source': trackSource,
+      'data-lk-source': source,
       ...mergedProps,
     },
   };
@@ -100,17 +103,19 @@ export function ParticipantContextIfNeeded(
 export const ParticipantTile = ({
   participant,
   children,
-  trackSource = Track.Source.Camera,
+  source = Track.Source.Camera,
   onParticipantClick,
+  publication,
   ...htmlProps
 }: ParticipantTileProps) => {
-  const trackSource_ = trackSource;
+  const trackSource_ = source;
   const p = useEnsureParticipant(participant);
 
   const { elementProps } = useParticipantTile({
     participant: p,
     props: htmlProps,
-    trackSource: trackSource_,
+    source: trackSource_,
+    publication,
     onParticipantClick,
   });
 
@@ -119,16 +124,16 @@ export const ParticipantTile = ({
   const handleSubscribe = React.useCallback(
     (subscribed: boolean) => {
       if (
-        trackSource &&
+        source &&
         !subscribed &&
         layoutContext &&
         layoutContext.pin.dispatch &&
-        isParticipantSourcePinned(p, trackSource, layoutContext.pin.state)
+        isParticipantSourcePinned(p, source, layoutContext.pin.state)
       ) {
         layoutContext.pin.dispatch({ msg: 'clear_pin' });
       }
     },
-    [p, layoutContext, trackSource],
+    [p, layoutContext, source],
   );
 
   return (

--- a/packages/react/src/components/participant/ScreenShareRenderer.tsx
+++ b/packages/react/src/components/participant/ScreenShareRenderer.tsx
@@ -13,6 +13,12 @@ type ScreenShareOptions = {
   ) => void;
   room?: Room;
 };
+
+/**
+ * @deprecated use `useTracks([Track.Source.ScreenShare])` instead
+ * @param param0
+ * @returns
+ */
 export const useScreenShare = ({
   room: passedRoom,
   onScreenShareChange,

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -3,3 +3,4 @@ export * from './layout-context';
 export * from './participant-context';
 export * from './pin-context';
 export * from './room-context';
+export * from './track-context';

--- a/packages/react/src/context/layout-context.ts
+++ b/packages/react/src/context/layout-context.ts
@@ -29,6 +29,15 @@ export function useLayoutContext(): LayoutContextType {
   return layoutContext;
 }
 
+export function useEnsureLayoutContext(layoutContext?: LayoutContextType) {
+  const layout = useMaybeLayoutContext();
+  layoutContext ??= layout;
+  if (!layoutContext) {
+    throw Error('Tried to access LayoutContext context outside a LayoutContextProvider provider.');
+  }
+  return layoutContext;
+}
+
 export function useMaybeLayoutContext(): LayoutContextType | undefined {
   return React.useContext(LayoutContext);
 }

--- a/packages/react/src/context/participant-context.ts
+++ b/packages/react/src/context/participant-context.ts
@@ -1,5 +1,6 @@
 import type { Participant } from 'livekit-client';
 import * as React from 'react';
+import { useMaybeTrackContext } from './track-context';
 
 export const ParticipantContext = React.createContext<Participant | undefined>(undefined);
 
@@ -17,7 +18,8 @@ export function useMaybeParticipantContext() {
 
 export function useEnsureParticipant(participant?: Participant) {
   const context = useMaybeParticipantContext();
-  const p = participant ?? context;
+  const trackContext = useMaybeTrackContext();
+  const p = participant ?? context ?? trackContext?.participant;
   if (!p) {
     throw new Error(
       'No participant provided, make sure you are inside a participant context or pass the participant explicitly',

--- a/packages/react/src/context/track-context.ts
+++ b/packages/react/src/context/track-context.ts
@@ -4,11 +4,11 @@ import * as React from 'react';
 export const TrackContext = React.createContext<TrackReferenceOrPlaceholder | undefined>(undefined);
 
 export function useTrackContext() {
-  const participant = React.useContext(TrackContext);
-  if (!participant) {
+  const trackReference = React.useContext(TrackContext);
+  if (!trackReference) {
     throw Error('tried to access track context outside of track context provider');
   }
-  return participant;
+  return trackReference;
 }
 
 export function useMaybeTrackContext() {
@@ -20,7 +20,7 @@ export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder) {
   const trackRef = track ?? context;
   if (!trackRef) {
     throw new Error(
-      'No participant provided, make sure you are inside a participant context or pass the participant explicitly',
+      'No TrackReference provided, make sure you are inside a track context or pass the track reference explicitly',
     );
   }
   return trackRef;

--- a/packages/react/src/context/track-context.ts
+++ b/packages/react/src/context/track-context.ts
@@ -1,0 +1,27 @@
+import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
+import * as React from 'react';
+
+export const TrackContext = React.createContext<TrackReferenceOrPlaceholder | undefined>(undefined);
+
+export function useTrackContext() {
+  const participant = React.useContext(TrackContext);
+  if (!participant) {
+    throw Error('tried to access track context outside of track context provider');
+  }
+  return participant;
+}
+
+export function useMaybeTrackContext() {
+  return React.useContext(TrackContext);
+}
+
+export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder) {
+  const context = useMaybeTrackContext();
+  const trackRef = track ?? context;
+  if (!trackRef) {
+    throw new Error(
+      'No participant provided, make sure you are inside a participant context or pass the participant explicitly',
+    );
+  }
+  return trackRef;
+}

--- a/packages/react/src/hooks/useGridLayout.ts
+++ b/packages/react/src/hooks/useGridLayout.ts
@@ -1,7 +1,7 @@
 import {
   GRID_LAYOUTS,
   selectGridLayout,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
 } from '@livekit/components-core';
 import { GridLayout } from '@livekit/components-core/dist/helper/grid-layouts';
 import * as React from 'react';
@@ -19,8 +19,8 @@ export function useGridLayout(
   /** HTML element that contains the grid. */
   gridElement: React.RefObject<HTMLDivElement>,
   /** `TrackReference`s to display in the grid.  */
-  trackReferences: TrackReferenceWithPlaceholder[],
-): { layout: GridLayout; trackReferences: TrackReferenceWithPlaceholder[] } {
+  trackReferences: TrackReferenceOrPlaceholder[],
+): { layout: GridLayout; trackReferences: TrackReferenceOrPlaceholder[] } {
   const { width, height } = useSize(gridElement);
 
   const layout =

--- a/packages/react/src/hooks/useMediaTrack.ts
+++ b/packages/react/src/hooks/useMediaTrack.ts
@@ -1,9 +1,13 @@
 import { VideoSource, AudioSource } from '@livekit/components-core';
+import { Participant } from 'livekit-client';
+import { useEnsureParticipant } from '../context/participant-context';
 import { UseMediaTrackOptions, useMediaTrackBySourceOrName } from './useMediaTrackBySourceOrName';
 
 export function useMediaTrack(
   source: VideoSource | AudioSource,
+  participant?: Participant,
   options: UseMediaTrackOptions = {},
 ) {
-  return useMediaTrackBySourceOrName({ source }, options);
+  const p = useEnsureParticipant(participant);
+  return useMediaTrackBySourceOrName({ source, participant: p }, options);
 }

--- a/packages/react/src/hooks/useMediaTrackByName.ts
+++ b/packages/react/src/hooks/useMediaTrackByName.ts
@@ -1,5 +1,12 @@
+import { Participant } from 'livekit-client';
+import { useEnsureParticipant } from '../context';
 import { useMediaTrackBySourceOrName, UseMediaTrackOptions } from './useMediaTrackBySourceOrName';
 
-export function useMediaTrackByName(name: string, options: UseMediaTrackOptions = {}) {
-  return useMediaTrackBySourceOrName({ name }, options);
+export function useMediaTrackByName(
+  name: string,
+  participant?: Participant,
+  options: UseMediaTrackOptions = {},
+) {
+  const p = useEnsureParticipant(participant);
+  return useMediaTrackBySourceOrName({ name, participant: p }, options);
 }

--- a/packages/react/src/hooks/usePinnedTracks.ts
+++ b/packages/react/src/hooks/usePinnedTracks.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useLayoutContext } from '../context';
+
+export function usePinnedTracks() {
+  const layoutContext = useLayoutContext();
+  return React.useMemo(() => {
+    if (layoutContext?.pin.state !== undefined && layoutContext.pin.state.length >= 1) {
+      return layoutContext.pin.state;
+    }
+    return undefined;
+  }, [layoutContext]);
+}

--- a/packages/react/src/hooks/usePinnedTracks.ts
+++ b/packages/react/src/hooks/usePinnedTracks.ts
@@ -1,12 +1,13 @@
+import { TrackReference } from '@livekit/components-core';
 import React from 'react';
 import { LayoutContextType, useEnsureLayoutContext } from '../context';
 
-export function usePinnedTracks(layoutContext?: LayoutContextType) {
+export function usePinnedTracks(layoutContext?: LayoutContextType): TrackReference[] {
   layoutContext = useEnsureLayoutContext(layoutContext);
   return React.useMemo(() => {
     if (layoutContext?.pin.state !== undefined && layoutContext.pin.state.length >= 1) {
       return layoutContext.pin.state;
     }
-    return undefined;
+    return [];
   }, [layoutContext]);
 }

--- a/packages/react/src/hooks/usePinnedTracks.ts
+++ b/packages/react/src/hooks/usePinnedTracks.ts
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useLayoutContext } from '../context';
+import { LayoutContextType, useEnsureLayoutContext } from '../context';
 
-export function usePinnedTracks() {
-  const layoutContext = useLayoutContext();
+export function usePinnedTracks(layoutContext?: LayoutContextType) {
+  layoutContext = useEnsureLayoutContext(layoutContext);
   return React.useMemo(() => {
     if (layoutContext?.pin.state !== undefined && layoutContext.pin.state.length >= 1) {
       return layoutContext.pin.state;

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -4,7 +4,7 @@ import {
   log,
   SourcesArray,
   TrackReference,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
   trackReferencesObservable,
   TrackSourceWithOptions,
   TrackReferencePlaceholder,
@@ -21,7 +21,7 @@ type UseTracksOptions = {
 type UseTracksHookReturnType<T> = T extends Track.Source[]
   ? TrackReference[]
   : T extends TrackSourceWithOptions[]
-  ? TrackReferenceWithPlaceholder[]
+  ? TrackReferenceOrPlaceholder[]
   : never;
 
 /**
@@ -66,7 +66,7 @@ export function useTracks<T extends SourcesArray = SourcesArray>(
       const requirePlaceholder = requiredPlaceholders(sources, participants);
       const trackReferencesWithPlaceholders = Array.from(
         trackReferences,
-      ) as TrackReferenceWithPlaceholder[];
+      ) as TrackReferenceOrPlaceholder[];
       participants.forEach((participant) => {
         if (requirePlaceholder.has(participant.identity)) {
           const sourcesToAddPlaceholder = requirePlaceholder.get(participant.identity) ?? [];

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -9,13 +9,14 @@ import {
   TrackSourceWithOptions,
   TrackReferencePlaceholder,
 } from '@livekit/components-core';
-import { Participant, RoomEvent, Track } from 'livekit-client';
+import { Participant, Room, RoomEvent, Track } from 'livekit-client';
 import * as React from 'react';
-import { useRoomContext } from '../context';
+import { useEnsureRoom } from '../context';
 
 type UseTracksOptions = {
   updateOnlyOn?: RoomEvent[];
   onlySubscribed?: boolean;
+  room?: Room;
 };
 
 type UseTracksHookReturnType<T> = T extends Track.Source[]
@@ -47,7 +48,7 @@ export function useTracks<T extends SourcesArray = Track.Source[]>(
   ] as T,
   options: UseTracksOptions = {},
 ): UseTracksHookReturnType<T> {
-  const room = useRoomContext();
+  const room = useEnsureRoom(options.room);
   const [trackReferences, setTrackReferences] = React.useState<TrackReference[]>([]);
   const [participants, setParticipants] = React.useState<Participant[]>([]);
 

--- a/packages/react/src/hooks/useVisualStableUpdate.ts
+++ b/packages/react/src/hooks/useVisualStableUpdate.ts
@@ -1,7 +1,7 @@
 import {
   log,
   sortTrackReferences,
-  TrackReferenceWithPlaceholder,
+  TrackReferenceOrPlaceholder,
   updatePages,
 } from '@livekit/components-core';
 import * as React from 'react';
@@ -9,8 +9,8 @@ import * as React from 'react';
 interface UseVisualStableUpdateOptions {
   /** Overwrites the default sort function. */
   customSortFunction?: (
-    trackReferences: TrackReferenceWithPlaceholder[],
-  ) => TrackReferenceWithPlaceholder[];
+    trackReferences: TrackReferenceOrPlaceholder[],
+  ) => TrackReferenceOrPlaceholder[];
 }
 
 /**
@@ -22,11 +22,11 @@ interface UseVisualStableUpdateOptions {
  */
 export function useVisualStableUpdate(
   /** `TrackReference`s to display in the grid.  */
-  trackReferences: TrackReferenceWithPlaceholder[],
+  trackReferences: TrackReferenceOrPlaceholder[],
   maxItemsOnPage: number,
   options: UseVisualStableUpdateOptions = {},
-): TrackReferenceWithPlaceholder[] {
-  const stateTrackReferences = React.useRef<TrackReferenceWithPlaceholder[]>([]);
+): TrackReferenceOrPlaceholder[] {
+  const stateTrackReferences = React.useRef<TrackReferenceOrPlaceholder[]>([]);
   const maxTilesOnPage = React.useRef<number>(-1);
 
   const nextSortedTrackReferences =
@@ -34,7 +34,7 @@ export function useVisualStableUpdate(
       ? options.customSortFunction(trackReferences)
       : sortTrackReferences(trackReferences);
 
-  let updatedTrackReferences: TrackReferenceWithPlaceholder[] = nextSortedTrackReferences;
+  let updatedTrackReferences: TrackReferenceOrPlaceholder[] = nextSortedTrackReferences;
   if (maxItemsOnPage === maxTilesOnPage.current) {
     try {
       updatedTrackReferences = updatePages(

--- a/packages/react/src/prefabs/AudioConference.tsx
+++ b/packages/react/src/prefabs/AudioConference.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { ControlBar } from './ControlBar';
-import { FocusLayoutContainer } from '../components/layout/FocusLayout';
 import { GridLayout } from '../components/layout/GridLayout';
-import { TrackLoop } from '../components/TrackLoop';
 import { Track } from 'livekit-client';
 import { ParticipantAudioTile } from '../components/participant/ParticipantAudioTile';
 import { LayoutContextProvider } from '../components/layout/LayoutContextProvider';
-import { PinState, WidgetState } from '@livekit/components-core';
+import { WidgetState } from '@livekit/components-core';
 import { Chat } from './Chat';
 import { useTracks } from '../hooks';
 
@@ -28,29 +26,19 @@ export type AudioConferenceProps = React.HTMLAttributes<HTMLDivElement>;
  * ```
  */
 export function AudioConference({ ...props }: AudioConferenceProps) {
-  type Layout = 'grid' | 'focus';
-  const [layout, setLayout] = React.useState<Layout>('grid');
   const [widgetState, setWidgetState] = React.useState<WidgetState>({ showChat: false });
-
-  const handlePinStateChange = (pinState: PinState) => {
-    setLayout(pinState.length >= 1 ? 'focus' : 'grid');
-  };
 
   const trackReferences = useTracks([Track.Source.Microphone]);
 
   return (
     <div className="lk-audio-conference" {...props}>
-      <LayoutContextProvider onPinChange={handlePinStateChange} onWidgetChange={setWidgetState}>
+      <LayoutContextProvider onWidgetChange={setWidgetState}>
         <div className="lk-audio-conference-stage">
-          {layout === 'grid' ? (
-            <GridLayout>
-              <TrackLoop trackReferences={trackReferences}>
-                <ParticipantAudioTile />
-              </TrackLoop>
+          <div className="lk-grid-wrapper">
+            <GridLayout tracks={trackReferences}>
+              <ParticipantAudioTile />
             </GridLayout>
-          ) : (
-            <FocusLayoutContainer />
-          )}
+          </div>
           <ControlBar
             controls={{ microphone: true, screenShare: false, camera: false, chat: true }}
           />

--- a/packages/react/src/prefabs/AudioConference.tsx
+++ b/packages/react/src/prefabs/AudioConference.tsx
@@ -28,14 +28,14 @@ export type AudioConferenceProps = React.HTMLAttributes<HTMLDivElement>;
 export function AudioConference({ ...props }: AudioConferenceProps) {
   const [widgetState, setWidgetState] = React.useState<WidgetState>({ showChat: false });
 
-  const trackReferences = useTracks([Track.Source.Microphone]);
+  const tracks = useTracks([Track.Source.Microphone]);
 
   return (
     <div className="lk-audio-conference" {...props}>
       <LayoutContextProvider onWidgetChange={setWidgetState}>
         <div className="lk-audio-conference-stage">
           <div className="lk-grid-wrapper">
-            <GridLayout tracks={trackReferences}>
+            <GridLayout tracks={tracks}>
               <ParticipantAudioTile />
             </GridLayout>
           </div>

--- a/packages/react/src/prefabs/VideoConference.tsx
+++ b/packages/react/src/prefabs/VideoConference.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
-import { LayoutContextProvider } from '../components/layout/LayoutContextProvider';
+import {
+  LayoutContextProvider,
+  useCreateLayoutContext,
+} from '../components/layout/LayoutContextProvider';
 import { RoomAudioRenderer } from '../components/RoomAudioRenderer';
 import { ControlBar } from './ControlBar';
 import { FocusLayout, FocusLayoutContainer } from '../components/layout/FocusLayout';
 import { GridLayout } from '../components/layout/GridLayout';
-import { PinState, WidgetState } from '@livekit/components-core';
+import { isEqualTrackRef, isTrackReference, PinState, WidgetState } from '@livekit/components-core';
 import { Chat } from './Chat';
 import { ConnectionStateToast } from '../components/Toast';
 import { useMediaQuery } from '../hooks/internal/useMediaQuery';
@@ -44,21 +47,25 @@ export function VideoConference({ chatMessageFormatter, ...props }: VideoConfere
 
   const isMobile = useMediaQuery(`(max-width: 660px)`);
 
-  const tracks = useTracks([
-    { source: Track.Source.Camera, withPlaceholder: true },
-    { source: Track.Source.ScreenShare, withPlaceholder: false },
-  ]);
+  const tracks = useTracks(
+    [
+      { source: Track.Source.Camera, withPlaceholder: true },
+      { source: Track.Source.ScreenShare, withPlaceholder: false },
+    ],
+    { updateOnlyOn: [] },
+  );
 
-  // TODO
-  // const pinnedTracks = usePinnedTracks();
-  // const otherTracks = diff(pinnedTracks, tracks);
-
-  const focusTrack = usePinnedTracks()?.[0];
-  const carouselTracks = tracks.filter((track) => track !== focusTrack);
+  const layoutContext = useCreateLayoutContext();
+  const focusTrack = usePinnedTracks(layoutContext)?.[0];
+  const carouselTracks = tracks.filter((track) => !isEqualTrackRef(track, focusTrack));
 
   return (
     <div className="lk-video-conference" {...props}>
-      <LayoutContextProvider onPinChange={handleFocusStateChange} onWidgetChange={setWidgetState}>
+      <LayoutContextProvider
+        value={layoutContext}
+        onPinChange={handleFocusStateChange}
+        onWidgetChange={setWidgetState}
+      >
         <div className="lk-video-conference-inner">
           {layout === 'grid' ? (
             <GridLayout tracks={tracks} />

--- a/packages/react/src/prefabs/VideoConference.tsx
+++ b/packages/react/src/prefabs/VideoConference.tsx
@@ -2,13 +2,17 @@ import * as React from 'react';
 import { LayoutContextProvider } from '../components/layout/LayoutContextProvider';
 import { RoomAudioRenderer } from '../components/RoomAudioRenderer';
 import { ControlBar } from './ControlBar';
-import { FocusLayoutContainer } from '../components/layout/FocusLayout';
+import { FocusLayout, FocusLayoutContainer } from '../components/layout/FocusLayout';
 import { GridLayout } from '../components/layout/GridLayout';
 import { PinState, WidgetState } from '@livekit/components-core';
 import { Chat } from './Chat';
 import { ConnectionStateToast } from '../components/Toast';
 import { useMediaQuery } from '../hooks/internal/useMediaQuery';
 import { MessageFormatter } from '../components/ChatEntry';
+import { Track } from 'livekit-client';
+import { useTracks } from '../hooks/useTracks';
+import { usePinnedTracks } from '../hooks/usePinnedTracks';
+import { CarouselView } from '../components/layout/CarouselView';
 
 export interface VideoConferenceProps extends React.HTMLAttributes<HTMLDivElement> {
   chatMessageFormatter?: MessageFormatter;
@@ -40,15 +44,30 @@ export function VideoConference({ chatMessageFormatter, ...props }: VideoConfere
 
   const isMobile = useMediaQuery(`(max-width: 660px)`);
 
+  const tracks = useTracks([
+    { source: Track.Source.Camera, withPlaceholder: true },
+    { source: Track.Source.ScreenShare, withPlaceholder: false },
+  ]);
+
+  // TODO
+  // const pinnedTracks = usePinnedTracks();
+  // const otherTracks = diff(pinnedTracks, tracks);
+
+  const focusTrack = usePinnedTracks()?.[0];
+  const carouselTracks = tracks.filter((track) => track !== focusTrack);
+
   return (
     <div className="lk-video-conference" {...props}>
       <LayoutContextProvider onPinChange={handleFocusStateChange} onWidgetChange={setWidgetState}>
         <div className="lk-video-conference-inner">
           {layout === 'grid' ? (
-            <GridLayout />
+            <GridLayout tracks={tracks} />
           ) : (
             <div className="lk-focus-layout-wrapper">
-              <FocusLayoutContainer />
+              <FocusLayoutContainer>
+                <CarouselView tracks={carouselTracks} />
+                {focusTrack && <FocusLayout track={focusTrack} />}
+              </FocusLayoutContainer>
             </div>
           )}
           <ControlBar variation={isMobile ? 'minimal' : 'verbose'} controls={{ chat: true }} />


### PR DESCRIPTION

In order to be able to specify which tracks should be rendered within a `<GridLayout/>` the structure of how tracks are passed to the layout components had to change. 

We updated all examples accordingly to showcase the new, more flexible structure. One simple example 
```tsx
const cameraTracks = useTracks([Track.Source.Camera]);
return <GridLayout tracks={cameraTracks}/>;
```

This also means that the GridLayout now already loops over tracks, so a child passed to the <GridLayout/> will be treated as a tile. 

In order to facilitate the usage of the `useTracks` return type (`TrackReference`), also VideoTrack components now accept a track reference when spread like so
```tsx
const myCameraTrack = useTracks([Track.Source.Camera])[0];
return <VideoTrack {...myCameraTrack}) />
```