### PR TITLE
Handle track references type change in updatePages

### DIFF
--- a/.changeset/tender-walls-cross.md
+++ b/.changeset/tender-walls-cross.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-core": patch
+---
+
+Fix: Handle track reference type changes in the `updatePages` function by returning the new track reference instead of the old one.

--- a/packages/core/src/sorting/tile-array-update.test.ts
+++ b/packages/core/src/sorting/tile-array-update.test.ts
@@ -6,6 +6,7 @@ import {
   mockTrackReferenceSubscribed,
 } from '../track-reference/test-utils';
 import { divideIntoPages, swapItems, updatePages, visualPageChange } from './tile-array-update';
+import type { TrackReferenceOrPlaceholder } from '../track-reference';
 
 const stateNextExpectedString = (text: string) =>
   `${text}:\n$state \t\t<= t\n$next \t\t<= t+1\n--------\n$expected  \t<= expected result`;
@@ -340,7 +341,9 @@ describe('Test updating the list based while considering pages.', () => {
   test.each([
     {
       state: [mockTrackReferencePlaceholder('A', Track.Source.Camera)],
-      next: [mockTrackReferenceSubscribed('A', Track.Source.Camera, { mockPublication: true })],
+      next: [
+        mockTrackReferenceSubscribed('A', Track.Source.Camera, { mockPublication: true }),
+      ] as TrackReferenceOrPlaceholder[],
       expected: [mockTrackReferenceSubscribed('A', Track.Source.Camera, { mockPublication: true })],
       itemsOnPage: 1,
     },

--- a/packages/core/src/sorting/tile-array-update.test.ts
+++ b/packages/core/src/sorting/tile-array-update.test.ts
@@ -2,6 +2,7 @@ import { Track } from 'livekit-client';
 import { describe, test, expect } from 'vitest';
 import {
   flatTrackReferenceArray,
+  mockTrackReferencePlaceholder,
   mockTrackReferenceSubscribed,
 } from '../track-reference/test-utils';
 import { divideIntoPages, swapItems, updatePages, visualPageChange } from './tile-array-update';
@@ -335,4 +336,21 @@ describe('Test updating the list based while considering pages.', () => {
     expect(result).toHaveLength(next.length);
     expect(flatTrackReferenceArray(result)).toStrictEqual(flatTrackReferenceArray(expected));
   });
+
+  test.each([
+    {
+      state: [mockTrackReferencePlaceholder('A', Track.Source.Camera)],
+      next: [mockTrackReferenceSubscribed('A', Track.Source.Camera, { mockPublication: true })],
+      expected: [mockTrackReferenceSubscribed('A', Track.Source.Camera, { mockPublication: true })],
+      itemsOnPage: 1,
+    },
+  ])(
+    'Test track reference type change from `TrackReferencePlaceholder` to `TrackReference`',
+    ({ state, next, itemsOnPage, expected }) => {
+      const result = updatePages(state, next, itemsOnPage);
+      expect(result).toHaveLength(next.length);
+      expect(flatTrackReferenceArray(result)).toStrictEqual(flatTrackReferenceArray(expected));
+      expect(result[0].publication).toBeDefined();
+    },
+  );
 });

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -11,7 +11,7 @@ type VisualChanges<T> = {
 
 export type UpdatableItem = TrackReferenceOrPlaceholder | number;
 
-/** Check if something visually change on the page. */
+/** Check to see if anything visually changes on the page. */
 export function visualPageChange<T extends UpdatableItem>(state: T[], next: T[]): VisualChanges<T> {
   return {
     dropped: differenceBy(state, next, getTrackReferenceId),
@@ -78,7 +78,7 @@ export function updatePages<T extends UpdatableItem>(
   nextList: T[],
   maxItemsOnPage: number,
 ): T[] {
-  let updatedList: T[] = [...currentList];
+  let updatedList: T[] = refreshList(currentList, nextList);
 
   if (currentList.length < nextList.length) {
     // Items got added: Find newly added items and add them to the end of the list.
@@ -138,4 +138,22 @@ export function updatePages<T extends UpdatableItem>(
   }
 
   return updatedList;
+}
+
+/**
+ * Update the first list with the items from the second list whenever the ids are the same.
+ * @remarks
+ * This is needed because `TrackReference`s can change their internal state while keeping the same id.
+ */
+function refreshList<T extends UpdatableItem>(currentList: T[], nextList: T[]): T[] {
+  return currentList.map((currentItem) => {
+    const updateForCurrentItem = nextList.find(
+      (newItem_) => getTrackReferenceId(currentItem) === getTrackReferenceId(newItem_),
+    );
+    if (updateForCurrentItem) {
+      return updateForCurrentItem;
+    } else {
+      return currentItem;
+    }
+  });
 }

--- a/packages/core/src/track-reference/test-utils.test.ts
+++ b/packages/core/src/track-reference/test-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect, expectTypeOf } from 'vitest';
+import { mockTrackReferenceSubscribed } from './test-utils';
+import type { Participant, TrackPublication } from 'livekit-client';
+import { Track } from 'livekit-client';
+
+describe('Test mocking functions ', () => {
+  test('mockTrackReferenceSubscribed without options.', () => {
+    const mock = mockTrackReferenceSubscribed('MOCK_ID', Track.Source.Camera);
+    expect(mock).toBeDefined();
+    // Check if the participant is mocked correctly:
+    expect(mock.participant).toBeDefined();
+    expect(mock.participant.identity).toBe('MOCK_ID');
+    expectTypeOf(mock.participant).toMatchTypeOf<Participant>();
+
+    // Check if the publication is mocked correctly:
+    expect(mock.publication).toBeDefined();
+    expect(mock.publication.kind).toBe(Track.Kind.Video);
+    expectTypeOf(mock.publication).toMatchTypeOf<TrackPublication>();
+
+    // Check if the source is mocked correctly:
+    expect(mock.source).toBeDefined();
+    expect(mock.source).toBe(Track.Source.Camera);
+    expectTypeOf(mock.source).toMatchTypeOf<Track.Source>();
+  });
+});


### PR DESCRIPTION
This PR fixes the bug where e.g. a track reference changing from type `TrackReferencePlaceholder` to `TrackReference` was not picked up by the `updatePages` function.
Because we update based on ID, we did not pick up the change in type and stuck with the old track reference.