### PR TITLE
Combined Device Permissions in useMediaAllDevicesSelect

### DIFF
--- a/packages/core/src/observables/participant.ts
+++ b/packages/core/src/observables/participant.ts
@@ -126,9 +126,11 @@ export function participantEventSelector<T extends ParticipantEvent>(
       // @ts-ignore
       subscribe.next(params);
     };
+    // @ts-ignore
     participant.on(event, update);
 
     const unsubscribe = () => {
+      // @ts-ignore
       participant.off(event, update);
     };
     return unsubscribe;

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -1,47 +1,7 @@
 import * as React from 'react';
 import { useMaybeRoomContext } from '../../context';
-import { setupDeviceSelector, createMediaDeviceObserver } from '@livekit/components-core';
 import { mergeProps } from '../../utils';
-import type { Room } from 'livekit-client';
-import { useObservableState } from '../../hooks/internal/useObservableState';
-
-/** @public */
-export function useMediaDevices({ kind }: { kind: MediaDeviceKind }) {
-  const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);
-  const devices = useObservableState(deviceObserver, []);
-  return devices;
-}
-
-/** @public */
-export interface UseMediaDeviceSelectProps {
-  kind: MediaDeviceKind;
-  room?: Room;
-}
-
-/** @public */
-export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps) {
-  const roomContext = useMaybeRoomContext();
-  // List of all devices.
-  const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);
-  const devices = useObservableState(deviceObserver, []);
-  // Active device management.
-  const [currentDeviceId, setCurrentDeviceId] = React.useState<string>('');
-  const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
-    () => setupDeviceSelector(kind, room ?? roomContext),
-    [kind, room, roomContext],
-  );
-
-  React.useEffect(() => {
-    const listener = activeDeviceObservable.subscribe((deviceId) => {
-      if (deviceId) setCurrentDeviceId(deviceId);
-    });
-    return () => {
-      listener?.unsubscribe();
-    };
-  }, [activeDeviceObservable]);
-
-  return { devices, className, activeDeviceId: currentDeviceId, setActiveMediaDevice };
-}
+import { useMediaDeviceSelect } from '../../hooks/useMediaDevices';
 
 /** @public */
 export interface MediaDeviceSelectProps extends React.HTMLAttributes<HTMLUListElement> {

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -9,6 +9,12 @@ export { useMediaTrack, UseMediaTrackOptions } from './useMediaTrack';
 export { useMediaTrackByName } from './useMediaTrackByName';
 export { usePagination } from './usePagination';
 export {
+  useMediaAllDevicesSelect,
+  useMediaDeviceSelect,
+  MediaDevices,
+  MediaDevicesSelection,
+} from './useMediaDevices';
+export {
   useParticipantPermissions,
   UseParticipantPermissionsOptions,
 } from './useParticipantPermissions';

--- a/packages/react/src/hooks/useMediaDevices.ts
+++ b/packages/react/src/hooks/useMediaDevices.ts
@@ -47,9 +47,9 @@ export function useMediaAllDevicesSelect({
   const [devices, permittedDevices] = useObservableState(deviceObserver, [[], {}]);
 
   // Active device management.
-  const [currentAudioId, setcurrentAudioId] = React.useState<string>('');
-  const [currentVideoId, setcurrentVideoId] = React.useState<string>('');
-  const [currentAudioOutId, setcurrentAudioOutId] = React.useState<string>(audioOut);
+  const [currentAudioId, setcurrentAudioId] = React.useState<string>(audio ?? '');
+  const [currentVideoId, setcurrentVideoId] = React.useState<string>(video ?? '');
+  const [currentAudioOutId, setcurrentAudioOutId] = React.useState<string>(audioOut ?? '');
 
   const {
     className: audioClassName,

--- a/packages/react/src/hooks/useMediaDevices.ts
+++ b/packages/react/src/hooks/useMediaDevices.ts
@@ -1,0 +1,185 @@
+import type { Room } from 'livekit-client';
+import { useMaybeRoomContext } from '../context';
+import React from 'react';
+import { createMediaDeviceObserver, setupDeviceSelector } from '@livekit/components-core';
+import { useObservableState } from './internal';
+
+import type { PermittedDevices } from 'livekit-client/dist/src/room/DeviceManager';
+
+export type MediaDevices = {
+  available: MediaDeviceInfo[];
+  selectedId: string;
+  setSelected: (deviceId: string) => Promise<void>;
+};
+
+export type MediaDevicesSelection = {
+  audioIn?: MediaDevices;
+  audioOut?: MediaDevices;
+  videoIn?: MediaDevices;
+  classNames: { audio?: string; video?: string; audioOut?: string };
+  permittedDevices: PermittedDevices;
+};
+
+export type MediaAllDevicesSelectProps = {
+  room?: Room;
+  // A string with the deviceId.
+  audio: string;
+  video: string;
+  audioOut: string;
+};
+
+export function useMediaAllDevicesSelect({
+  room,
+  audio,
+  video,
+  audioOut,
+}: MediaAllDevicesSelectProps): MediaDevicesSelection {
+  const roomContext = useMaybeRoomContext();
+  // List of all devices.
+  const deviceObserver = React.useMemo(
+    () =>
+      createMediaDeviceObserver(undefined, {
+        audio: { deviceId: audio },
+        video: { deviceId: video },
+      }),
+    [audio, video],
+  );
+  const [devices, permittedDevices] = useObservableState(deviceObserver, [[], {}]);
+
+  // Active device management.
+  const [currentAudioId, setcurrentAudioId] = React.useState<string>('');
+  const [currentVideoId, setcurrentVideoId] = React.useState<string>('');
+  const [currentAudioOutId, setcurrentAudioOutId] = React.useState<string>(audioOut);
+
+  const {
+    className: audioClassName,
+    activeDeviceObservable: activeAudioObservable,
+    setActiveMediaDevice: setActiveAudioDevice,
+  } = React.useMemo(
+    () => setupDeviceSelector('audioinput', room ?? roomContext),
+    [room, roomContext],
+  );
+  const {
+    className: videoClassName,
+    activeDeviceObservable: activeVideoObservable,
+    setActiveMediaDevice: setActiveVideoDevice,
+  } = React.useMemo(
+    () => setupDeviceSelector('videoinput', room ?? roomContext),
+    [room, roomContext],
+  );
+  const {
+    className: audioOutClassName,
+    activeDeviceObservable: activeAudioOutObservable,
+    setActiveMediaDevice: setActiveAudioOutDevice,
+  } = React.useMemo(
+    () => setupDeviceSelector('audiooutput', room ?? roomContext),
+    [room, roomContext],
+  );
+
+  React.useEffect(() => {
+    const listenerAudio = activeAudioObservable.subscribe((deviceId) => {
+      if (deviceId) setcurrentAudioId(deviceId);
+    });
+    return () => {
+      listenerAudio?.unsubscribe();
+    };
+  }, [activeAudioObservable]);
+  React.useEffect(() => {
+    const listenerVideo = activeVideoObservable.subscribe((deviceId) => {
+      if (deviceId) setcurrentVideoId(deviceId);
+    });
+    return () => {
+      listenerVideo?.unsubscribe();
+    };
+  }, [activeVideoObservable]);
+  React.useEffect(() => {
+    const listenerAudioOut = activeAudioOutObservable.subscribe((deviceId) => {
+      if (deviceId) setcurrentAudioOutId(deviceId);
+    });
+    return () => {
+      listenerAudioOut?.unsubscribe();
+    };
+  }, [activeAudioOutObservable]);
+
+  // Update the selected/active device to the one for which the user granted permission.
+  React.useEffect(() => {
+    if (permittedDevices.audioDeviceId) {
+      setActiveAudioDevice(permittedDevices.audioDeviceId);
+    }
+    if (permittedDevices.videoDeviceId) {
+      setActiveVideoDevice(permittedDevices.videoDeviceId);
+    }
+  }, [permittedDevices, setActiveAudioDevice, setActiveVideoDevice]);
+
+  return {
+    audioIn: {
+      available: devices.filter((d) => d.kind == 'audioinput'),
+      selectedId: currentAudioId,
+      setSelected: setActiveAudioDevice,
+    },
+    audioOut: {
+      available: devices.filter((d) => d.kind == 'audiooutput'),
+      selectedId: currentAudioOutId,
+      setSelected: setActiveAudioOutDevice,
+    },
+    videoIn: {
+      available: devices.filter((d) => d.kind == 'videoinput'),
+      selectedId: currentVideoId,
+      setSelected: setActiveVideoDevice,
+    },
+    classNames: {
+      audio: audioClassName,
+      video: videoClassName,
+      audioOut: audioOutClassName,
+    },
+    permittedDevices,
+  };
+}
+
+export interface UseMediaDeviceSelectProps {
+  kind: MediaDeviceKind;
+  room?: Room;
+}
+
+export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps) {
+  const roomContext = useMaybeRoomContext();
+
+  // List of all devices.
+  const deviceObserver = React.useMemo(() => createMediaDeviceObserver(undefined), [kind]);
+  const [devices, permittedDevices] = useObservableState(deviceObserver, [[], {}]);
+
+  // Active device management.
+  const [currentDeviceId, setCurrentDeviceId] = React.useState<string>(
+    kind == 'audioinput'
+      ? permittedDevices.audioDeviceId ?? ''
+      : permittedDevices.videoDeviceId ?? '',
+  );
+  const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
+    () => setupDeviceSelector(kind, room ?? roomContext),
+    [kind, room, roomContext],
+  );
+
+  React.useEffect(() => {
+    const listener = activeDeviceObservable.subscribe((deviceId) => {
+      if (deviceId) setCurrentDeviceId(deviceId);
+    });
+    return () => {
+      listener?.unsubscribe();
+    };
+  }, [activeDeviceObservable]);
+
+  return { devices, className, activeDeviceId: currentDeviceId, setActiveMediaDevice };
+}
+
+export function useMediaDevices({ kind }: { kind?: MediaDeviceKind }, requestPermissions = true) {
+  const deviceObserver = React.useMemo(
+    () =>
+      createMediaDeviceObserver(kind, {
+        video: kind == 'videoinput' && requestPermissions,
+        audio: kind == 'audioinput' && requestPermissions,
+      }),
+    [kind, requestPermissions],
+  );
+  const devices = useObservableState(deviceObserver, [[], {}]);
+  return devices;
+}

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -102,7 +102,7 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
     }
   }, [enabled, localTrack, deviceError]);
 
