### PR TITLE
Remove filter from ParticipantLoop 

### DIFF
--- a/.changeset/four-needles-retire.md
+++ b/.changeset/four-needles-retire.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-react": patch
+"@livekit/component-example-next": patch
+---
+
+Remove filter from `ParticipantLoop` and add option to pass room to `useParticipants`, `useLocalParticipant` and `useRemoteParticipants`.

--- a/examples/nextjs/pages/clubhouse.tsx
+++ b/examples/nextjs/pages/clubhouse.tsx
@@ -8,6 +8,7 @@ import {
   useIsMuted,
   useIsSpeaking,
   useParticipantContext,
+  useParticipants,
   useToken,
 } from '@livekit/components-react';
 import styles from '../styles/Clubhouse.module.scss';
@@ -72,10 +73,11 @@ const Clubhouse = () => {
 };
 
 const Stage = () => {
+  const participants = useParticipants();
   return (
     <div className="">
       <div className={styles.stageGrid}>
-        <ParticipantLoop>
+        <ParticipantLoop participants={participants}>
           <CustomParticipantTile></CustomParticipantTile>
         </ParticipantLoop>
       </div>

--- a/packages/react/src/components/ParticipantLoop.tsx
+++ b/packages/react/src/components/ParticipantLoop.tsx
@@ -1,68 +1,39 @@
-import type { ParticipantFilter } from '@livekit/components-core';
-import type { RoomEvent } from 'livekit-client';
+import type { Participant } from 'livekit-client';
 import { Track } from 'livekit-client';
 import * as React from 'react';
 import { ParticipantContext } from '../context';
-import { useParticipants } from '../hooks';
 import { ParticipantTile } from '../prefabs';
 import { cloneSingleChild } from '../utils';
 
 type ParticipantLoopProps = {
-  filter?: ParticipantFilter;
-  /**
-   * If your filter function is dependent on some external state, and you want it to be re-filtered
-   * whenever that external state changes, you will need to provide a dependency array with all of
-   * the external dependencies, just as you would on a React useEffect hook.
-   */
-  filterDependencies?: Array<unknown>;
-  /**
-   * To optimize performance, you can use the updateOnlyOn property to decide on
-   * what RoomEvents the hook updates. By default it updates on all relevant RoomEvents
-   * to keep the returned participants array up to date.
-   * The minimal set of non-overwriteable RoomEvents is: [RoomEvent.ParticipantConnected, RoomEvent.ParticipantDisconnected, RoomEvent.ConnectionStateChanged]
-   */
-  updateOnlyOn?: RoomEvent[];
+  /** The participants to loop over. If not provided, the participants from the current room context are used. */
+  participants: Participant[];
 };
 
 /**
- * The ParticipantLoop component loops over all or a filtered subset of participants to create a visual
+ * The ParticipantLoop component loops over an array of participants to create a visual
  * representation and context for every participant. This component takes zero or more children.
  * By providing your own template as a child you have full control over the look and feel of your
  * participant representations.
- * You could use this for example to create a list of participants.
  *
  * @remarks
- * If you are looking for a way to have tiles for each participant that work for all video tracks at the same time out of the box
- * have a look at the `TileLoop`.
+ * If you want to loop over individual tracks instead of participants, you can use the `TrackLoop` component.
  *
  * @example
  * ```tsx
- * {...}
- *   <ParticipantLoop>
- *     <ParticipantName />
- *   <ParticipantLoop />
- * {...}
+ * const participants = useParticipants();
+ * <ParticipantLoop participants={participants}>
+ *   <ParticipantName />
+ * <ParticipantLoop />
  * ```
- *
- * @see `ParticipantTile` component
  */
 export const ParticipantLoop = ({
-  filter,
-  filterDependencies,
-  updateOnlyOn = [],
+  participants,
   ...props
 }: React.PropsWithChildren<ParticipantLoopProps>) => {
-  const participants = useParticipants({
-    updateOnlyOn: filter && updateOnlyOn.length === 0 ? undefined : updateOnlyOn,
-  });
-  const filterDependenciesArray = filterDependencies ?? [];
-  const filteredParticipants = React.useMemo(() => {
-    return filter ? participants.filter(filter) : participants;
-  }, [participants, filter, ...filterDependenciesArray]);
-
   return (
     <>
-      {filteredParticipants.map((participant) => (
+      {participants.map((participant) => (
         <ParticipantContext.Provider value={participant} key={participant.identity}>
           {props.children ? (
             cloneSingleChild(props.children)

--- a/packages/react/src/hooks/useLocalParticipant.ts
+++ b/packages/react/src/hooks/useLocalParticipant.ts
@@ -1,14 +1,21 @@
 import type { ParticipantMedia } from '@livekit/components-core';
 import { observeParticipantMedia } from '@livekit/components-core';
-import type { TrackPublication, LocalParticipant } from 'livekit-client';
+import type { TrackPublication, LocalParticipant, Room } from 'livekit-client';
 import * as React from 'react';
-import { useRoomContext } from '../context';
+import { useEnsureRoom } from '../context';
+
+export interface UseLocalParticipantOptions {
+  /**
+   * The room to use. If not provided, the hook will use the room from the context.
+   */
+  room?: Room;
+}
 
 /**
  * The useLocalParticipant hook the state of the local participant.
  */
-export const useLocalParticipant = () => {
-  const room = useRoomContext();
+export const useLocalParticipant = (options: UseLocalParticipantOptions = {}) => {
+  const room = useEnsureRoom(options.room);
   const [localParticipant, setLocalParticipant] = React.useState(room.localParticipant);
   const [isMicrophoneEnabled, setIsMicrophoneEnabled] = React.useState(
     localParticipant.isMicrophoneEnabled,

--- a/packages/react/src/hooks/useParticipants.ts
+++ b/packages/react/src/hooks/useParticipants.ts
@@ -1,4 +1,4 @@
-import type { RoomEvent } from 'livekit-client';
+import type { Room, RoomEvent } from 'livekit-client';
 import { useLocalParticipant } from './useLocalParticipant';
 import { useRemoteParticipants } from './useRemoteParticipants';
 
@@ -9,6 +9,10 @@ export interface UseParticipantsOptions {
    * The minimal set of non-overwriteable `RoomEvents` is: `[RoomEvent.ParticipantConnected, RoomEvent.ParticipantDisconnected, RoomEvent.ConnectionStateChanged]`
    */
   updateOnlyOn?: RoomEvent[];
+  /**
+   * The room to use. If not provided, the hook will use the room from the context.
+   */
+  room?: Room;
 }
 
 /**
@@ -16,7 +20,7 @@ export interface UseParticipantsOptions {
  */
 export const useParticipants = (options: UseParticipantsOptions = {}) => {
   const remoteParticipants = useRemoteParticipants(options);
-  const { localParticipant } = useLocalParticipant();
+  const { localParticipant } = useLocalParticipant(options);
 
   return [localParticipant, ...remoteParticipants];
 };

--- a/packages/react/src/hooks/useRemoteParticipants.ts
+++ b/packages/react/src/hooks/useRemoteParticipants.ts
@@ -1,17 +1,26 @@
 import { connectedParticipantsObserver } from '@livekit/components-core';
-import type { RoomEvent, RemoteParticipant } from 'livekit-client';
+import type { RoomEvent, RemoteParticipant, Room } from 'livekit-client';
 import * as React from 'react';
-import { useRoomContext } from '../context';
+import { useEnsureRoom } from '../context';
 
 export interface UseRemoteParticipantsOptions {
+  /**
+   * To optimize performance, you can use the `updateOnlyOn` property to decide on what RoomEvents the hook updates.
+   * By default it updates on all relevant RoomEvents to keep the returned participants array up to date.
+   * The minimal set of non-overwriteable `RoomEvents` is: `[RoomEvent.ParticipantConnected, RoomEvent.ParticipantDisconnected, RoomEvent.ConnectionStateChanged]`
+   */
   updateOnlyOn?: RoomEvent[];
+  /**
+   * The room to use. If not provided, the hook will use the room from the context.
+   */
+  room?: Room;
 }
 
 /**
  * The useRemoteParticipants
  */
 export const useRemoteParticipants = (options: UseRemoteParticipantsOptions = {}) => {
-  const room = useRoomContext();
+  const room = useEnsureRoom(options.room);
   const [participants, setParticipants] = React.useState<RemoteParticipant[]>([]);
 
   React.useEffect(() => {

--- a/packages/react/src/prefabs/AudioConference.tsx
+++ b/packages/react/src/prefabs/AudioConference.tsx
@@ -6,6 +6,7 @@ import { LayoutContextProvider } from '../components/layout/LayoutContextProvide
 import type { WidgetState } from '@livekit/components-core';
 import { Chat } from './Chat';
 import { ParticipantLoop } from '../components';
+import { useParticipants } from '../hooks';
 
 export type AudioConferenceProps = React.HTMLAttributes<HTMLDivElement>;
 
@@ -26,12 +27,13 @@ export type AudioConferenceProps = React.HTMLAttributes<HTMLDivElement>;
  */
 export function AudioConference({ ...props }: AudioConferenceProps) {
   const [widgetState, setWidgetState] = React.useState<WidgetState>({ showChat: false });
+  const participants = useParticipants();
 
   return (
     <LayoutContextProvider onWidgetChange={setWidgetState}>
       <div className="lk-audio-conference" {...props}>
         <div className="lk-audio-conference-stage">
-          <ParticipantLoop>
+          <ParticipantLoop participants={participants}>
             <ParticipantAudioTile />
           </ParticipantLoop>
         </div>


### PR DESCRIPTION
This PR changes:
- update participant hooks to accept a room
- remove filter from ParticipantLoop
- updates examples that use the ParticipantLoop comp