### PR TITLE
show toggle btn connection quality on focus

### DIFF
--- a/packages/styles/scss/components/participant/_participant-tile.scss
+++ b/packages/styles/scss/components/participant/_participant-tile.scss
@@ -31,7 +31,8 @@
     transition-delay: 0.2s;
   }
 
-  &:hover .focus-toggle-button {
+  &:hover .focus-toggle-button,
+  &:focus .focus-toggle-button {
     opacity: 1;
     transition-delay: 0;
   }
@@ -47,7 +48,8 @@
     }
   }
 
-  &:hover .connection-quality {
+  &:hover .connection-quality,
+  &:focus .connection-quality {
     opacity: 1;
     transition-delay: 0;
   }


### PR DESCRIPTION
This PR is a simple fix to show the focus toggle btn and connection quality indicator on mobile. Tapping on the tile will set it in focus and this will display the elements that are normally only visible on hover. 
I don't know if there are any downsides we need to consider?