### PR TITLE
fix carousel comp

### DIFF
--- a/.changeset/poor-geckos-exercise.md
+++ b/.changeset/poor-geckos-exercise.md
@@ -1,0 +1,7 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+"@livekit/components-styles": patch
+---
+
+Fix the carousel component for iOS and fix a possible unstable UI condition.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -43,3 +43,35 @@ export function isParticipantSourcePinned(
       pinnedTrack.source === source && pinnedParticipant.identity === participant.identity,
   );
 }
+
+/**
+ * Calculates the scrollbar width by creating two HTML elements
+ * and messaging the difference.
+ * @internal
+ */
+export function getScrollBarWidth() {
+  const inner = document.createElement('p');
+  inner.style.width = '100%';
+  inner.style.height = '200px';
+
+  const outer = document.createElement('div');
+  outer.style.position = 'absolute';
+  outer.style.top = '0px';
+  outer.style.left = '0px';
+  outer.style.visibility = 'hidden';
+  outer.style.width = '200px';
+  outer.style.height = '150px';
+  outer.style.overflow = 'hidden';
+  outer.appendChild(inner);
+
+  document.body.appendChild(outer);
+  const w1 = inner.offsetWidth;
+  outer.style.overflow = 'scroll';
+  let w2 = inner.offsetWidth;
+  if (w1 === w2) {
+    w2 = outer.clientWidth;
+  }
+  document.body.removeChild(outer);
+  const scrollBarWidth = w1 - w2;
+  return scrollBarWidth;
+}

--- a/packages/react/src/components/layout/CarouselView.tsx
+++ b/packages/react/src/components/layout/CarouselView.tsx
@@ -36,11 +36,13 @@ export function CarouselView({ tracks, orientation, ...props }: CarouselViewProp
       : Math.max(Math.floor(width / tileWidth), MIN_VISIBLE_TILES);
 
   // To avoid an unstable UI state, on overflow, we need to consider the scrollbar wide.
-  const scrollBarWidth = tracks.length > maxVisibleTiles ? getScrollBarWidth() : 0;
-  maxVisibleTiles =
-    carouselOrientation === 'vertical'
-      ? Math.max(Math.floor(height / (tileHeight - scrollBarWidth)), MIN_VISIBLE_TILES)
-      : Math.max(Math.floor(width / (tileWidth - scrollBarWidth)), MIN_VISIBLE_TILES);
+  if (tracks.length > maxVisibleTiles) {
+    const scrollBarWidth = getScrollBarWidth();
+    maxVisibleTiles =
+      carouselOrientation === 'vertical'
+        ? Math.max(Math.floor(height / (tileHeight - scrollBarWidth)), MIN_VISIBLE_TILES)
+        : Math.max(Math.floor(width / (tileWidth - scrollBarWidth)), MIN_VISIBLE_TILES);
+  }
 
   const sortedTiles = useVisualStableUpdate(tracks, maxVisibleTiles);
 

--- a/packages/react/src/components/layout/CarouselView.tsx
+++ b/packages/react/src/components/layout/CarouselView.tsx
@@ -1,4 +1,5 @@
-import { TrackReferenceOrPlaceholder, getScrollBarWidth } from '@livekit/components-core';
+import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
+import { getScrollBarWidth } from '@livekit/components-core';
 import * as React from 'react';
 import { useSize } from '../../hooks/internal';
 import { useVisualStableUpdate } from '../../hooks';

--- a/packages/react/src/components/layout/CarouselView.tsx
+++ b/packages/react/src/components/layout/CarouselView.tsx
@@ -1,4 +1,4 @@
-import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
+import { TrackReferenceOrPlaceholder, getScrollBarWidth } from '@livekit/components-core';
 import * as React from 'react';
 import { useSize } from '../../hooks/internal';
 import { useVisualStableUpdate } from '../../hooks';
@@ -30,10 +30,17 @@ export function CarouselView({ tracks, orientation, ...props }: CarouselViewProp
   const tileHeight = Math.max(width * ASPECT_RATIO_INVERT, MIN_HEIGHT);
   const tileWidth = Math.max(height * ASPECT_RATIO, MIN_WIDTH);
 
-  const maxVisibleTiles =
+  let maxVisibleTiles =
     carouselOrientation === 'vertical'
       ? Math.max(Math.floor(height / tileHeight), MIN_VISIBLE_TILES)
       : Math.max(Math.floor(width / tileWidth), MIN_VISIBLE_TILES);
+
+  // To avoid an unstable UI state, on overflow, we need to consider the scrollbar wide.
+  const scrollBarWidth = tracks.length > maxVisibleTiles ? getScrollBarWidth() : 0;
+  maxVisibleTiles =
+    carouselOrientation === 'vertical'
+      ? Math.max(Math.floor(height / (tileHeight - scrollBarWidth)), MIN_VISIBLE_TILES)
+      : Math.max(Math.floor(width / (tileWidth - scrollBarWidth)), MIN_VISIBLE_TILES);
 
   const sortedTiles = useVisualStableUpdate(tracks, maxVisibleTiles);
 

--- a/packages/styles/scss/components/layout/_carousel-view.scss
+++ b/packages/styles/scss/components/layout/_carousel-view.scss
@@ -24,15 +24,10 @@
 
   &[data-orientation='horizontal'] {
     scroll-snap-type: x mandatory;
-    writing-mode: vertical-rl; // trick css to think this is vertical text in order to apply the scrollbar gutter horizontally
-    flex-direction: column; // this is needed because of the vertical hack above
-    scrollbar-gutter: stable;
     overflow-y: hidden;
     overflow-x: auto;
 
     > * {
-      writing-mode: horizontal-tb; // reset text orientation hack
-
       --width-minus-gaps: calc(100% - var(--grid-gap) * (var(--max-visible-tiles) - 1));
       width: calc(var(--width-minus-gaps) / var(--max-visible-tiles));
     }


### PR DESCRIPTION
- undo a css hack to prevent unstable UI states in CarouselView. Unfortunately it did not work on iOS
- handle the unstable UI state by taking into account the width of the scrollbar when CarouselView overflows.

- [x] CarouselView does not update to show talking participant