### PR TITLE
fix: export of LayoutContextType

### DIFF
--- a/.changeset/sour-suns-leave.md
+++ b/.changeset/sour-suns-leave.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Rexport `LayoutContextType` as type.

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -1,13 +1,13 @@
 export {} from './chat-context';
 export {
   LayoutContext,
-  LayoutContextType,
   useCreateLayoutContext,
   useEnsureCreateLayoutContext,
   useEnsureLayoutContext,
   useLayoutContext,
   useMaybeLayoutContext,
 } from './layout-context';
+export type { LayoutContextType } from './layout-context';
 export {
   ParticipantContext,
   useEnsureParticipant,


### PR DESCRIPTION
Rexport `LayoutContextType` explitly as type to work with tsconfig `isolatedModules`. 