### PR TITLE
Shrink bundle size for LiveKitRoom

### DIFF
--- a/packages/core/.size-limit.js
+++ b/packages/core/.size-limit.js
@@ -1,8 +1,8 @@
 module.exports = [
   {
     path: 'dist/index.mjs',
-    import: '{ setupLiveKitRoom }',
-    ignore: ['global-tld-list', 'email-regex'],
+    import: '{ roomEventSelector }',
+    ignore: [],
     limit: '13 kB',
   },
 ];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,14 +10,9 @@
   },
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
@@ -41,7 +36,6 @@
     "@floating-ui/dom": "^1.1.0",
     "email-regex": "^5.0.0",
     "global-tld-list": "^0.0.1061",
-    "ip-regex": "^5.0.0",
     "loglevel": "^1.8.1",
     "rxjs": "^7.8.0"
   },

--- a/packages/core/src/helper/urlRegex.ts
+++ b/packages/core/src/helper/urlRegex.ts
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import ipRegex from 'ip-regex';
 import { TLDs } from 'global-tld-list';
 interface RegExOptions {
   /**
@@ -44,7 +43,10 @@ export const createUrlRegExp = (options: RegExOptions) => {
 
   const protocol = `(?:(?:[a-z]+:)?//)${options.strict ? '' : '?'}`;
   const auth = '(?:\\S+(?::\\S*)?@)?';
-  const ip = ipRegex.v4().source;
+  const ip = new RegExp(
+    '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}',
+    'g',
+  ).source;
   const host = '(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)';
   const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
   const tld = `(?:\\.${

--- a/packages/react/.size-limit.js
+++ b/packages/react/.size-limit.js
@@ -4,7 +4,7 @@ module.exports = [
     path: 'dist/index.mjs',
     import: '{ LiveKitRoom }',
     limit: '10 kB',
-    ignore: ['livekit-client', 'react', 'react-dom'],
+    ignore: ['livekit-client', 'react', 'react-dom', 'loglevel'],
   },
   {
     name: 'Room with defaults',

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -1,4 +1,4 @@
-import { log, roomEventSelector, setupLiveKitRoom } from '@livekit/components-core';
+import { log, setupLiveKitRoom } from '@livekit/components-core';
 import type {
   AudioCaptureOptions,
   RoomConnectOptions,
@@ -187,10 +187,7 @@ export function useLiveKitRoom(props: LiveKitRoomProps) {
 
   React.useEffect(() => {
     if (!room) return;
-    const connectionStateChangeListener = roomEventSelector(
-      room,
-      RoomEvent.ConnectionStateChanged,
-    ).subscribe(([state]) => {
+    const connectionStateChangeListener = (state: ConnectionState) => {
       switch (state) {
         case ConnectionState.Disconnected:
           if (onDisconnected) onDisconnected();
@@ -202,8 +199,11 @@ export function useLiveKitRoom(props: LiveKitRoomProps) {
         default:
           break;
       }
-    });
-    return () => connectionStateChangeListener.unsubscribe();
+    };
+    room.on(RoomEvent.ConnectionStateChanged, connectionStateChangeListener);
+    return () => {
+      room.off(RoomEvent.ConnectionStateChanged, connectionStateChangeListener);
+    };
   }, [token, onConnected, onDisconnected, room]);
 
   React.useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6506,11 +6506,6 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-ip-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-5.0.0.tgz#cd313b2ae9c80c07bd3851e12bf4fa4dc5480632"
-  integrity sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==
-
 ip@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"


### PR DESCRIPTION
If users decide to _only_ import `LiveKitRoom` we want to try to use as little resources as possible. 
Some of our dependencies were either unnecessary or caused the bundle to bloat even when not being imported (failed tree shaking). This PR addresses the lowest hanging fruits in that regard so that importing `LiveKitRoom` by itself only takes ~1.9kB.