### PR TITLE
fix style participant audio tile

### DIFF
--- a/packages/react/src/components/participant/ParticipantAudioTile.tsx
+++ b/packages/react/src/components/participant/ParticipantAudioTile.tsx
@@ -56,9 +56,7 @@ export const ParticipantAudioTile = ({
                 <TrackMutedIndicator source={Track.Source.Microphone}></TrackMutedIndicator>
                 <ParticipantName />
               </div>
-              <div className="lk-participant-metadata-item">
-                <ConnectionQualityIndicator />
-              </div>
+              <ConnectionQualityIndicator className="lk-participant-metadata-item" />
             </div>
           </>
         )}


### PR DESCRIPTION
The black background of the connection indicator was always visible.

before: 
<img width="433" alt="Screenshot 2023-04-11 at 12 13 25" src="https://user-images.githubusercontent.com/11357413/231130752-335bacad-5298-4c83-8f1b-0037c65b4969.png">

after:
<img width="422" alt="Screenshot 2023-04-11 at 12 13 40" src="https://user-images.githubusercontent.com/11357413/231130822-0e2c9a80-b8f8-49d9-9768-172469f88b1d.png">
