### PR TITLE
add useAudioPlayback hook and expose existing hooks

### DIFF
--- a/.changeset/fluffy-rivers-explode.md
+++ b/.changeset/fluffy-rivers-explode.md
@@ -2,4 +2,4 @@
 "@livekit/components-react": patch
 ---
 
-Add `usePreviewDevice` and `useStartAudio` hooks to public API.
+Add `usePreviewDevice`, `useStartAudio` and newly created `useAudioPlayback` hooks to public API.

--- a/.changeset/fluffy-rivers-explode.md
+++ b/.changeset/fluffy-rivers-explode.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Add `usePreviewDevice` and `useStartAudio` hooks to public API.

--- a/.changeset/metal-toes-run.md
+++ b/.changeset/metal-toes-run.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-core": patch
+---
+
+Add roomAudioPlaybackAllowedObservable

--- a/packages/core/src/components/startAudio.ts
+++ b/packages/core/src/components/startAudio.ts
@@ -5,7 +5,11 @@ import log from '../logger';
 import { observeRoomEvents } from '../observables/room';
 import { prefixClass } from '../styles-interface';
 
-function roomAudioPlaybackAllowedObservable(room: Room) {
+/**
+ * Returns whether or not audio playback is allowed in the current context.
+ * @internal
+ */
+export function roomAudioPlaybackAllowedObservable(room: Room) {
   const observable = observeRoomEvents(room, RoomEvent.AudioPlaybackStatusChanged).pipe(
     map((room) => {
       return { canPlayAudio: room.canPlaybackAudio };

--- a/packages/core/src/components/startAudio.ts
+++ b/packages/core/src/components/startAudio.ts
@@ -1,22 +1,7 @@
 import type { Room } from 'livekit-client';
-import { RoomEvent } from 'livekit-client';
-import { map } from 'rxjs';
 import log from '../logger';
-import { observeRoomEvents } from '../observables/room';
+import { roomAudioPlaybackAllowedObservable } from '../observables/room';
 import { prefixClass } from '../styles-interface';
-
-/**
- * Returns whether or not audio playback is allowed in the current context.
- * @internal
- */
-export function roomAudioPlaybackAllowedObservable(room: Room) {
-  const observable = observeRoomEvents(room, RoomEvent.AudioPlaybackStatusChanged).pipe(
-    map((room) => {
-      return { canPlayAudio: room.canPlaybackAudio };
-    }),
-  );
-  return observable;
-}
 
 export function setupStartAudio() {
   const handleStartAudioPlayback = async (room: Room) => {

--- a/packages/core/src/observables/room.ts
+++ b/packages/core/src/observables/room.ts
@@ -206,3 +206,12 @@ export function createMediaDeviceObserver(kind?: MediaDeviceKind, requestPermiss
 export function createDataObserver(room: Room) {
   return roomEventSelector(room, RoomEvent.DataReceived);
 }
+
+export function roomAudioPlaybackAllowedObservable(room: Room) {
+  const observable = observeRoomEvents(room, RoomEvent.AudioPlaybackStatusChanged).pipe(
+    map((room) => {
+      return { canPlayAudio: room.canPlaybackAudio };
+    }),
+  );
+  return observable;
+}

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -427,6 +427,12 @@ export type TrackToggleProps<T extends ToggleSource> = Omit<React_2.ButtonHTMLAt
     captureOptions?: CaptureOptionsBySource<T>;
 };
 
+// @alpha
+export function useAudioPlayback(room: Room): {
+    canPlayAudio: boolean;
+    startAudio: () => Promise<void>;
+};
+
 // @public (undocumented)
 export function useChat(): {
     send: ((message: string) => Promise<void>) | undefined;
@@ -705,10 +711,18 @@ export function useSortedParticipants(participants: Array<Participant>): Partici
 export const useSpeakingParticipants: () => Participant[];
 
 // @alpha
-export function useStartAudio(room: Room): {
+export function useStartAudio({ room, props }: UseStartAudioProps): {
+    mergedProps: React_2.HTMLAttributes<HTMLElement>;
     canPlayAudio: boolean;
-    startAudio: () => void;
 };
+
+// @alpha (undocumented)
+export interface UseStartAudioProps {
+    // (undocumented)
+    props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
+    // (undocumented)
+    room: Room;
+}
 
 // @alpha
 export function useSwipe(element: React_2.RefObject<HTMLElement>, options?: UseSwipeOptions): void;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -428,7 +428,7 @@ export type TrackToggleProps<T extends ToggleSource> = Omit<React_2.ButtonHTMLAt
 };
 
 // @alpha
-export function useAudioPlayback(room: Room): {
+export function useAudioPlayback(room?: Room): {
     canPlayAudio: boolean;
     startAudio: () => Promise<void>;
 };
@@ -721,7 +721,7 @@ export interface UseStartAudioProps {
     // (undocumented)
     props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
     // (undocumented)
-    room: Room;
+    room?: Room;
 }
 
 // @alpha

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -15,8 +15,10 @@ import { ConnectionState as ConnectionState_2 } from 'livekit-client';
 import { DataSendOptions } from '@livekit/components-core';
 import type { GridLayout as GridLayout_2 } from '@livekit/components-core/dist/helper/grid-layouts';
 import { HTMLAttributes } from 'react';
+import type { LocalAudioTrack } from 'livekit-client';
 import { LocalParticipant } from 'livekit-client';
 import { LocalTrackPublication } from 'livekit-client';
+import type { LocalVideoTrack } from 'livekit-client';
 import { MediaDeviceFailure } from 'livekit-client';
 import { Participant } from 'livekit-client';
 import type { ParticipantClickEvent } from '@livekit/components-core';
@@ -647,6 +649,13 @@ export type UseParticipantTileProps<T extends HTMLElement> = TrackReferenceOrPla
 export function usePinnedTracks(layoutContext?: LayoutContextType): TrackReferenceOrPlaceholder[];
 
 // @public (undocumented)
+export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(enabled: boolean, deviceId: string, kind: 'videoinput' | 'audioinput'): {
+    selectedDevice: MediaDeviceInfo | undefined;
+    localTrack: T | undefined;
+    deviceError: Error | null;
+};
+
+// @public (undocumented)
 export const useRemoteParticipant: (identity: string, options?: UseRemoteParticipantOptions) => RemoteParticipant | undefined;
 
 // @public (undocumented)
@@ -694,6 +703,12 @@ export function useSortedParticipants(participants: Array<Participant>): Partici
 
 // @public
 export const useSpeakingParticipants: () => Participant[];
+
+// @alpha
+export function useStartAudio(room: Room): {
+    canPlayAudio: boolean;
+    startAudio: () => void;
+};
 
 // @alpha
 export function useSwipe(element: React_2.RefObject<HTMLElement>, options?: UseSwipeOptions): void;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.21.7",
-    "@microsoft/api-extractor": "^7.34.4",
+    "@microsoft/api-extractor": "^7.35.0",
     "@size-limit/file": "^8.2.4",
     "@size-limit/webpack": "^8.2.4",
     "@svgr/cli": "^7.0.0",

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -10,7 +10,7 @@ interface UseStartAudioProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
-function useStartAudio({ room, props }: UseStartAudioProps) {
+export function useStartAudio({ room, props }: UseStartAudioProps) {
   const { className, roomAudioPlaybackAllowedObservable, handleStartAudioPlayback } = React.useMemo(
     () => setupStartAudio(),
     [],

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -1,13 +1,13 @@
 import { setupStartAudio } from '@livekit/components-core';
 import type { Room } from 'livekit-client';
 import * as React from 'react';
-import { useRoomContext } from '../../context';
+import { useEnsureRoom, useRoomContext } from '../../context';
 import { useObservableState } from '../../hooks/internal/useObservableState';
 import { mergeProps } from '../../utils';
 
 /** @alpha */
 export interface UseStartAudioProps {
-  room: Room;
+  room?: Room;
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
@@ -21,13 +21,14 @@ export interface UseStartAudioProps {
  * @alpha
  */
 export function useStartAudio({ room, props }: UseStartAudioProps) {
+  const roomEnsured = useEnsureRoom(room);
   const { className, roomAudioPlaybackAllowedObservable, handleStartAudioPlayback } = React.useMemo(
     () => setupStartAudio(),
     [],
   );
   const observable = React.useMemo(
-    () => roomAudioPlaybackAllowedObservable(room),
-    [room, roomAudioPlaybackAllowedObservable],
+    () => roomAudioPlaybackAllowedObservable(roomEnsured),
+    [roomEnsured, roomAudioPlaybackAllowedObservable],
   );
   const { canPlayAudio } = useObservableState(observable, { canPlayAudio: false });
 
@@ -36,11 +37,11 @@ export function useStartAudio({ room, props }: UseStartAudioProps) {
       mergeProps(props, {
         className,
         onClick: () => {
-          handleStartAudioPlayback(room);
+          handleStartAudioPlayback(roomEnsured);
         },
         style: { display: canPlayAudio ? 'none' : 'block' },
       }),
-    [props, className, canPlayAudio, handleStartAudioPlayback, room],
+    [props, className, canPlayAudio, handleStartAudioPlayback, roomEnsured],
   );
 
   return { mergedProps, canPlayAudio };

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -6,7 +6,7 @@ import { useObservableState } from '../../hooks/internal/useObservableState';
 import { mergeProps } from '../../utils';
 
 /**
- * In many browser to start audio playback, the user must perform a user-initiated event such as clicking a button.
+ * In many browsers to start audio playback, the user must perform a user-initiated event such as clicking a button.
  * The `useStatAudio` hook returns an object with a boolean `canPlayAudio` flag
  * that indicates whether audio playback is allowed in the current context,
  * as well as a `startAudio` function that can be called in a button `onClick` callback to start audio playback in the current context.

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useAudioPlayback } from './useAudioPlayback';
 export { useDataChannel } from './useDataChannel';
 export { useGridLayout } from './useGridLayout';
 export { useIsMuted, UseIsMutedOptions } from './useIsMuted';

--- a/packages/react/src/hooks/useAudioPlayback.ts
+++ b/packages/react/src/hooks/useAudioPlayback.ts
@@ -2,6 +2,7 @@ import type { Room } from 'livekit-client';
 import * as React from 'react';
 import { useObservableState } from './internal';
 import { roomAudioPlaybackAllowedObservable } from '@livekit/components-core';
+import { useEnsureRoom } from '../context';
 
 /**
  * In many browsers to start audio playback, the user must perform a user-initiated event such as clicking a button.
@@ -12,15 +13,19 @@ import { roomAudioPlaybackAllowedObservable } from '@livekit/components-core';
  * @see Autoplay policy on MDN web docs for more info: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
  * @alpha
  */
-export function useAudioPlayback(room: Room): {
+export function useAudioPlayback(room?: Room): {
   canPlayAudio: boolean;
   startAudio: () => Promise<void>;
 } {
+  const roomEnsured = useEnsureRoom(room);
   const startAudio = React.useCallback(async () => {
-    await room.startAudio();
-  }, [room]);
+    await roomEnsured.startAudio();
+  }, [roomEnsured]);
 
-  const observable = React.useMemo(() => roomAudioPlaybackAllowedObservable(room), [room]);
+  const observable = React.useMemo(
+    () => roomAudioPlaybackAllowedObservable(roomEnsured),
+    [roomEnsured],
+  );
   const { canPlayAudio } = useObservableState(observable, { canPlayAudio: false });
 
   return { canPlayAudio, startAudio };

--- a/packages/react/src/hooks/useAudioPlayback.ts
+++ b/packages/react/src/hooks/useAudioPlayback.ts
@@ -1,0 +1,27 @@
+import type { Room } from 'livekit-client';
+import * as React from 'react';
+import { useObservableState } from './internal';
+import { roomAudioPlaybackAllowedObservable } from '@livekit/components-core';
+
+/**
+ * In many browsers to start audio playback, the user must perform a user-initiated event such as clicking a button.
+ * The `useAudioPlayback` hook returns an object with a boolean `canPlayAudio` flag
+ * that indicates whether audio playback is allowed in the current context,
+ * as well as a `startAudio` function that can be called in a button `onClick` callback to start audio playback in the current context.
+ *
+ * @see Autoplay policy on MDN web docs for more info: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
+ * @alpha
+ */
+export function useAudioPlayback(room: Room): {
+  canPlayAudio: boolean;
+  startAudio: () => Promise<void>;
+} {
+  const startAudio = React.useCallback(async () => {
+    await room.startAudio();
+  }, [room]);
+
+  const observable = React.useMemo(() => roomAudioPlaybackAllowedObservable(room), [room]);
+  const { canPlayAudio } = useObservableState(observable, { canPlayAudio: false });
+
+  return { canPlayAudio, startAudio };
+}

--- a/packages/react/src/hooks/useAudioPlayback.ts
+++ b/packages/react/src/hooks/useAudioPlayback.ts
@@ -5,9 +5,9 @@ import { roomAudioPlaybackAllowedObservable } from '@livekit/components-core';
 
 /**
  * In many browsers to start audio playback, the user must perform a user-initiated event such as clicking a button.
- * The `useAudioPlayback` hook returns an object with a boolean `canPlayAudio` flag
- * that indicates whether audio playback is allowed in the current context,
- * as well as a `startAudio` function that can be called in a button `onClick` callback to start audio playback in the current context.
+ * The `useAudioPlayback` hook returns an object with a boolean `canPlayAudio` flag that indicates whether audio
+ * playback is allowed in the current context, as well as a `startAudio` function that can be called in a button
+ * `onClick` callback to start audio playback in the current context.
  *
  * @see Autoplay policy on MDN web docs for more info: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
  * @alpha

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -44,7 +44,7 @@ export type PreJoinProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'onSubmit'
 };
 
 /** @public */
-function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
+export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
   enabled: boolean,
   deviceId: string,
   kind: 'videoinput' | 'audioinput',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,23 +1659,32 @@
     "@microsoft/tsdoc-config" "~0.16.1"
     "@rushstack/node-core-library" "3.58.0"
 
-"@microsoft/api-extractor@^7.34.4":
-  version "7.34.8"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.34.8.tgz#c39a15d5edde13d6613d192eaadec160d1e362ca"
-  integrity sha512-2Eh1PlZ8wULtH3kyAWcj62gFtjGKRXrEplsCO54vMLjiav3qet454VpSBXwKkXBenBylZRMk3SMBcpcuJ8RnKQ==
+"@microsoft/api-extractor-model@7.27.0":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.27.0.tgz#d648629a1fde6933663bdb613f0ee39c425aae7a"
+  integrity sha512-wHqIMiwSARmiuVLn/zmVpiRncq6hvBfC5GF+sjrN3w4FqVkqFYk7DetvfRNdy/3URdqqmYGrhJlcU9HpLnHOPg==
   dependencies:
-    "@microsoft/api-extractor-model" "7.26.8"
     "@microsoft/tsdoc" "0.14.2"
     "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.58.0"
-    "@rushstack/rig-package" "0.3.18"
-    "@rushstack/ts-command-line" "4.13.2"
+    "@rushstack/node-core-library" "3.59.1"
+
+"@microsoft/api-extractor@^7.35.0":
+  version "7.35.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.35.0.tgz#0452bc6e4765d2dcc95b6f21489216c521595bfd"
+  integrity sha512-yBGfPJeEtzk8sg2hE2/vOPRvnJBvstbWNGeyGV1jIEUSgytzQ0QPgPEkOsP2n7nBfnyRXmZaBa2vJPGOzVWy+g==
+  dependencies:
+    "@microsoft/api-extractor-model" "7.27.0"
+    "@microsoft/tsdoc" "0.14.2"
+    "@microsoft/tsdoc-config" "~0.16.1"
+    "@rushstack/node-core-library" "3.59.1"
+    "@rushstack/rig-package" "0.3.19"
+    "@rushstack/ts-command-line" "4.13.3"
     colors "~1.2.1"
     lodash "~4.17.15"
     resolve "~1.22.1"
     semver "~7.3.0"
     source-map "~0.6.1"
-    typescript "~4.8.4"
+    typescript "~5.0.4"
 
 "@microsoft/tsdoc-config@0.16.2", "@microsoft/tsdoc-config@~0.16.1":
   version "0.16.2"
@@ -1907,10 +1916,23 @@
     semver "~7.3.0"
     z-schema "~5.0.2"
 
-"@rushstack/rig-package@0.3.18":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.3.18.tgz#2b59eb8ed482e8cd6ad8d396414bf3200efdd682"
-  integrity sha512-SGEwNTwNq9bI3pkdd01yCaH+gAsHqs0uxfGvtw9b0LJXH52qooWXnrFTRRLG1aL9pf+M2CARdrA9HLHJys3jiQ==
+"@rushstack/node-core-library@3.59.1":
+  version "3.59.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.59.1.tgz#6c051d1f861a6c2b07c637d2c48d75a526e9e80d"
+  integrity sha512-iy/xaEhXGpX+DY1ZzAtNA+QPw+9+TJh773Im+JxG4R1fu00/vWq470UOEj6upxlUxmp0JxhnmNRxzfptHrn/Uw==
+  dependencies:
+    colors "~1.2.1"
+    fs-extra "~7.0.1"
+    import-lazy "~4.0.0"
+    jju "~1.4.0"
+    resolve "~1.22.1"
+    semver "~7.3.0"
+    z-schema "~5.0.2"
+
+"@rushstack/rig-package@0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@rushstack/rig-package/-/rig-package-0.3.19.tgz#635ca524cbb73523af3a0a19b4a0821c61800fdf"
+  integrity sha512-2d0/Gn+qjOYneZbiHjn4SjyDwq9I0WagV37z0F1V71G+yONgH7wlt3K/UoNiDkhA8gTHYPRo2jz3CvttybwSag==
   dependencies:
     resolve "~1.22.1"
     strip-json-comments "~3.1.1"
@@ -1919,6 +1941,16 @@
   version "4.13.2"
   resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.13.2.tgz#2dfdcf418d58256671433b1da4a3b67e1814cc7a"
   integrity sha512-bCU8qoL9HyWiciltfzg7GqdfODUeda/JpI0602kbN5YH22rzTxyqYvv7aRLENCM7XCQ1VRs7nMkEqgJUOU8Sag==
+  dependencies:
+    "@types/argparse" "1.0.38"
+    argparse "~1.0.9"
+    colors "~1.2.1"
+    string-argv "~0.3.1"
+
+"@rushstack/ts-command-line@4.13.3":
+  version "4.13.3"
+  resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.13.3.tgz#39c1cd4b0a8d86a6552a7a0635671f164a22d904"
+  integrity sha512-6aQIv/o1EgsC/+SpgUyRmzg2QIAL6sudEzw3sWzJKwWuQTc5XRsyZpyldfE7WAmIqMXDao9QG35/NYORjHm5Zw==
   dependencies:
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
@@ -10351,15 +10383,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.0.0:
+typescript@^5.0.0, typescript@~5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
-
-typescript@~4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 ua-parser-js@^1.0.2:
   version "1.0.35"


### PR DESCRIPTION
Add `usePreviewDevice`, `useStartAudio` and newly created `useAudioPlayback` hooks to public API.