### PR TITLE
Prejoin update

### DIFF
--- a/.changeset/bright-candles-beg.md
+++ b/.changeset/bright-candles-beg.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Improve PreJoin component by requesting combined permissions when possible

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
+  reactStrictMode: true,
   swcMinify: true,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
     // Important: return the modified config

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   swcMinify: true,
   webpack: (config, { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
     // Important: return the modified config

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@livekit/components-react": "~1.0.6",
     "@livekit/components-styles": "~1.0.2",
-    "livekit-client": "^1.11.2",
+    "livekit-client": "^1.11.4",
     "livekit-server-sdk": "^1.0.3",
     "next": "^12.2.4",
     "react": "^18.2.0",

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -4,19 +4,23 @@ import styles from '../styles/Home.module.scss';
 import { faker } from '@faker-js/faker';
 
 const EXAMPLE_ROUTES = {
-  minimal: { title: 'Minimal example', href: `/minimal?user=${faker.name.fullName()}` },
-  simple: { title: 'Simple example', href: `/simple?user=${faker.name.fullName()}` },
+  minimal: { title: 'Minimal example', href: () => `/minimal?user=${faker.name.fullName()}` },
+  simple: { title: 'Simple example', href: () => `/simple?user=${faker.name.fullName()}` },
   audioOnly: {
     title: 'Audio only example',
-    href: `/audio-only?user=${faker.name.fullName()}`,
+    href: () => `/audio-only?user=${faker.name.fullName()}`,
   },
   customize: {
     title: 'Simple example with custom components',
-    href: `/customize?user=${faker.name.fullName()}`,
+    href: () => `/customize?user=${faker.name.fullName()}`,
   },
   clubhouse: {
     title: 'Clubhouse clone build with LiveKit components',
-    href: `/clubhouse?user=${faker.name.fullName()}`,
+    href: () => `/clubhouse?user=${faker.name.fullName()}`,
+  },
+  processors: {
+    title: 'Minimal example with background blur',
+    href: () => `/processors?user=${faker.name.fullName()}`,
   },
 } as const;
 
@@ -42,7 +46,7 @@ const Home: NextPage = () => {
           {Object.values(EXAMPLE_ROUTES).map(({ title, href }, index) => {
             return (
               <li className={styles.listItem} key={index}>
-                <a className={styles.link} href={href}>
+                <a className={styles.link} href={href()}>
                   {title}
                 </a>
               </li>

--- a/examples/nextjs/pages/prejoin.tsx
+++ b/examples/nextjs/pages/prejoin.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { setLogLevel } from '@livekit/components-core';
+import { LiveKitRoom, PreJoin, useToken, VideoConference } from '@livekit/components-react';
+import type { NextPage } from 'next';
+
+const MinimalExample: NextPage = () => {
+  //   const params = typeof window !== 'undefined' ? new URLSearchParams(location.search) : null;
+  //   const roomName = params?.get('room') ?? 'test-room';
+  //   const userIdentity = params?.get('user') ?? 'test-identity';
+  setLogLevel('debug', { liveKitClientLogLevel: 'warn' });
+  //   const [controlBarOptions, setControlBarOptions] = React.useState<ControlBarControls>({
+  //     chat: true,
+  //   });
+
+  //   const token = useToken(process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT, roomName, {
+  //     userInfo: {
+  //       identity: userIdentity,
+  //       name: userIdentity,
+  //     },
+  //   });
+
+  //   React.useEffect(() => {
+  //     import('@livekit/track-processors').then((pkg) => {
+  //       setControlBarOptions({
+  //         camera: { processors: { 'Background Blur': pkg.BackgroundBlur(10) } },
+  //         chat: true,
+  //       });
+  //     });
+  //   }, []);
+
+  return (
+    <div data-lk-theme="default" style={{ height: '100vh' }}>
+      <PreJoin />
+    </div>
+  );
+};
+
+export default MinimalExample;

--- a/examples/nextjs/pages/prejoin.tsx
+++ b/examples/nextjs/pages/prejoin.tsx
@@ -3,7 +3,7 @@ import { setLogLevel } from '@livekit/components-core';
 import { LiveKitRoom, PreJoin, useToken, VideoConference } from '@livekit/components-react';
 import type { NextPage } from 'next';
 
-const MinimalExample: NextPage = () => {
+const PreJoinExample: NextPage = () => {
   //   const params = typeof window !== 'undefined' ? new URLSearchParams(location.search) : null;
   //   const roomName = params?.get('room') ?? 'test-room';
   //   const userIdentity = params?.get('user') ?? 'test-identity';

--- a/examples/nextjs/pages/prejoin.tsx
+++ b/examples/nextjs/pages/prejoin.tsx
@@ -1,32 +1,10 @@
 import * as React from 'react';
 import { setLogLevel } from '@livekit/components-core';
-import { LiveKitRoom, PreJoin, useToken, VideoConference } from '@livekit/components-react';
+import { PreJoin } from '@livekit/components-react';
 import type { NextPage } from 'next';
 
 const PreJoinExample: NextPage = () => {
-  //   const params = typeof window !== 'undefined' ? new URLSearchParams(location.search) : null;
-  //   const roomName = params?.get('room') ?? 'test-room';
-  //   const userIdentity = params?.get('user') ?? 'test-identity';
   setLogLevel('debug', { liveKitClientLogLevel: 'warn' });
-  //   const [controlBarOptions, setControlBarOptions] = React.useState<ControlBarControls>({
-  //     chat: true,
-  //   });
-
-  //   const token = useToken(process.env.NEXT_PUBLIC_LK_TOKEN_ENDPOINT, roomName, {
-  //     userInfo: {
-  //       identity: userIdentity,
-  //       name: userIdentity,
-  //     },
-  //   });
-
-  //   React.useEffect(() => {
-  //     import('@livekit/track-processors').then((pkg) => {
-  //       setControlBarOptions({
-  //         camera: { processors: { 'Background Blur': pkg.BackgroundBlur(10) } },
-  //         chat: true,
-  //       });
-  //     });
-  //   }, []);
 
   return (
     <div data-lk-theme="default" style={{ height: '100vh' }}>
@@ -35,4 +13,4 @@ const PreJoinExample: NextPage = () => {
   );
 };
 
-export default MinimalExample;
+export default PreJoinExample;

--- a/packages/core/src/components/mediaDeviceSelect.ts
+++ b/packages/core/src/components/mediaDeviceSelect.ts
@@ -1,4 +1,4 @@
-import type { Room } from 'livekit-client';
+import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
 import { BehaviorSubject } from 'rxjs';
 import { log } from '../logger';
 import { prefixClass } from '../styles-interface';
@@ -12,7 +12,11 @@ export type SetMediaDeviceOptions = {
   exact?: boolean;
 };
 
-export function setupDeviceSelector(kind: MediaDeviceKind, room?: Room) {
+export function setupDeviceSelector(
+  kind: MediaDeviceKind,
+  room?: Room,
+  localTrack?: LocalAudioTrack | LocalVideoTrack,
+) {
   const activeDeviceSubject = new BehaviorSubject<string | undefined>(undefined);
 
   const activeDeviceObservable = room
@@ -30,6 +34,10 @@ export function setupDeviceSelector(kind: MediaDeviceKind, room?: Room) {
         );
       }
       activeDeviceSubject.next(id === 'default' ? id : actualDeviceId);
+    } else if (localTrack) {
+      await localTrack.setDeviceId(options.exact ? { exact: id } : id);
+      const actualId = await localTrack.getDeviceId();
+      activeDeviceSubject.next(actualId);
     } else if (activeDeviceSubject.value !== id) {
       log.debug('Skip the device switch because the room object is not available. ');
       activeDeviceSubject.next(id);

--- a/packages/core/src/components/mediaDeviceSelect.ts
+++ b/packages/core/src/components/mediaDeviceSelect.ts
@@ -30,7 +30,7 @@ export function setupDeviceSelector(kind: MediaDeviceKind, room?: Room) {
         );
       }
       activeDeviceSubject.next(id === 'default' ? id : actualDeviceId);
-    } else {
+    } else if (activeDeviceSubject.value !== id) {
       log.debug('Skip the device switch because the room object is not available. ');
       activeDeviceSubject.next(id);
     }

--- a/packages/core/src/components/mediaDeviceSelect.ts
+++ b/packages/core/src/components/mediaDeviceSelect.ts
@@ -37,9 +37,11 @@ export function setupDeviceSelector(
     } else if (localTrack) {
       await localTrack.setDeviceId(options.exact ? { exact: id } : id);
       const actualId = await localTrack.getDeviceId();
-      activeDeviceSubject.next(actualId);
+      activeDeviceSubject.next(id === 'default' ? id : actualId);
     } else if (activeDeviceSubject.value !== id) {
-      log.debug('Skip the device switch because the room object is not available. ');
+      log.warn(
+        'device switch skipped, please provide either a room or a local track to switch on. ',
+      );
       activeDeviceSubject.next(id);
     }
   };

--- a/packages/core/src/components/mediaDeviceSelect.ts
+++ b/packages/core/src/components/mediaDeviceSelect.ts
@@ -3,7 +3,7 @@ import {
   type LocalAudioTrack,
   type LocalVideoTrack,
   type Room,
-  LocalTrack,
+  type LocalTrack,
 } from 'livekit-client';
 import { BehaviorSubject } from 'rxjs';
 import { log } from '../logger';
@@ -50,8 +50,6 @@ export function setupDeviceSelector(
         (id === 'default' && targetTrack?.mediaStreamTrack.label.startsWith('Default'));
       activeDeviceSubject.next(useDefault ? id : actualDeviceId);
     } else if (localTrack) {
-      log.info('try to acquire', id);
-      log.info(await navigator.mediaDevices.enumerateDevices());
       await localTrack.setDeviceId(options.exact ? { exact: id } : id);
       const actualId = await localTrack.getDeviceId();
       activeDeviceSubject.next(

--- a/packages/core/src/observables/room.ts
+++ b/packages/core/src/observables/room.ts
@@ -3,6 +3,7 @@ import { Subject, map, Observable, startWith, finalize, filter } from 'rxjs';
 import type { Participant, TrackPublication } from 'livekit-client';
 import { Room, RoomEvent, Track } from 'livekit-client';
 import type { RoomEventCallbacks } from 'livekit-client/dist/src/room/Room';
+import { log } from '../logger';
 export function observeRoomEvents(room: Room, ...events: RoomEvent[]): Observable<Room> {
   const observable = new Observable<Room>((subscribe) => {
     const onRoomUpdate = () => {
@@ -220,7 +221,7 @@ export function createActiveDeviceObservable(room: Room, kind: MediaDeviceKind) 
   return roomEventSelector(room, RoomEvent.ActiveDeviceChanged).pipe(
     filter(([kindOfDevice]) => kindOfDevice === kind),
     map(([kind, deviceId]) => {
-      console.log('activeDeviceObservable | RoomEvent.ActiveDeviceChanged', { kind, deviceId });
+      log.debug('activeDeviceObservable | RoomEvent.ActiveDeviceChanged', { kind, deviceId });
       return deviceId;
     }),
     startWith(room.getActiveDevice(kind)),

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -12,11 +12,13 @@ import type { CaptureOptionsBySource } from '@livekit/components-core';
 import type { ChatMessage } from '@livekit/components-core';
 import { ConnectionQuality } from 'livekit-client';
 import { ConnectionState as ConnectionState_2 } from 'livekit-client';
+import type { CreateLocalTracksOptions } from 'livekit-client';
 import { DataSendOptions } from '@livekit/components-core';
 import type { GridLayout as GridLayout_2 } from '@livekit/components-core/dist/helper/grid-layouts';
 import { HTMLAttributes } from 'react';
 import type { LocalAudioTrack } from 'livekit-client';
 import { LocalParticipant } from 'livekit-client';
+import type { LocalTrack } from 'livekit-client';
 import { LocalTrackPublication } from 'livekit-client';
 import type { LocalVideoTrack } from 'livekit-client';
 import { MediaDeviceFailure } from 'livekit-client';
@@ -283,7 +285,7 @@ export type LocalUserChoices = {
 };
 
 // @public
-export const MediaDeviceMenu: ({ kind, initialSelection, onActiveDeviceChange, ...props }: MediaDeviceMenuProps) => React_2.JSX.Element;
+export const MediaDeviceMenu: ({ kind, initialSelection, onActiveDeviceChange, tracks, requestPermissions, ...props }: MediaDeviceMenuProps) => React_2.JSX.Element;
 
 // @public (undocumented)
 export interface MediaDeviceMenuProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -293,10 +295,13 @@ export interface MediaDeviceMenuProps extends React_2.ButtonHTMLAttributes<HTMLB
     kind?: MediaDeviceKind;
     // (undocumented)
     onActiveDeviceChange?: (kind: MediaDeviceKind, deviceId: string) => void;
+    requestPermissions?: boolean;
+    // (undocumented)
+    tracks?: Partial<Record<MediaDeviceKind, LocalAudioTrack | LocalVideoTrack | undefined>>;
 }
 
 // @public
-export function MediaDeviceSelect({ kind, initialSelection, onActiveDeviceChange, onDeviceListChange, onDeviceSelectError, exactMatch, ...props }: MediaDeviceSelectProps): React_2.JSX.Element;
+export function MediaDeviceSelect({ kind, initialSelection, onActiveDeviceChange, onDeviceListChange, onDeviceSelectError, exactMatch, track, requestPermissions, ...props }: MediaDeviceSelectProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface MediaDeviceSelectProps extends React_2.HTMLAttributes<HTMLUListElement> {
@@ -311,6 +316,9 @@ export interface MediaDeviceSelectProps extends React_2.HTMLAttributes<HTMLUList
     onDeviceListChange?: (devices: MediaDeviceInfo[]) => void;
     // (undocumented)
     onDeviceSelectError?: (e: Error) => void;
+    requestPermissions?: boolean;
+    // (undocumented)
+    track?: LocalAudioTrack | LocalVideoTrack;
 }
 
 // @public (undocumented)
@@ -555,7 +563,7 @@ export function useMediaDevices({ kind }: {
 }): MediaDeviceInfo[];
 
 // @public (undocumented)
-export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps): {
+export function useMediaDeviceSelect({ kind, room, track, requestPermissions, }: UseMediaDeviceSelectProps): {
     devices: MediaDeviceInfo[];
     className: string;
     activeDeviceId: string;
@@ -566,8 +574,11 @@ export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps):
 export interface UseMediaDeviceSelectProps {
     // (undocumented)
     kind: MediaDeviceKind;
+    requestPermissions?: boolean;
     // (undocumented)
     room?: Room;
+    // (undocumented)
+    track?: LocalAudioTrack | LocalVideoTrack;
 }
 
 // @public (undocumented)
@@ -663,6 +674,9 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(en
     localTrack: T | undefined;
     deviceError: Error | null;
 };
+
+// @alpha (undocumented)
+export function usePreviewTracks(options: CreateLocalTracksOptions, onError?: (err: Error) => void): LocalTrack[] | undefined;
 
 // @public (undocumented)
 export const useRemoteParticipant: (identity: string, options?: UseRemoteParticipantOptions) => RemoteParticipant | undefined;

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -17,13 +17,31 @@ export interface UseMediaDeviceSelectProps {
   kind: MediaDeviceKind;
   room?: Room;
   track?: LocalAudioTrack | LocalVideoTrack;
+  /**
+   * this will call getUserMedia if the permissions are not yet given to enumerate the devices with device labels.
+   * in some browsers multiple calls to getUserMedia result in multiple permission prompts.
+   * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
+   * appropriate permissions.
+   *
+   * @see [MediaDeviceMenu](../../prefabs/MediaDeviceMenu.tsx)
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+   */
+  requestPermissions?: boolean;
 }
 
 /** @public */
-export function useMediaDeviceSelect({ kind, room, track }: UseMediaDeviceSelectProps) {
+export function useMediaDeviceSelect({
+  kind,
+  room,
+  track,
+  requestPermissions,
+}: UseMediaDeviceSelectProps) {
   const roomContext = useMaybeRoomContext();
   // List of all devices.
-  const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);
+  const deviceObserver = React.useMemo(
+    () => createMediaDeviceObserver(kind, requestPermissions),
+    [kind, requestPermissions],
+  );
   const devices = useObservableState(deviceObserver, []);
   // Active device management.
   const [currentDeviceId, setCurrentDeviceId] = React.useState<string>('');
@@ -57,6 +75,16 @@ export interface MediaDeviceSelectProps extends React.HTMLAttributes<HTMLUListEl
    */
   exactMatch?: boolean;
   track?: LocalAudioTrack | LocalVideoTrack;
+  /**
+   * this will call getUserMedia if the permissions are not yet given to enumerate the devices with device labels.
+   * in some browsers multiple calls to getUserMedia result in multiple permission prompts.
+   * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
+   * appropriate permissions.
+   *
+   * @see [MediaDeviceMenu](../../prefabs/MediaDeviceMenu.tsx)
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+   */
+  requestPermissions?: boolean;
 }
 
 /**
@@ -79,6 +107,7 @@ export function MediaDeviceSelect({
   onDeviceSelectError,
   exactMatch,
   track,
+  requestPermissions,
   ...props
 }: MediaDeviceSelectProps) {
   const room = useMaybeRoomContext();
@@ -86,6 +115,7 @@ export function MediaDeviceSelect({
     kind,
     room,
     track,
+    requestPermissions,
   });
   React.useEffect(() => {
     if (initialSelection) {

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -32,8 +32,10 @@ export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps) 
   );
 
   React.useEffect(() => {
+    console.log('resubscribing to active device observable');
     const listener = activeDeviceObservable.subscribe((deviceId) => {
       if (deviceId) setCurrentDeviceId(deviceId);
+      console.log('active device observable update', deviceId);
     });
     return () => {
       listener?.unsubscribe();
@@ -86,7 +88,7 @@ export function MediaDeviceSelect({
     if (initialSelection) {
       setActiveMediaDevice(initialSelection);
     }
-  });
+  }, [initialSelection, setActiveMediaDevice]);
 
   React.useEffect(() => {
     if (typeof onDeviceListChange === 'function') {
@@ -95,8 +97,11 @@ export function MediaDeviceSelect({
   }, [onDeviceListChange, devices]);
 
   React.useEffect(() => {
-    onActiveDeviceChange?.(activeDeviceId);
-  }, [activeDeviceId, onActiveDeviceChange]);
+    if (activeDeviceId && activeDeviceId !== '') {
+      onActiveDeviceChange?.(activeDeviceId);
+      console.log('active device id', activeDeviceId);
+    }
+  }, [activeDeviceId]);
 
   const handleActiveDeviceChange = async (deviceId: string) => {
     try {

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -52,7 +52,7 @@ export function useMediaDeviceSelect({
 
   React.useEffect(() => {
     const listener = activeDeviceObservable.subscribe((deviceId) => {
-      log.info('setCurrentDeviceId');
+      log.info('setCurrentDeviceId', deviceId);
       if (deviceId) setCurrentDeviceId(deviceId);
     });
     return () => {
@@ -118,7 +118,7 @@ export function MediaDeviceSelect({
     requestPermissions,
   });
   React.useEffect(() => {
-    if (initialSelection) {
+    if (initialSelection !== undefined) {
       setActiveMediaDevice(initialSelection);
     }
   }, [setActiveMediaDevice]);
@@ -152,14 +152,18 @@ export function MediaDeviceSelect({
     [className, props],
   );
 
+  function isActive(deviceId: string, activeDeviceId: string, index: number) {
+    return deviceId === activeDeviceId || (index === 0 && activeDeviceId === 'default');
+  }
+
   return (
     <ul {...mergedProps}>
-      {devices.map((device) => (
+      {devices.map((device, index) => (
         <li
           key={device.deviceId}
           id={device.deviceId}
-          data-lk-active={device.deviceId === activeDeviceId}
-          aria-selected={device.deviceId === activeDeviceId}
+          data-lk-active={isActive(device.deviceId, activeDeviceId, index)}
+          aria-selected={isActive(device.deviceId, activeDeviceId, index)}
           role="option"
         >
           <button className="lk-button" onClick={() => handleActiveDeviceChange(device.deviceId)}>

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -23,8 +23,8 @@ export interface UseMediaDeviceSelectProps {
    * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
    * appropriate permissions.
    *
-   * @see [MediaDeviceMenu](../../prefabs/MediaDeviceMenu.tsx)
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+   * @see {@link MediaDeviceMenu}
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices | MDN enumerateDevices}
    */
   requestPermissions?: boolean;
 }
@@ -81,8 +81,8 @@ export interface MediaDeviceSelectProps extends React.HTMLAttributes<HTMLUListEl
    * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
    * appropriate permissions.
    *
-   * @see [MediaDeviceMenu](../../prefabs/MediaDeviceMenu.tsx)
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+   * @see {@link MediaDeviceMenu}
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices | MDN enumerateDevices}
    */
   requestPermissions?: boolean;
 }

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useMaybeRoomContext } from '../../context';
 import { setupDeviceSelector, createMediaDeviceObserver } from '@livekit/components-core';
 import { mergeProps } from '../../utils';
-import type { Room } from 'livekit-client';
+import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
 import { useObservableState } from '../../hooks/internal/useObservableState';
 
 /** @public */
@@ -16,10 +16,11 @@ export function useMediaDevices({ kind }: { kind: MediaDeviceKind }) {
 export interface UseMediaDeviceSelectProps {
   kind: MediaDeviceKind;
   room?: Room;
+  track?: LocalAudioTrack | LocalVideoTrack;
 }
 
 /** @public */
-export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps) {
+export function useMediaDeviceSelect({ kind, room, track }: UseMediaDeviceSelectProps) {
   const roomContext = useMaybeRoomContext();
   // List of all devices.
   const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);
@@ -27,8 +28,8 @@ export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps) 
   // Active device management.
   const [currentDeviceId, setCurrentDeviceId] = React.useState<string>('');
   const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
-    () => setupDeviceSelector(kind, room ?? roomContext),
-    [kind, room, roomContext],
+    () => setupDeviceSelector(kind, room ?? roomContext, track),
+    [kind, room, roomContext, track],
   );
 
   React.useEffect(() => {
@@ -54,6 +55,7 @@ export interface MediaDeviceSelectProps extends React.HTMLAttributes<HTMLUListEl
    * will call `onDeviceSelectError` with the error in case this fails
    */
   exactMatch?: boolean;
+  track?: LocalAudioTrack | LocalVideoTrack;
 }
 
 /**
@@ -75,12 +77,14 @@ export function MediaDeviceSelect({
   onDeviceListChange,
   onDeviceSelectError,
   exactMatch,
+  track,
   ...props
 }: MediaDeviceSelectProps) {
   const room = useMaybeRoomContext();
   const { devices, activeDeviceId, setActiveMediaDevice, className } = useMediaDeviceSelect({
     kind,
     room,
+    track,
   });
   React.useEffect(() => {
     if (initialSelection) {

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useMaybeRoomContext } from '../../context';
-import { setupDeviceSelector, createMediaDeviceObserver } from '@livekit/components-core';
+import { setupDeviceSelector, createMediaDeviceObserver, log } from '@livekit/components-core';
 import { mergeProps } from '../../utils';
 import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
 import { useObservableState } from '../../hooks/internal/useObservableState';
@@ -34,6 +34,7 @@ export function useMediaDeviceSelect({ kind, room, track }: UseMediaDeviceSelect
 
   React.useEffect(() => {
     const listener = activeDeviceObservable.subscribe((deviceId) => {
+      log.info('setCurrentDeviceId');
       if (deviceId) setCurrentDeviceId(deviceId);
     });
     return () => {

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -86,7 +86,7 @@ export function MediaDeviceSelect({
     if (initialSelection) {
       setActiveMediaDevice(initialSelection);
     }
-  }, [initialSelection, setActiveMediaDevice]);
+  }, [setActiveMediaDevice]);
 
   React.useEffect(() => {
     if (typeof onDeviceListChange === 'function') {

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -32,10 +32,8 @@ export function useMediaDeviceSelect({ kind, room }: UseMediaDeviceSelectProps) 
   );
 
   React.useEffect(() => {
-    console.log('resubscribing to active device observable');
     const listener = activeDeviceObservable.subscribe((deviceId) => {
       if (deviceId) setCurrentDeviceId(deviceId);
-      console.log('active device observable update', deviceId);
     });
     return () => {
       listener?.unsubscribe();
@@ -99,7 +97,6 @@ export function MediaDeviceSelect({
   React.useEffect(() => {
     if (activeDeviceId && activeDeviceId !== '') {
       onActiveDeviceChange?.(activeDeviceId);
-      console.log('active device id', activeDeviceId);
     }
   }, [activeDeviceId]);
 

--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -16,8 +16,8 @@ export interface MediaDeviceMenuProps extends React.ButtonHTMLAttributes<HTMLBut
    * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
    * appropriate permissions.
    *
-   * @see [PreJoin](./PreJoin.tsx)
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+   * @see {@link PreJoin}
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices | MDN enumerateDevices}
    */
   requestPermissions?: boolean;
 }
@@ -51,7 +51,7 @@ export const MediaDeviceMenu = ({
 
   const handleActiveDeviceChange = (kind: MediaDeviceKind, deviceId: string) => {
     log.debug('handle device change');
-    // setIsOpen(false); // TODO re-enable
+    setIsOpen(false);
     onActiveDeviceChange?.(kind, deviceId);
   };
 

--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -93,39 +93,45 @@ export const MediaDeviceMenu = ({
       >
         {props.children}
       </button>
-
-      <div
-        className="lk-device-menu"
-        ref={tooltip}
-        style={{ visibility: isOpen ? 'visible' : 'hidden' }}
-      >
-        {kind ? (
-          <MediaDeviceSelect
-            initialSelection={initialSelection}
-            onActiveDeviceChange={(deviceId) => handleActiveDeviceChange(kind, deviceId)}
-            onDeviceListChange={setDevices}
-            kind={kind}
-            track={tracks?.[kind]}
-          />
-        ) : (
-          <>
-            <div className="lk-device-menu-heading">Audio inputs</div>
+      {/** only render when enabled in order to make sure that the permissions are requested only if the menu is enabled */}
+      {!props.disabled && (
+        <div
+          className="lk-device-menu"
+          ref={tooltip}
+          style={{ visibility: isOpen ? 'visible' : 'hidden' }}
+        >
+          {kind ? (
             <MediaDeviceSelect
-              kind="audioinput"
-              onActiveDeviceChange={(deviceId) => handleActiveDeviceChange('audioinput', deviceId)}
+              initialSelection={initialSelection}
+              onActiveDeviceChange={(deviceId) => handleActiveDeviceChange(kind, deviceId)}
               onDeviceListChange={setDevices}
-              track={tracks?.audioinput}
+              kind={kind}
+              track={tracks?.[kind]}
             />
-            <div className="lk-device-menu-heading">Video inputs</div>
-            <MediaDeviceSelect
-              kind="videoinput"
-              onActiveDeviceChange={(deviceId) => handleActiveDeviceChange('videoinput', deviceId)}
-              onDeviceListChange={setDevices}
-              track={tracks?.videoinput}
-            />
-          </>
-        )}
-      </div>
+          ) : (
+            <>
+              <div className="lk-device-menu-heading">Audio inputs</div>
+              <MediaDeviceSelect
+                kind="audioinput"
+                onActiveDeviceChange={(deviceId) =>
+                  handleActiveDeviceChange('audioinput', deviceId)
+                }
+                onDeviceListChange={setDevices}
+                track={tracks?.audioinput}
+              />
+              <div className="lk-device-menu-heading">Video inputs</div>
+              <MediaDeviceSelect
+                kind="videoinput"
+                onActiveDeviceChange={(deviceId) =>
+                  handleActiveDeviceChange('videoinput', deviceId)
+                }
+                onDeviceListChange={setDevices}
+                track={tracks?.videoinput}
+              />
+            </>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -37,7 +37,7 @@ export const MediaDeviceMenu = ({
 
   const handleActiveDeviceChange = (kind: MediaDeviceKind, deviceId: string) => {
     log.debug('handle device change');
-    setIsOpen(false);
+    // setIsOpen(false); // TODO re-enable
     onActiveDeviceChange?.(kind, deviceId);
   };
 

--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -10,6 +10,16 @@ export interface MediaDeviceMenuProps extends React.ButtonHTMLAttributes<HTMLBut
   initialSelection?: string;
   onActiveDeviceChange?: (kind: MediaDeviceKind, deviceId: string) => void;
   tracks?: Partial<Record<MediaDeviceKind, LocalAudioTrack | LocalVideoTrack | undefined>>;
+  /**
+   * this will call getUserMedia if the permissions are not yet given to enumerate the devices with device labels.
+   * in some browsers multiple calls to getUserMedia result in multiple permission prompts.
+   * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
+   * appropriate permissions.
+   *
+   * @see [PreJoin](./PreJoin.tsx)
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices
+   */
+  requestPermissions?: boolean;
 }
 
 /**
@@ -32,6 +42,7 @@ export const MediaDeviceMenu = ({
   initialSelection,
   onActiveDeviceChange,
   tracks,
+  requestPermissions = false,
   ...props
 }: MediaDeviceMenuProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -107,6 +118,7 @@ export const MediaDeviceMenu = ({
               onDeviceListChange={setDevices}
               kind={kind}
               track={tracks?.[kind]}
+              requestPermissions={requestPermissions}
             />
           ) : (
             <>
@@ -118,6 +130,7 @@ export const MediaDeviceMenu = ({
                 }
                 onDeviceListChange={setDevices}
                 track={tracks?.audioinput}
+                requestPermissions={requestPermissions}
               />
               <div className="lk-device-menu-heading">Video inputs</div>
               <MediaDeviceSelect
@@ -127,6 +140,7 @@ export const MediaDeviceMenu = ({
                 }
                 onDeviceListChange={setDevices}
                 track={tracks?.videoinput}
+                requestPermissions={requestPermissions}
               />
             </>
           )}

--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -2,12 +2,14 @@ import { computeMenuPosition, wasClickOutside } from '@livekit/components-core';
 import * as React from 'react';
 import { MediaDeviceSelect } from '../components/controls/MediaDeviceSelect';
 import { log } from '@livekit/components-core';
+import type { LocalAudioTrack, LocalVideoTrack } from 'livekit-client';
 
 /** @public */
 export interface MediaDeviceMenuProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   kind?: MediaDeviceKind;
   initialSelection?: string;
   onActiveDeviceChange?: (kind: MediaDeviceKind, deviceId: string) => void;
+  tracks?: Partial<Record<MediaDeviceKind, LocalAudioTrack | LocalVideoTrack | undefined>>;
 }
 
 /**
@@ -29,6 +31,7 @@ export const MediaDeviceMenu = ({
   kind,
   initialSelection,
   onActiveDeviceChange,
+  tracks,
   ...props
 }: MediaDeviceMenuProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -102,6 +105,7 @@ export const MediaDeviceMenu = ({
             onActiveDeviceChange={(deviceId) => handleActiveDeviceChange(kind, deviceId)}
             onDeviceListChange={setDevices}
             kind={kind}
+            track={tracks?.[kind]}
           />
         ) : (
           <>
@@ -110,12 +114,14 @@ export const MediaDeviceMenu = ({
               kind="audioinput"
               onActiveDeviceChange={(deviceId) => handleActiveDeviceChange('audioinput', deviceId)}
               onDeviceListChange={setDevices}
+              track={tracks?.audioinput}
             />
             <div className="lk-device-menu-heading">Video inputs</div>
             <MediaDeviceSelect
               kind="videoinput"
               onActiveDeviceChange={(deviceId) => handleActiveDeviceChange('videoinput', deviceId)}
               onDeviceListChange={setDevices}
+              track={tracks?.videoinput}
             />
           </>
         )}

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -273,7 +273,7 @@ export const PreJoin = ({
         )}
       </div>
       <div className="lk-button-group-container">
-        {/* <div className="lk-button-group audio">
+        <div className="lk-button-group audio">
           <TrackToggle
             initialState={audioEnabled}
             source={Track.Source.Microphone}
@@ -286,13 +286,12 @@ export const PreJoin = ({
               initialSelection={audio.selectedDevice?.deviceId}
               kind="audioinput"
               onActiveDeviceChange={(_, deviceId) => {
-                log.warn('active device chanaged', deviceId);
                 setAudioDeviceId(deviceId);
               }}
               disabled={!!!audio.selectedDevice}
             />
           </div>
-        </div> */}
+        </div>
         <div className="lk-button-group video">
           <TrackToggle
             initialState={videoEnabled}
@@ -306,7 +305,6 @@ export const PreJoin = ({
               initialSelection={video.selectedDevice?.deviceId}
               kind="videoinput"
               onActiveDeviceChange={(_, deviceId) => {
-                log.warn('active device chanaged', deviceId);
                 setVideoDeviceId(deviceId);
               }}
               disabled={!!!video.selectedDevice}

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -228,11 +228,11 @@ export const PreJoin = ({
   const videoEl = React.useRef(null);
 
   const videoTrack = React.useMemo(
-    () => tracks?.filter((track) => track.kind === Track.Kind.Video)[0],
+    () => tracks?.filter((track) => track.kind === Track.Kind.Video)[0] as LocalVideoTrack,
     [tracks],
   );
   const audioTrack = React.useMemo(
-    () => tracks?.filter((track) => track.kind === Track.Kind.Audio)[0],
+    () => tracks?.filter((track) => track.kind === Track.Kind.Audio)[0] as LocalAudioTrack,
     [tracks],
   );
 
@@ -259,31 +259,17 @@ export const PreJoin = ({
     [onValidate],
   );
 
-  function gatherUserChoices() {
-    Promise.all([videoTrack?.getDeviceId(), audioTrack?.getDeviceId()]).then(
-      ([videoId, audioId]) => {
-        const newUserChoices = {
-          username: username,
-          videoEnabled: videoEnabled,
-          videoDeviceId: videoId ?? '',
-          audioEnabled: audioEnabled,
-          audioDeviceId: audioId ?? '',
-        };
-        if (videoId) {
-          setVideoDeviceId(videoId);
-        }
-        if (audioId) {
-          setAudioDeviceId(audioId);
-        }
-        setUserChoices(newUserChoices);
-        setIsValid(handleValidation(newUserChoices));
-      },
-    );
-  }
-
   React.useEffect(() => {
-    gatherUserChoices();
-  }, [username, videoEnabled, handleValidation, audioEnabled, audioTrack, videoTrack]);
+    const newUserChoices = {
+      username: username,
+      videoEnabled: videoEnabled,
+      videoDeviceId: videoDeviceId,
+      audioEnabled: audioEnabled,
+      audioDeviceId: audioDeviceId,
+    };
+    setUserChoices(newUserChoices);
+    setIsValid(handleValidation(newUserChoices));
+  }, [username, videoEnabled, handleValidation, audioEnabled, audioDeviceId, videoDeviceId]);
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -323,6 +309,7 @@ export const PreJoin = ({
                 setAudioDeviceId(deviceId);
               }}
               disabled={!audioTrack}
+              tracks={{ audioinput: audioTrack }}
             />
           </div>
         </div>
@@ -341,7 +328,8 @@ export const PreJoin = ({
               onActiveDeviceChange={(_, deviceId) => {
                 setVideoDeviceId(deviceId);
               }}
-              disabled={!audioTrack}
+              disabled={!videoTrack}
+              tracks={{ videoinput: videoTrack }}
             />
           </div>
         </div>

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -29,10 +29,10 @@ export type LocalUserChoices = {
 
 const DEFAULT_USER_CHOICES = {
   username: '',
-  videoEnabled: true,
-  audioEnabled: true,
-  videoDeviceId: '',
-  audioDeviceId: '',
+  videoEnabled: false,
+  audioEnabled: false,
+  videoDeviceId: 'default',
+  audioDeviceId: 'default',
 };
 
 /** @public */

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -29,8 +29,8 @@ export type LocalUserChoices = {
 
 const DEFAULT_USER_CHOICES = {
   username: '',
-  videoEnabled: false,
-  audioEnabled: false,
+  videoEnabled: true,
+  audioEnabled: true,
   videoDeviceId: 'default',
   audioDeviceId: 'default',
 };

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -143,15 +143,9 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
       return;
     }
     if (!enabled) {
-      if (localTrack) {
-        log.debug(`muting ${kind} track`);
-        localTrack.mute().then(() => log.debug(localTrack.mediaStreamTrack));
-      }
-    } else if (
-      localTrack &&
-      selectedDevice?.deviceId &&
-      prevDeviceId.current !== selectedDevice?.deviceId
-    ) {
+      log.debug(`muting ${kind} track`);
+      localTrack.mute().then(() => log.debug(localTrack.mediaStreamTrack));
+    } else if (selectedDevice?.deviceId && prevDeviceId.current !== selectedDevice?.deviceId) {
       log.debug(`switching ${kind} device from`, prevDeviceId.current, selectedDevice.deviceId);
       switchDevice(localTrack, selectedDevice.deviceId);
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7939,6 +7939,18 @@ livekit-client@^1.11.4:
     ts-debounce "^4.0.0"
     webrtc-adapter "^8.1.1"
 
+livekit-client@^1.11.4:
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-1.11.4.tgz#e222afc111f36a28a7171755cdcfe6b8fa2ca2dc"
+  integrity sha512-TX53HRrtz7ZPWLasnrUOkrGN8EL22/IDwg39uLT7aJcSBWtgKlCueQkwjW4nn7KVWRF8mv00g8WiPDE9jyS8fQ==
+  dependencies:
+    eventemitter3 "^5.0.1"
+    loglevel "^1.8.0"
+    protobufjs "^7.0.0"
+    sdp-transform "^2.14.1"
+    ts-debounce "^4.0.0"
+    webrtc-adapter "^8.1.1"
+
 livekit-server-sdk@^1.0.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/livekit-server-sdk/-/livekit-server-sdk-1.2.3.tgz#851a104b0f05da1038a69ecc27267c199ff635fd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,30 +7915,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-livekit-client@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-1.11.2.tgz#a567fb5f099f1f638bb58f4b35aae980a95ffb49"
-  integrity sha512-zVGmUltO7udhSHcIbBofOzJBCXaHefqZZZhW+1okDWktSydHE6Se55je/OUx1Qwnaji6ub5jLSDB9WpX/+7eoQ==
-  dependencies:
-    eventemitter3 "^5.0.1"
-    loglevel "^1.8.0"
-    protobufjs "^7.0.0"
-    sdp-transform "^2.14.1"
-    ts-debounce "^4.0.0"
-    webrtc-adapter "^8.1.1"
-
-livekit-client@^1.11.4:
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-1.11.4.tgz#e222afc111f36a28a7171755cdcfe6b8fa2ca2dc"
-  integrity sha512-TX53HRrtz7ZPWLasnrUOkrGN8EL22/IDwg39uLT7aJcSBWtgKlCueQkwjW4nn7KVWRF8mv00g8WiPDE9jyS8fQ==
-  dependencies:
-    eventemitter3 "^5.0.1"
-    loglevel "^1.8.0"
-    protobufjs "^7.0.0"
-    sdp-transform "^2.14.1"
-    ts-debounce "^4.0.0"
-    webrtc-adapter "^8.1.1"
-
 livekit-client@^1.11.4:
   version "1.11.4"
   resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-1.11.4.tgz#e222afc111f36a28a7171755cdcfe6b8fa2ca2dc"


### PR DESCRIPTION
main objectives:

- request device specific permissions (and both at once if audio and video are specified)
- on subsequent requests, make sure it's only for the request of that device type (so that you don't get a prompt for both again, just because you're switching mics)
- make sure enumeration permission requests are only acquired after the other permissions have been successfully acquired

this is done primarily for a smoother experience on FF, where permissions are granted on a per-device basis which could, among other things, lead to multiple permission requests popping up for the same media device kind (e.g. two pop ups for microphone)