### PR TITLE
underline links in chat message

### DIFF
--- a/.changeset/light-pots-bake.md
+++ b/.changeset/light-pots-bake.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-styles": patch
+---
+
+Underline links in chat message.

--- a/packages/styles/scss/prefabs/chat.scss
+++ b/packages/styles/scss/prefabs/chat.scss
@@ -60,6 +60,7 @@
 
   a {
     text-decoration: underline;
+    color: inherit;
   }
 }
 

--- a/packages/styles/scss/prefabs/chat.scss
+++ b/packages/styles/scss/prefabs/chat.scss
@@ -57,6 +57,10 @@
       background-color: var(--accent4);
     }
   }
+
+  a {
+    text-decoration: underline;
+  }
 }
 
 .chat-form {


### PR DESCRIPTION
Currently, links in chat messages are not distinguishable from regular text. This PR underlines links in chat messages.
Why underline and not change the text color, you may ask? Underlining is more or less an established convention on the web, and colors open up a whole new can of worms because you have to think about enough contrast with the background and other style and accessibility issues.
Underlining felt like the appropriate solution to the problem.
