### PR TITLE
Chat-revision

### DIFF
--- a/packages/react/src/components/ChatEntry.tsx
+++ b/packages/react/src/components/ChatEntry.tsx
@@ -8,13 +8,11 @@ export type MessageFormatter = (message: string) => React.ReactNode;
  * These are the props specific to the ChatEntry component:
  */
 export interface ChatEntryProps extends React.HTMLAttributes<HTMLLIElement> {
-  /**
-   * The chat massage object to display.
-   */
+  /** The chat massage object to display. */
   entry: ReceivedChatMessage;
-  /**
-   * An optional formatter for the message body.
-   */
+  /** Hide name and time. Useful when displaying multiple consecutive chat messages from the same person. */
+  hideMetaData?: boolean;
+  /** An optional formatter for the message body. */
   messageFormatter?: MessageFormatter;
 }
 
@@ -30,20 +28,32 @@ export interface ChatEntryProps extends React.HTMLAttributes<HTMLLIElement> {
  * {...}
  * ```
  */
-export function ChatEntry({ entry, messageFormatter, ...props }: ChatEntryProps) {
+export function ChatEntry({
+  entry,
+  hideMetaData = false,
+  messageFormatter,
+  ...props
+}: ChatEntryProps) {
   const formattedMessage = React.useMemo(() => {
     return messageFormatter ? messageFormatter(entry.message) : entry.message;
   }, [entry.message, messageFormatter]);
+  const time = new Date(entry.timestamp);
+  const locale = navigator ? navigator.language : 'en-US';
 
   return (
     <li
       className="lk-chat-entry"
-      title={new Date(entry.timestamp).toLocaleTimeString()}
+      title={time.toLocaleTimeString(locale, { timeStyle: 'full' })}
       data-lk-message-origin={entry.from?.isLocal ? 'local' : 'remote'}
       {...props}
     >
-      <strong>{entry.from?.name ?? entry.from?.identity}</strong>
-      <span>{formattedMessage}</span>
+      {!hideMetaData && (
+        <span className="lk-meta-data" style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <strong>{entry.from?.name ?? entry.from?.identity}</strong>{' '}
+          <span>{time.toLocaleTimeString(navigator.language, { timeStyle: 'short' })}</span>
+        </span>
+      )}
+      <span className="lk-message-body">{formattedMessage}</span>
     </li>
   );
 }

--- a/packages/react/src/prefabs/Chat.tsx
+++ b/packages/react/src/prefabs/Chat.tsx
@@ -70,9 +70,17 @@ export function Chat({ messageFormatter, ...props }: ChatProps) {
                 messageFormatter,
               }),
             )
-          : chatMessages.map((msg, idx) => (
-              <ChatEntry key={idx} entry={msg} messageFormatter={messageFormatter} />
-            ))}
+          : chatMessages.map((msg, idx, allMsg) => {
+              const hideMetaData = idx >= 1 && allMsg[idx - 1].from === msg.from;
+              return (
+                <ChatEntry
+                  key={idx}
+                  hideMetaData={hideMetaData}
+                  entry={msg}
+                  messageFormatter={messageFormatter}
+                />
+              );
+            })}
       </ul>
       <form className="lk-chat-form" onSubmit={handleSubmit}>
         <input

--- a/packages/styles/scss/prefab-components/_chat.scss
+++ b/packages/styles/scss/prefab-components/_chat.scss
@@ -12,20 +12,43 @@
   flex-grow: 1;
   max-height: 100%;
   overflow: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem !important;
 }
 
 .chat-entry {
   display: flex;
-  gap: 0.75rem;
-  padding: 0.25rem 0.75rem;
-  word-break: break-word;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 0.25rem;
 
-  > strong {
+  .meta-data {
+    margin-top: 1rem;
+    font-size: 0.75rem;
+    color: var(--fg5);
     white-space: nowrap;
+    padding: 0 0.3rem;
+  }
+
+  .message-body {
+    border-radius: 15px;
+    padding: 0.25rem 0.75rem;
+    word-break: break-word;
+    width: fit-content;
   }
 
   &[data-message-origin='local'] {
-    background-color: rgba(3, 56, 109, 0.5);
+    .message-body {
+      background-color: var(--bg5);
+    }
+  }
+  &[data-message-origin='remote'] {
+    .message-body {
+      background-color: var(--accent4);
+    }
   }
 }
 

--- a/packages/styles/scss/prefab-components/_chat.scss
+++ b/packages/styles/scss/prefab-components/_chat.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  width: 280px;
+  width: clamp(200px, 55ch, 60ch);
   background-color: var(--bg2);
   border-left: 1px solid var(--border-color);
 }


### PR DESCRIPTION
- Group consecutive chat messages from the same participant. Show only the name on the first message.
- Increase default chat width to work better in focus layout.
- update chat message styling
- add prop to ChatEntry to allow hiding chat message meta data (name, timestamp).