-  // switch camera device
+  // update track based on mute state and changed deviceId
   React.useEffect(() => {
     if (!enabled) {
       if (localTrack) {
@@ -111,13 +111,9 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
       }
       return;
     }
-    if (
-      localTrack &&
-      selectedDevice?.deviceId &&
-      prevDeviceId.current !== selectedDevice?.deviceId
-    ) {
-      log.debug(`switching ${kind} device from`, prevDeviceId.current, selectedDevice.deviceId);
-      switchDevice(localTrack, selectedDevice.deviceId);
+    if (localTrack && localDeviceId && prevDeviceId.current !== localDeviceId) {
+      log.debug(`switching ${kind} device from`, prevDeviceId.current, localDeviceId);
+      switchDevice(localTrack, localDeviceId);
     } else {
       log.debug(`unmuting local ${kind} track`);
       localTrack?.unmute();
@@ -130,7 +126,7 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
         localTrack.mute();
       }
     };
-  }, [localTrack, selectedDevice, enabled, kind]);
+  }, [localTrack, localDeviceId, enabled, kind]);
 
   React.useEffect(() => {
     setSelectedDevice(devices.find((dev) => dev.deviceId === localDeviceId));


### PR DESCRIPTION
depends on: https://github.com/livekit/client-sdk-js/pull/755
Add an additional useMediaDevices hook.
Next to useMediaDeviceSelect there is also useMediaAllDevicesSelect that asks for permissions for all devices simultaneously and makes the one selected by the user the active ones.

Overview:
 - `useMediaAllDevicesSelect`: tracks the state of all media device selections and updates the device selection in an active livekit room.
 - `useMediaDeviceSelect`: tracks one device and updates the active device in a livekit room.
 - `useMediaDevices`: only returns the device list.

All of them allow to also ask for permission (Which is mandatory if one wants to see the actual device labels and not only the id's)
Signed-off-by: Timo K <toger5@hotmail.de>