### PR TITLE
add setLogLevel function

### DIFF
--- a/.changeset/chatty-jeans-call.md
+++ b/.changeset/chatty-jeans-call.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-core": patch
+---
+
+add `setLogLevel` function

--- a/examples/nextjs/pages/minimal.tsx
+++ b/examples/nextjs/pages/minimal.tsx
@@ -1,3 +1,4 @@
+import { setLogLevel } from '@livekit/components-core';
 import { LiveKitRoom, useToken, VideoConference } from '@livekit/components-react';
 import type { NextPage } from 'next';
 
@@ -5,6 +6,7 @@ const MinimalExample: NextPage = () => {
   const params = typeof window !== 'undefined' ? new URLSearchParams(location.search) : null;
   const roomName = params?.get('room') ?? 'test-room';
   const userIdentity = params?.get('user') ?? 'test-identity';
+  setLogLevel('info', { liveKitClientLogLevel: 'warn' });
 
   const token = useToken(process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT, roomName, {
     userInfo: {

--- a/packages/core/src/components/mediaDeviceSelect.ts
+++ b/packages/core/src/components/mediaDeviceSelect.ts
@@ -1,7 +1,7 @@
 import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
 import { Track } from 'livekit-client';
 import { BehaviorSubject, map, mergeWith } from 'rxjs';
-import log from '../logger';
+import { log } from '../logger';
 import { observeParticipantMedia } from '../observables/participant';
 import { prefixClass } from '../styles-interface';
 

--- a/packages/core/src/components/startAudio.ts
+++ b/packages/core/src/components/startAudio.ts
@@ -1,5 +1,5 @@
 import type { Room } from 'livekit-client';
-import log from '../logger';
+import { log } from '../logger';
 import { roomAudioPlaybackAllowedObservable } from '../observables/room';
 import { prefixClass } from '../styles-interface';
 

--- a/packages/core/src/helper/grid-layouts.ts
+++ b/packages/core/src/helper/grid-layouts.ts
@@ -1,4 +1,4 @@
-import log from '../logger';
+import { log } from '../logger';
 
 export type GridLayout = {
   name: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,5 +27,4 @@ export * from './observables/track';
 export * from './observables/dataChannel';
 export * from './observables/dom-event';
 
-import logger from './logger';
-export const log = logger;
+export { log, setLogLevel } from './logger';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -14,15 +14,7 @@ type SetLogLevelOptions = {
  * To set the `@livekit-client` log independently, use the `liveKitClientLogLevel` prop on the `options` object.
  * @public
  */
-export function setLogLevel(
-  level: LogLevel,
-  options: SetLogLevelOptions = { liveKitClientLogLevel: undefined },
-): void {
-  if (options.liveKitClientLogLevel) {
-    log.setLevel(level);
-    setClientSdkLogLevel(options.liveKitClientLogLevel);
-  } else {
-    log.setLevel(level);
-    setClientSdkLogLevel(level);
-  }
+export function setLogLevel(level: LogLevel, options: SetLogLevelOptions = {}): void {
+  log.setLevel(level);
+  setClientSdkLogLevel(options.liveKitClientLogLevel ?? level);
 }

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,7 +1,7 @@
 import { setLogLevel as setClientSdkLogLevel } from 'livekit-client';
 import loglevel from 'loglevel';
 
-const log = loglevel.getLogger('lk-components-js');
+export const log = loglevel.getLogger('lk-components-js');
 log.setDefaultLevel('WARN');
 
 type LogLevel = Parameters<typeof setClientSdkLogLevel>[0];
@@ -26,5 +26,3 @@ export function setLogLevel(
     setClientSdkLogLevel(level);
   }
 }
-
-export default log;

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,6 +1,30 @@
+import { setLogLevel as setClientSdkLogLevel } from 'livekit-client';
 import loglevel from 'loglevel';
 
 const log = loglevel.getLogger('lk-components-js');
 log.setDefaultLevel('WARN');
+
+type LogLevel = Parameters<typeof setClientSdkLogLevel>[0];
+type SetLogLevelOptions = {
+  liveKitClientLogLevel?: LogLevel;
+};
+
+/**
+ * Set the log level for both the `@livekit/components-react` package and the `@livekit-client` package.
+ * To set the `@livekit-client` log independently, use the `liveKitClientLogLevel` prop on the `options` object.
+ * @public
+ */
+export function setLogLevel(
+  level: LogLevel,
+  options: SetLogLevelOptions = { liveKitClientLogLevel: undefined },
+): void {
+  if (options.liveKitClientLogLevel) {
+    log.setLevel(level);
+    setClientSdkLogLevel(options.liveKitClientLogLevel);
+  } else {
+    log.setLevel(level);
+    setClientSdkLogLevel(level);
+  }
+}
 
 export default log;

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -9,7 +9,7 @@ import type {
 import { RoomEvent, TrackEvent } from 'livekit-client';
 import { map, Observable, startWith } from 'rxjs';
 import { allParticipantRoomEvents } from '../helper';
-import log from '../logger';
+import { log } from '../logger';
 import type { TrackReference } from '../track-reference';
 import { observeRoomEvents } from './room';
 

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -1,5 +1,5 @@
 import { differenceBy, chunk, zip } from '../helper/array-helper';
-import log from '../logger';
+import { log } from '../logger';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
 import { getTrackReferenceId } from '../track-reference';
 import { flatTrackReferenceArray } from '../track-reference/test-utils';


### PR DESCRIPTION
Add a setLogLevel function. By default this function sets the log level for both `@livekit/components-react` and the `@livekit-client` package. But there is an option to set `@livekit-client` independently.