### PR TITLE
Add data-lk-orientation for kind video

### DIFF
--- a/.changeset/seven-adults-try.md
+++ b/.changeset/seven-adults-try.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Add data-lk-orientation for all video tracks

--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -1,7 +1,6 @@
 import type { TrackIdentifier } from '@livekit/components-core';
 import { isTrackReference } from '@livekit/components-core';
 import { setupMediaTrack, log, isLocal, getTrackByIdentifier } from '@livekit/components-core';
-import { Track } from 'livekit-client';
 import * as React from 'react';
 import { mergeProps } from '../utils';
 import type { UseMediaTrackOptions } from './useMediaTrack';
@@ -82,11 +81,7 @@ export function useMediaTrackBySourceOrName(
       className,
       'data-lk-local-participant': observerOptions.participant.isLocal,
       'data-lk-source': publication?.source,
-      ...(publication?.kind === 'video' ||
-      publication?.source === Track.Source.Camera ||
-      publication?.source === Track.Source.ScreenShare
-        ? { 'data-lk-orientation': orientation }
-        : {}),
+      ...(publication?.kind === 'video' && { 'data-lk-orientation': orientation }),
     }),
   };
 }

--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -82,7 +82,8 @@ export function useMediaTrackBySourceOrName(
       className,
       'data-lk-local-participant': observerOptions.participant.isLocal,
       'data-lk-source': publication?.source,
-      ...(publication?.source === Track.Source.Camera ||
+      ...(publication?.kind === 'video' ||
+      publication?.source === Track.Source.Camera ||
       publication?.source === Track.Source.ScreenShare
         ? { 'data-lk-orientation': orientation }
         : {}),


### PR DESCRIPTION
This handles cases where `source === Track.Source.Unknown` but still has `kind === 'video'` using the same logic as https://github.com/livekit/components-js/blob/main/packages/react/src/components/participant/ParticipantTile.tsx#L155