### PR TITLE
Default username displayed in input box

### DIFF
--- a/.changeset/six-rice-perform.md
+++ b/.changeset/six-rice-perform.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Display default username in PreJoin component

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -321,7 +321,7 @@ export const PreJoin = ({
           id="username"
           name="username"
           type="text"
-          value={username}
+          defaultValue={username}
           placeholder={userLabel}
           onChange={(inputEl) => setUsername(inputEl.target.value)}
           autoComplete="off"

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -321,6 +321,7 @@ export const PreJoin = ({
           id="username"
           name="username"
           type="text"
+          value={username}
           placeholder={userLabel}
           onChange={(inputEl) => setUsername(inputEl.target.value)}
           autoComplete="off"


### PR DESCRIPTION
### Improvement

Manually added username in PreJoin Component using props not shown in Input Box. 
Fixed that issue.