### PR TITLE
Control bar fixes for small screen

### DIFF
--- a/packages/react/src/prefabs/ControlBar.tsx
+++ b/packages/react/src/prefabs/ControlBar.tsx
@@ -9,6 +9,7 @@ import { ChatToggle } from '../components/controls/ChatToggle';
 import { isMobileBrowser } from '@livekit/components-core';
 import { useLocalParticipantPermissions } from '../hooks';
 import { useMediaQuery } from '../hooks/internal';
+import { useMaybeLayoutContext } from '../context';
 
 type ControlBarControls = {
   microphone?: boolean;
@@ -39,8 +40,16 @@ export type ControlBarProps = React.HTMLAttributes<HTMLDivElement> & {
  * ```
  */
 export function ControlBar({ variation, controls, ...props }: ControlBarProps) {
-  const defaultVariation = useMediaQuery(`(max-width: 660px)`) ? 'minimal' : 'verbose';
+  const [isChatOpen, setIsChatOpen] = React.useState(false);
+  const layoutContext = useMaybeLayoutContext();
+  React.useEffect(() => {
+    if (layoutContext?.widget.state?.showChat !== undefined) {
+      setIsChatOpen(layoutContext?.widget.state?.showChat);
+    }
+  }, [layoutContext?.widget.state?.showChat]);
+  const isTooLittleSpace = useMediaQuery(`(max-width: ${isChatOpen ? 1000 : 760}px)`);
 
+  const defaultVariation = isTooLittleSpace ? 'minimal' : 'verbose';
   variation ??= defaultVariation;
 
   const visibleControls = { leave: true, ...controls };

--- a/packages/styles/scss/components/controls/_button.scss
+++ b/packages/styles/scss/components/controls/_button.scss
@@ -10,6 +10,7 @@
   border: 0;
   border-radius: var(--border-radius);
   cursor: pointer;
+  white-space: nowrap;
 
   &:not(:disabled):hover {
     background-color: var(--control-hover-bg);


### PR DESCRIPTION
- set “nowrap" as default for buttons
- switch the control bar to the minimal variant faster
- when switching control bar variations, it is now also taken into account whether the chat is open.