### PR TITLE
Adding a resize listener for the useSize hook

### DIFF
--- a/packages/react/src/hooks/internal/useResizeObserver.ts
+++ b/packages/react/src/hooks/internal/useResizeObserver.ts
@@ -100,18 +100,19 @@ export type UseResizeObserverCallback = (
 
 export const useSize = (target: React.RefObject<HTMLDivElement>) => {
   const [size, setSize] = React.useState({ width: 0, height: 0 });
-  React.useLayoutEffect(() => {
+
+  const handleResize = () => {
     if (target.current) {
       const { width, height } = target.current.getBoundingClientRect();
       setSize({ width, height });
     }
-  }, [target.current]);
+  };
 
-  const resizeCallback = React.useCallback(
-    (entry: ResizeObserverEntry) => setSize(entry.contentRect),
-    [],
-  );
-  // Where the magic happens
-  useResizeObserver(target, resizeCallback);
+  React.useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [target]);
+
   return size;
 };


### PR DESCRIPTION
Hello everyone, in my app and your your app (https://meet.livekit.io) there was a bug in which the **--lk-max-visible-tiles variable** was constantly changing its value due to which there was such a defect in the **CarouselLayout** component (attached video).

As I understood it, this was due to the multiple creation of **ResizeObserver**.

I checked my solution and this bug doesn't happen with it anymore. Also, the useGridLayout component, which uses the **useSize** hook, normally calculates variables.

Can you please see my solution, or we can try to solve this problem together with ResizeObserver.

Video example:
https://www.awesomescreenshot.com/video/17758562?key=7761dd3662adb0bd3d78493c377678a0