### PR TITLE
add screen share feature detection

### DIFF
--- a/.changeset/sour-months-share.md
+++ b/.changeset/sour-months-share.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Add screen share feature detection to hide screen share button in control bar.

--- a/packages/core/src/helper/featureDetection.ts
+++ b/packages/core/src/helper/featureDetection.ts
@@ -1,0 +1,6 @@
+/**
+ * Returns `true` if the browser supports screen sharing.
+ */
+export function supportsScreenSharing(): boolean {
+  return navigator?.mediaDevices && !!navigator.mediaDevices.getDisplayMedia;
+}

--- a/packages/core/src/helper/featureDetection.ts
+++ b/packages/core/src/helper/featureDetection.ts
@@ -2,5 +2,9 @@
  * Returns `true` if the browser supports screen sharing.
  */
 export function supportsScreenSharing(): boolean {
-  return navigator?.mediaDevices && !!navigator.mediaDevices.getDisplayMedia;
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.mediaDevices &&
+    !!navigator.mediaDevices.getDisplayMedia
+  );
 }

--- a/packages/core/src/helper/index.ts
+++ b/packages/core/src/helper/index.ts
@@ -6,3 +6,4 @@ export * from './tokenizer';
 export * from './eventGroups';
 export { selectGridLayout, GRID_LAYOUTS } from './grid-layouts';
 export { setDifference } from './set-helper';
+export { supportsScreenSharing } from './featureDetection';

--- a/packages/react/src/prefabs/ControlBar.tsx
+++ b/packages/react/src/prefabs/ControlBar.tsx
@@ -6,10 +6,10 @@ import { TrackToggle } from '../components/controls/TrackToggle';
 import { StartAudio } from '../components/controls/StartAudio';
 import { ChatIcon, LeaveIcon } from '../assets/icons';
 import { ChatToggle } from '../components/controls/ChatToggle';
-import { isMobileBrowser } from '@livekit/components-core';
 import { useLocalParticipantPermissions } from '../hooks';
 import { useMediaQuery } from '../hooks/internal';
 import { useMaybeLayoutContext } from '../context';
+import { supportsScreenSharing } from '@livekit/components-core';
 
 /** @public */
 export type ControlBarControls = {
@@ -80,7 +80,7 @@ export function ControlBar({ variation, controls, ...props }: ControlBarProps) {
     [variation],
   );
 
-  const isMobile = React.useMemo(() => isMobileBrowser(), []);
+  const browserSupportsScreenSharing = React.useMemo(() => supportsScreenSharing(), []);
 
   const [isScreenShareEnabled, setIsScreenShareEnabled] = React.useState(false);
 
@@ -110,7 +110,7 @@ export function ControlBar({ variation, controls, ...props }: ControlBarProps) {
           </div>
         </div>
       )}
-      {visibleControls.screenShare && !isMobile && (
+      {visibleControls.screenShare && browserSupportsScreenSharing && (
         <TrackToggle
           source={Track.Source.ScreenShare}
           captureOptions={{ audio: true, selfBrowserSurface: 'include' }}

--- a/packages/react/src/prefabs/ControlBar.tsx
+++ b/packages/react/src/prefabs/ControlBar.tsx
@@ -80,7 +80,7 @@ export function ControlBar({ variation, controls, ...props }: ControlBarProps) {
     [variation],
   );
 
-  const browserSupportsScreenSharing = React.useMemo(() => supportsScreenSharing(), []);
+  const browserSupportsScreenSharing = supportsScreenSharing();
 
   const [isScreenShareEnabled, setIsScreenShareEnabled] = React.useState(false);
 


### PR DESCRIPTION
This PR replaces the condition wheater to show the screen sharing button in the control bar. The current detection was based on is-mobile-browser, which did not work for iPads. The new detection is based on feature-detection whether screen sharing is possible or not.

Thanks to Adam Conway for reporting this 👍 