### PR TITLE
Add facingMode detection

### DIFF
--- a/.changeset/hot-ways-push.md
+++ b/.changeset/hot-ways-push.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Added facingMode detection to minimize unwanted local participant video track mirroring.

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -25,6 +25,6 @@
     "eslint": "^8.21.0",
     "eslint-config-next": "^12.2.4",
     "source-map-loader": "^4.0.1",
-    "typescript": "^5.0.0"
+    "typescript": "5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "5.0.4"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",
@@ -40,6 +40,6 @@
     "glob": "^8.1.0",
     "prettier": "^2.8.3",
     "turbo": "^1.9.3",
-    "typescript": "^5.0.0"
+    "typescript": "5.0.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "eslint-config-lk-custom": "^0.1.1",
     "size-limit": "^8.2.4",
     "tsup": "^7.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "5.0.4",
     "vitest": "^0.32.0"
   },
   "engines": {

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -458,7 +458,7 @@ export function useClearPinButton(props: ClearPinButtonProps): {
 
 // @public (undocumented)
 export function useConnectionQualityIndicator(options?: ConnectionQualityIndicatorOptions): {
-    className: "lk-list" | "lk-button" | "lk-rotate" | "lk-audio-conference" | "lk-audio-conference-stage" | "lk-audio-container" | "lk-button-group" | "lk-button-group-container" | "lk-camera-off-note" | "lk-chat" | "lk-chat-entry" | "lk-chat-form" | "lk-chat-form-input" | "lk-chat-messages" | "lk-control-bar" | "lk-focus-layout-wrapper" | "lk-form-control" | "lk-grid-layout-wrapper" | "lk-join-button" | "lk-message-body" | "lk-meta-data" | "lk-participant-name" | "lk-prejoin" | "lk-timestamp" | "lk-username-container" | "lk-video-conference" | "lk-video-conference-inner" | "lk-video-container" | "lk-audio-visualizer" | "lk-button-group-menu" | "lk-button-menu" | "lk-carousel" | "lk-chat-toggle" | "lk-connection-quality" | "lk-device-menu" | "lk-device-menu-heading" | "lk-disconnect-button" | "lk-focus-layout" | "lk-focus-toggle-button" | "lk-focused-participant" | "lk-grid-layout" | "lk-media-device-select" | "lk-pagination-control" | "lk-pagination-count" | "lk-pagination-indicator" | "lk-participant-media-audio" | "lk-participant-media-video" | "lk-participant-metadata" | "lk-participant-metadata-item" | "lk-participant-placeholder" | "lk-participant-tile" | "lk-pip-track" | "lk-room-container" | "lk-spinner" | "lk-start-audio-button" | "lk-toast" | "lk-track-muted-indicator-camera" | "lk-track-muted-indicator-microphone";
+    className: any;
     quality: ConnectionQuality;
 };
 
@@ -495,6 +495,9 @@ export function useEnsureRoom(room?: Room): Room;
 
 // @public
 export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder): TrackReferenceOrPlaceholder;
+
+// @alpha
+export function useFacingMode(trackReference: TrackReferenceOrPlaceholder): 'user' | 'environment' | 'left' | 'right' | 'undefined';
 
 // @public
 export function useGridLayout(

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -458,7 +458,7 @@ export function useClearPinButton(props: ClearPinButtonProps): {
 
 // @public (undocumented)
 export function useConnectionQualityIndicator(options?: ConnectionQualityIndicatorOptions): {
-    className: any;
+    className: "lk-list" | "lk-button" | "lk-rotate" | "lk-audio-conference" | "lk-audio-conference-stage" | "lk-audio-container" | "lk-button-group" | "lk-button-group-container" | "lk-camera-off-note" | "lk-chat" | "lk-chat-entry" | "lk-chat-form" | "lk-chat-form-input" | "lk-chat-messages" | "lk-control-bar" | "lk-focus-layout-wrapper" | "lk-form-control" | "lk-grid-layout-wrapper" | "lk-join-button" | "lk-message-body" | "lk-meta-data" | "lk-participant-name" | "lk-prejoin" | "lk-timestamp" | "lk-username-container" | "lk-video-conference" | "lk-video-conference-inner" | "lk-video-container" | "lk-audio-visualizer" | "lk-button-group-menu" | "lk-button-menu" | "lk-carousel" | "lk-chat-toggle" | "lk-connection-quality" | "lk-device-menu" | "lk-device-menu-heading" | "lk-disconnect-button" | "lk-focus-layout" | "lk-focus-toggle-button" | "lk-focused-participant" | "lk-grid-layout" | "lk-media-device-select" | "lk-pagination-control" | "lk-pagination-count" | "lk-pagination-indicator" | "lk-participant-media-audio" | "lk-participant-media-video" | "lk-participant-metadata" | "lk-participant-metadata-item" | "lk-participant-placeholder" | "lk-participant-tile" | "lk-pip-track" | "lk-room-container" | "lk-spinner" | "lk-start-audio-button" | "lk-toast" | "lk-track-muted-indicator-camera" | "lk-track-muted-indicator-microphone";
     quality: ConnectionQuality;
 };
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,7 +72,7 @@
     "react-dom": "^18.2.0",
     "size-limit": "^8.2.4",
     "tsup": "^7.0.0",
-    "typescript": "^5.0.0",
+    "typescript": "5.0.4",
     "vite": "^4.1.4",
     "vitest": "^0.32.0"
   },

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -13,7 +13,7 @@ import {
   useMaybeLayoutContext,
   useMaybeTrackContext,
 } from '../../context';
-import { useIsMuted, useIsSpeaking } from '../../hooks';
+import { useFacingMode, useIsMuted, useIsSpeaking } from '../../hooks';
 import { mergeProps } from '../../utils';
 import { FocusToggle } from '../controls/FocusToggle';
 import { ParticipantPlaceholder } from '../../assets/images';
@@ -65,6 +65,7 @@ export function useParticipantTile<T extends HTMLElement>({
   const isVideoMuted = useIsMuted(Track.Source.Camera, { participant });
   const isAudioMuted = useIsMuted(Track.Source.Microphone, { participant });
   const isSpeaking = useIsSpeaking(participant);
+  const facingMode = useFacingMode({ participant, publication, source });
   return {
     elementProps: {
       'data-lk-audio-muted': isAudioMuted,
@@ -72,6 +73,7 @@ export function useParticipantTile<T extends HTMLElement>({
       'data-lk-speaking': disableSpeakingIndicator === true ? false : isSpeaking,
       'data-lk-local-participant': participant.isLocal,
       'data-lk-source': source,
+      'data-lk-facing-mode': facingMode,
       ...mergedProps,
     } as React.HTMLAttributes<HTMLDivElement>,
   };

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -22,3 +22,4 @@ export { useTracks, UseTracksOptions, UseTracksHookReturnType } from './useTrack
 export { useVisualStableUpdate, UseVisualStableUpdateOptions } from './useVisualStableUpdate';
 export { usePinnedTracks } from './usePinnedTracks';
 export { useSwipe, UseSwipeOptions } from './useSwipe';
+export { useFacingMode } from './useFacingMode';

--- a/packages/react/src/hooks/useFacingMode.ts
+++ b/packages/react/src/hooks/useFacingMode.ts
@@ -1,6 +1,5 @@
 import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
-import { facingModeFromLocalTrack } from 'livekit-client';
-import type { LocalTrack } from 'livekit-client';
+import { LocalTrackPublication, facingModeFromLocalTrack } from 'livekit-client';
 
 /**
  * Try to determine the `facingMode` of a local participant video track.
@@ -12,19 +11,12 @@ import type { LocalTrack } from 'livekit-client';
 export function useFacingMode(
   trackReference: TrackReferenceOrPlaceholder,
 ): 'user' | 'environment' | 'left' | 'right' | 'undefined' {
-  if (!trackReference.participant.isLocal) {
-    return 'undefined';
+  if (trackReference.publication instanceof LocalTrackPublication) {
+    const localTrack = trackReference.publication.track;
+    if (localTrack) {
+      const { facingMode } = facingModeFromLocalTrack(localTrack);
+      return facingMode;
+    }
   }
-
-  let mediaStreamTrack: LocalTrack | undefined;
-  if (trackReference.publication !== undefined) {
-    mediaStreamTrack = trackReference.publication.track as LocalTrack;
-  }
-
-  if (mediaStreamTrack) {
-    const { facingMode } = facingModeFromLocalTrack(mediaStreamTrack);
-    return facingMode;
-  } else {
-    return 'undefined';
-  }
+  return 'undefined';
 }

--- a/packages/react/src/hooks/useFacingMode.ts
+++ b/packages/react/src/hooks/useFacingMode.ts
@@ -1,17 +1,34 @@
 import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
+import { facingModeFromLocalTrack } from 'livekit-client';
+import type { LocalTrack } from 'livekit-client';
 
 /**
- * Try to determine the `facingMode` of a local participant track.
- *
+ * Try to determine the `facingMode` of a local participant video track.
+ * @remarks
+ * Works only on local video tracks.
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode | MDN docs on facingMode}
  * @alpha
  */
 export function useFacingMode(
   trackReference: TrackReferenceOrPlaceholder,
-): 'user' | 'environment' | 'undefined' {
-  if (trackReference.participant.isLocal) {
-    //TODO: use client-sdk-js function to get facingMode.
-    return 'user';
+): 'user' | 'environment' | 'left' | 'right' | 'undefined' {
+  if (!trackReference.participant.isLocal) {
+    return 'undefined';
+  }
+
+  let mediaStreamTrack: LocalTrack | undefined;
+  if (trackReference.publication === undefined) {
+    if (trackReference.participant.videoTracks.size > 0) {
+      mediaStreamTrack = Array.from(trackReference.participant.videoTracks.values())[0]
+        .videoTrack as LocalTrack;
+    }
+  } else {
+    mediaStreamTrack = trackReference.publication.track as LocalTrack;
+  }
+
+  if (mediaStreamTrack) {
+    const { facingMode } = facingModeFromLocalTrack(mediaStreamTrack as LocalTrack);
+    return facingMode;
   } else {
     return 'undefined';
   }

--- a/packages/react/src/hooks/useFacingMode.ts
+++ b/packages/react/src/hooks/useFacingMode.ts
@@ -17,17 +17,12 @@ export function useFacingMode(
   }
 
   let mediaStreamTrack: LocalTrack | undefined;
-  if (trackReference.publication === undefined) {
-    if (trackReference.participant.videoTracks.size > 0) {
-      mediaStreamTrack = Array.from(trackReference.participant.videoTracks.values())[0]
-        .videoTrack as LocalTrack;
-    }
-  } else {
+  if (trackReference.publication !== undefined) {
     mediaStreamTrack = trackReference.publication.track as LocalTrack;
   }
 
   if (mediaStreamTrack) {
-    const { facingMode } = facingModeFromLocalTrack(mediaStreamTrack as LocalTrack);
+    const { facingMode } = facingModeFromLocalTrack(mediaStreamTrack);
     return facingMode;
   } else {
     return 'undefined';

--- a/packages/react/src/hooks/useFacingMode.ts
+++ b/packages/react/src/hooks/useFacingMode.ts
@@ -1,0 +1,18 @@
+import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
+
+/**
+ * Try to determine the `facingMode` of a local participant track.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode | MDN docs on facingMode}
+ * @alpha
+ */
+export function useFacingMode(
+  trackReference: TrackReferenceOrPlaceholder,
+): 'user' | 'environment' | 'undefined' {
+  if (trackReference.participant.isLocal) {
+    //TODO: use client-sdk-js function to get facingMode.
+    return 'user';
+  } else {
+    return 'undefined';
+  }
+}

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -8,6 +8,7 @@ import {
   createLocalAudioTrack,
   createLocalTracks,
   createLocalVideoTrack,
+  facingModeFromLocalTrack,
   Track,
   VideoPresets,
 } from 'livekit-client';
@@ -245,6 +246,16 @@ export const PreJoin = ({
     () => tracks?.filter((track) => track.kind === Track.Kind.Video)[0] as LocalVideoTrack,
     [tracks],
   );
+
+  const facingMode = React.useMemo(() => {
+    if (videoTrack) {
+      const { facingMode } = facingModeFromLocalTrack(videoTrack);
+      return facingMode;
+    } else {
+      return 'undefined';
+    }
+  }, [videoTrack]);
+
   const audioTrack = React.useMemo(
     () => tracks?.filter((track) => track.kind === Track.Kind.Audio)[0] as LocalAudioTrack,
     [tracks],
@@ -300,7 +311,9 @@ export const PreJoin = ({
   return (
     <div className="lk-prejoin" {...htmlProps}>
       <div className="lk-video-container">
-        {videoTrack && <video ref={videoEl} width="1280" height="720" />}
+        {videoTrack && (
+          <video ref={videoEl} width="1280" height="720" data-lk-facing-mode={facingMode} />
+        )}
         {(!videoTrack || !videoEnabled) && (
           <div className="lk-camera-off-note">
             <ParticipantPlaceholder />

--- a/packages/styles/scss/components/participant/_participant-media.scss
+++ b/packages/styles/scss/components/participant/_participant-media.scss
@@ -22,7 +22,7 @@
   width: auto;
 }
 
-// Flip the local participant camera video.
+// Mirror the camera video of the local participants.
 [data-facing-mode='user'] // 
   .participant-media-video[data-local-participant='true'][data-source='camera'] {
   transform: rotateY(180deg);

--- a/packages/styles/scss/components/participant/_participant-media.scss
+++ b/packages/styles/scss/components/participant/_participant-media.scss
@@ -6,11 +6,6 @@
   // aspect-ratio: 16 / 10;
   background-color: #000;
 
-  // Flip the local participant camera video.
-  &[data-local-participant='true'][data-source='camera'] {
-    transform: rotateY(180deg);
-  }
-
   &[data-orientation='landscape'] {
     object-fit: cover;
   }
@@ -25,4 +20,10 @@
 
 .participant-media-audio {
   width: auto;
+}
+
+// Flip the local participant camera video.
+[data-facing-mode='user'] // 
+  .participant-media-video[data-local-participant='true'][data-source='camera'] {
+  transform: rotateY(180deg);
 }

--- a/packages/styles/scss/prefabs/prejoin.scss
+++ b/packages/styles/scss/prefabs/prejoin.scss
@@ -29,7 +29,7 @@
       object-fit: cover;
     }
 
-    video {
+    video[data-facing-mode='user'] {
       transform: rotateY(180deg);
     }
 

--- a/tooling/eslint-config-custom/package.json
+++ b/tooling/eslint-config-custom/package.json
@@ -24,6 +24,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-standard": "^4.1.0",
     "eslint-plugin-tsdoc": "^0.2.17",
-    "typescript": "^5.0.0"
+    "typescript": "5.0.4"
   }
 }


### PR DESCRIPTION
Take advantage of the new facingMode detection https://github.com/livekit/client-sdk-js/pull/738 to stop mirroring the local participant's camera track when using backward facing mobile or OBS virtual cameras. 