### PR TITLE
Move Hooks into hook dir

### DIFF
--- a/.changeset/chatty-trees-behave.md
+++ b/.changeset/chatty-trees-behave.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Move Hooks into hook dir. Expose `useFocusToggle` and `useToggleChat` hooks.

--- a/packages/core/src/helper/urlRegex.ts
+++ b/packages/core/src/helper/urlRegex.ts
@@ -24,13 +24,13 @@ import { TLDs } from 'global-tld-list';
 interface RegExOptions {
   /**
 		Only match an exact string. Useful with `RegExp#test` to check if a string is a URL.
-		@default false
+		@defaultValue false
 		*/
   readonly exact?: boolean;
 
   /**
 		Force URLs to start with a valid protocol or `www`. If set to `false` it'll match the TLD against a list of valid [TLDs](https://github.com/stephenmathieson/node-tlds).
-		@default true
+		@defaultValue true
 		*/
   readonly strict?: boolean;
 }

--- a/packages/core/src/helper/urlRegex.ts
+++ b/packages/core/src/helper/urlRegex.ts
@@ -24,13 +24,13 @@ import { TLDs } from 'global-tld-list';
 interface RegExOptions {
   /**
 		Only match an exact string. Useful with `RegExp#test` to check if a string is a URL.
-		@defaultValue false
+		@default false
 		*/
   readonly exact?: boolean;
 
   /**
 		Force URLs to start with a valid protocol or `www`. If set to `false` it'll match the TLD against a list of valid [TLDs](https://github.com/stephenmathieson/node-tlds).
-		@defaultValue true
+		@default true
 		*/
   readonly strict?: boolean;
 }

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -483,6 +483,22 @@ export function useChat(): {
 };
 
 // @public (undocumented)
+export function useChatToggle({ props }: UseChatToggleProps): {
+    mergedProps: React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
+        className: string;
+        onClick: () => void;
+        'aria-pressed': string;
+        'data-lk-unread-msgs': string;
+    };
+};
+
+// @public (undocumented)
+export interface UseChatToggleProps {
+    // (undocumented)
+    props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
+}
+
+// @public (undocumented)
 export function useClearPinButton(props: ClearPinButtonProps): {
     buttonProps: ClearPinButtonProps & {
         className: string;
@@ -823,22 +839,6 @@ export type UseSwipeOptions = {
     onLeftSwipe?: () => void;
     onRightSwipe?: () => void;
 };
-
-// @public (undocumented)
-export function useToggleChat({ props }: UseToggleChatProps): {
-    mergedProps: React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
-        className: string;
-        onClick: () => void;
-        'aria-pressed': string;
-        'data-lk-unread-msgs': string;
-    };
-};
-
-// @public (undocumented)
-export interface UseToggleChatProps {
-    // (undocumented)
-    props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
-}
 
 // @public (undocumented)
 export function useToken(tokenEndpoint: string | undefined, roomName: string, options?: UseTokenOptions): string | undefined;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -8,7 +8,7 @@
 
 import type { AudioCaptureOptions } from 'livekit-client';
 import type { AudioSource } from '@livekit/components-core';
-import type { CaptureOptionsBySource } from '@livekit/components-core';
+import { CaptureOptionsBySource } from '@livekit/components-core';
 import type { ChatMessage } from '@livekit/components-core';
 import { ConnectionQuality } from 'livekit-client';
 import { ConnectionState as ConnectionState_2 } from 'livekit-client';
@@ -21,7 +21,7 @@ import { LocalParticipant } from 'livekit-client';
 import type { LocalTrack } from 'livekit-client';
 import { LocalTrackPublication } from 'livekit-client';
 import type { LocalVideoTrack } from 'livekit-client';
-import { MediaDeviceFailure } from 'livekit-client';
+import type { MediaDeviceFailure } from 'livekit-client';
 import { Participant } from 'livekit-client';
 import type { ParticipantClickEvent } from '@livekit/components-core';
 import type { ParticipantEvent } from 'livekit-client';
@@ -484,12 +484,16 @@ export function useChat(): {
 
 // @public (undocumented)
 export function useClearPinButton(props: ClearPinButtonProps): {
-    buttonProps: React_2.HTMLAttributes<HTMLElement>;
+    buttonProps: ClearPinButtonProps & {
+        className: string;
+        disabled: boolean;
+        onClick: () => void;
+    };
 };
 
 // @public (undocumented)
 export function useConnectionQualityIndicator(options?: ConnectionQualityIndicatorOptions): {
-    className: "lk-list" | "lk-button" | "lk-rotate" | "lk-audio-conference" | "lk-audio-conference-stage" | "lk-audio-container" | "lk-button-group" | "lk-button-group-container" | "lk-camera-off-note" | "lk-chat" | "lk-chat-entry" | "lk-chat-form" | "lk-chat-form-input" | "lk-chat-messages" | "lk-control-bar" | "lk-focus-layout-wrapper" | "lk-form-control" | "lk-grid-layout-wrapper" | "lk-join-button" | "lk-message-body" | "lk-meta-data" | "lk-participant-name" | "lk-prejoin" | "lk-timestamp" | "lk-username-container" | "lk-video-conference" | "lk-video-conference-inner" | "lk-video-container" | "lk-audio-visualizer" | "lk-button-group-menu" | "lk-button-menu" | "lk-carousel" | "lk-chat-toggle" | "lk-connection-quality" | "lk-device-menu" | "lk-device-menu-heading" | "lk-disconnect-button" | "lk-focus-layout" | "lk-focus-toggle-button" | "lk-focused-participant" | "lk-grid-layout" | "lk-media-device-select" | "lk-pagination-control" | "lk-pagination-count" | "lk-pagination-indicator" | "lk-participant-media-audio" | "lk-participant-media-video" | "lk-participant-metadata" | "lk-participant-metadata-item" | "lk-participant-placeholder" | "lk-participant-tile" | "lk-pip-track" | "lk-room-container" | "lk-spinner" | "lk-start-audio-button" | "lk-toast" | "lk-track-muted-indicator-camera" | "lk-track-muted-indicator-microphone";
+    className: "lk-rotate" | "lk-audio-conference" | "lk-audio-conference-stage" | "lk-audio-container" | "lk-button" | "lk-button-group" | "lk-button-group-container" | "lk-camera-off-note" | "lk-chat" | "lk-chat-entry" | "lk-chat-form" | "lk-chat-form-input" | "lk-chat-messages" | "lk-control-bar" | "lk-focus-layout-wrapper" | "lk-form-control" | "lk-grid-layout-wrapper" | "lk-join-button" | "lk-list" | "lk-message-body" | "lk-meta-data" | "lk-participant-name" | "lk-prejoin" | "lk-timestamp" | "lk-username-container" | "lk-video-conference" | "lk-video-conference-inner" | "lk-video-container" | "lk-audio-visualizer" | "lk-button-group-menu" | "lk-button-menu" | "lk-carousel" | "lk-chat-toggle" | "lk-connection-quality" | "lk-device-menu" | "lk-device-menu-heading" | "lk-disconnect-button" | "lk-focus-layout" | "lk-focus-toggle-button" | "lk-focused-participant" | "lk-grid-layout" | "lk-media-device-select" | "lk-pagination-control" | "lk-pagination-count" | "lk-pagination-indicator" | "lk-participant-media-audio" | "lk-participant-media-video" | "lk-participant-metadata" | "lk-participant-metadata-item" | "lk-participant-placeholder" | "lk-participant-tile" | "lk-pip-track" | "lk-room-container" | "lk-spinner" | "lk-start-audio-button" | "lk-toast" | "lk-track-muted-indicator-camera" | "lk-track-muted-indicator-microphone";
     quality: ConnectionQuality;
 };
 
@@ -509,7 +513,11 @@ export function useDataChannel(onMessage?: (msg: ReceivedDataMessage) => void): 
 
 // @public (undocumented)
 export function useDisconnectButton(props: DisconnectButtonProps): {
-    buttonProps: React_2.HTMLAttributes<HTMLElement>;
+    buttonProps: DisconnectButtonProps & {
+        className: string;
+        onClick: () => void;
+        disabled: boolean;
+    };
 };
 
 // @public (undocumented)
@@ -529,6 +537,25 @@ export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder): Tr
 
 // @alpha
 export function useFacingMode(trackReference: TrackReferenceOrPlaceholder): 'user' | 'environment' | 'left' | 'right' | 'undefined';
+
+// @public (undocumented)
+export function useFocusToggle({ trackSource, participant, props }: UseFocusToggleProps): {
+    mergedProps: React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
+        className: string;
+        onClick: (event: React_2.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    };
+    inFocus: boolean;
+};
+
+// @public (undocumented)
+export interface UseFocusToggleProps {
+    // (undocumented)
+    participant?: Participant;
+    // (undocumented)
+    props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
+    // (undocumented)
+    trackSource: Track.Source;
+}
 
 // @public
 export function useGridLayout(
@@ -553,9 +580,9 @@ export function useIsSpeaking(participant?: Participant): boolean;
 export function useLayoutContext(): LayoutContextType;
 
 // @public (undocumented)
-export function useLiveKitRoom(props: LiveKitRoomProps): {
+export function useLiveKitRoom<T extends HTMLElement>(props: LiveKitRoomProps): {
     room: Room | undefined;
-    htmlProps: React_2.HTMLAttributes<HTMLElement>;
+    htmlProps: HTMLAttributes<T>;
 };
 
 // @public
@@ -618,7 +645,7 @@ export function useMediaTrack(source: VideoSource | AudioSource, participant?: P
     isMuted: boolean | undefined;
     isSubscribed: boolean | undefined;
     track: Track | undefined;
-    elementProps: HTMLAttributes<HTMLElement>;
+    elementProps: React_2.HTMLAttributes<HTMLElement>;
 };
 
 // @public (undocumented)
@@ -633,9 +660,9 @@ export function useMediaTrackByName(name: string, participant?: Participant, opt
 // @public (undocumented)
 export interface UseMediaTrackOptions {
     // (undocumented)
-    element?: React.RefObject<HTMLMediaElement>;
+    element?: React_2.RefObject<HTMLMediaElement>;
     // (undocumented)
-    props?: React.HTMLAttributes<HTMLVideoElement | HTMLAudioElement>;
+    props?: React_2.HTMLAttributes<HTMLVideoElement | HTMLAudioElement>;
 }
 
 // @alpha
@@ -661,9 +688,10 @@ export function useParticipantInfo(props?: UseParticipantInfoOptions): {
 };
 
 // @public (undocumented)
-export type UseParticipantInfoOptions = {
+export interface UseParticipantInfoOptions {
+    // (undocumented)
     participant?: Participant;
-};
+}
 
 // @public (undocumented)
 export function useParticipantPermissions(options?: UseParticipantPermissionsOptions): ParticipantPermission | undefined;
@@ -685,7 +713,7 @@ export interface UseParticipantsOptions {
 
 // @public (undocumented)
 export function useParticipantTile<T extends HTMLElement>({ participant, source, publication, onParticipantClick, disableSpeakingIndicator, htmlProps, }: UseParticipantTileProps<T>): {
-    elementProps: React_2.HTMLAttributes<HTMLDivElement>;
+    elementProps: React_2.HTMLAttributes<T>;
 };
 
 // @public (undocumented)
@@ -768,7 +796,13 @@ export function useSpeakingParticipants(): Participant[];
 
 // @alpha
 export function useStartAudio({ room, props }: UseStartAudioProps): {
-    mergedProps: React_2.HTMLAttributes<HTMLElement>;
+    mergedProps: React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
+        className: string;
+        onClick: () => void;
+        style: {
+            display: string;
+        };
+    };
     canPlayAudio: boolean;
 };
 
@@ -789,6 +823,22 @@ export type UseSwipeOptions = {
     onLeftSwipe?: () => void;
     onRightSwipe?: () => void;
 };
+
+// @public (undocumented)
+export function useToggleChat({ props }: UseToggleChatProps): {
+    mergedProps: React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
+        className: string;
+        onClick: () => void;
+        'aria-pressed': string;
+        'data-lk-unread-msgs': string;
+    };
+};
+
+// @public (undocumented)
+export interface UseToggleChatProps {
+    // (undocumented)
+    props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
+}
 
 // @public (undocumented)
 export function useToken(tokenEndpoint: string | undefined, roomName: string, options?: UseTokenOptions): string | undefined;

--- a/packages/react/src/components/ConnectionState.tsx
+++ b/packages/react/src/components/ConnectionState.tsx
@@ -1,8 +1,6 @@
-import { connectionStateObserver } from '@livekit/components-core';
 import type { Room } from 'livekit-client';
 import * as React from 'react';
-import { useEnsureRoom } from '../context';
-import { useObservableState } from '../hooks/internal/useObservableState';
+import { useConnectionState } from '../hooks';
 
 /** @public */
 export interface ConnectionStatusProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -10,23 +8,6 @@ export interface ConnectionStatusProps extends React.HTMLAttributes<HTMLDivEleme
    * The room from which the connection status should be displayed.
    */
   room?: Room;
-}
-
-/**
- * The `useConnectionState` hook allows you to simply implement your own `ConnectionState` component.
- *
- * @example
- * ```tsx
- * const connectionState = useConnectionState(room);
- * ```
- * @public
- */
-export function useConnectionState(room?: Room) {
-  // passed room takes precedence, if not supplied get current room context
-  const r = useEnsureRoom(room);
-  const observable = React.useMemo(() => connectionStateObserver(r), [r]);
-  const connectionState = useObservableState(observable, r.state);
-  return connectionState;
 }
 
 /**

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -1,4 +1,3 @@
-import { log, setupLiveKitRoom } from '@livekit/components-core';
 import type {
   AudioCaptureOptions,
   RoomConnectOptions,
@@ -6,10 +5,10 @@ import type {
   ScreenShareCaptureOptions,
   VideoCaptureOptions,
 } from 'livekit-client';
-import { ConnectionState, MediaDeviceFailure, Room, RoomEvent } from 'livekit-client';
+import type { MediaDeviceFailure, Room } from 'livekit-client';
 import * as React from 'react';
 import { RoomContext } from '../context';
-import { mergeProps } from '../utils';
+import { useLiveKitRoom } from '../hooks';
 
 /** @public */
 export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onError'> {
@@ -84,150 +83,6 @@ export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivEleme
 //   participants: Participant[];
 //   audioTracks: AudioTrack[];
 // };
-
-const defaultRoomProps: Partial<LiveKitRoomProps> = {
-  connect: true,
-  audio: false,
-  video: false,
-};
-
-/** @public */
-export function useLiveKitRoom(props: LiveKitRoomProps) {
-  const {
-    token,
-    serverUrl,
-    options,
-    room: passedRoom,
-    connectOptions,
-    connect,
-    audio,
-    video,
-    screen,
-    onConnected,
-    onDisconnected,
-    onError,
-    onMediaDeviceFailure,
-    simulateParticipants,
-    ...rest
-  } = { ...defaultRoomProps, ...props };
-  if (options && passedRoom) {
-    log.warn(
-      'when using a manually created room, the options object will be ignored. set the desired options directly when creating the room instead.',
-    );
-  }
-
-  const [room, setRoom] = React.useState<Room | undefined>();
-
-  React.useEffect(() => {
-    setRoom(passedRoom ?? new Room(options));
-  }, [JSON.stringify(options), passedRoom]);
-
-  const htmlProps = React.useMemo(() => mergeProps(rest, setupLiveKitRoom()), [rest]);
-
-  React.useEffect(() => {
-    if (!room) return;
-    const onSignalConnected = () => {
-      const localP = room.localParticipant;
-
-      log.debug('trying to publish local tracks');
-      Promise.all([
-        localP.setMicrophoneEnabled(!!audio, typeof audio !== 'boolean' ? audio : undefined),
-        localP.setCameraEnabled(!!video, typeof video !== 'boolean' ? video : undefined),
-        localP.setScreenShareEnabled(!!screen, typeof screen !== 'boolean' ? screen : undefined),
-      ]).catch((e) => {
-        log.warn(e);
-        onError?.(e as Error);
-      });
-    };
-
-    const onMediaDeviceError = (e: Error) => {
-      const mediaDeviceFailure = MediaDeviceFailure.getFailure(e);
-      onMediaDeviceFailure?.(mediaDeviceFailure);
-    };
-    room.on(RoomEvent.SignalConnected, onSignalConnected);
-    room.on(RoomEvent.MediaDevicesError, onMediaDeviceError);
-
-    return () => {
-      room.off(RoomEvent.SignalConnected, onSignalConnected);
-      room.off(RoomEvent.MediaDevicesError, onMediaDeviceError);
-    };
-  }, [room, audio, video, screen, onError]);
-
-  React.useEffect(() => {
-    if (!room) return;
-
-    if (simulateParticipants) {
-      room.simulateParticipants({
-        participants: {
-          count: simulateParticipants,
-        },
-        publish: {
-          audio: true,
-          useRealTracks: true,
-        },
-      });
-      return;
-    }
-    if (!token) {
-      log.debug('no token yet');
-      return;
-    }
-    if (!serverUrl) {
-      log.warn('no livekit url provided');
-      onError?.(Error('no livekit url provided'));
-      return;
-    }
-    if (connect) {
-      log.debug('connecting');
-      room.connect(serverUrl, token, connectOptions).catch((e) => {
-        log.warn(e);
-        onError?.(e as Error);
-      });
-    } else {
-      log.debug('disconnecting because connect is false');
-      room.disconnect();
-    }
-  }, [
-    connect,
-    token,
-    JSON.stringify(connectOptions),
-    room,
-    onError,
-    serverUrl,
-    simulateParticipants,
-  ]);
-
-  React.useEffect(() => {
-    if (!room) return;
-    const connectionStateChangeListener = (state: ConnectionState) => {
-      switch (state) {
-        case ConnectionState.Disconnected:
-          if (onDisconnected) onDisconnected();
-          break;
-        case ConnectionState.Connected:
-          if (onConnected) onConnected();
-          break;
-
-        default:
-          break;
-      }
-    };
-    room.on(RoomEvent.ConnectionStateChanged, connectionStateChangeListener);
-    return () => {
-      room.off(RoomEvent.ConnectionStateChanged, connectionStateChangeListener);
-    };
-  }, [token, onConnected, onDisconnected, room]);
-
-  React.useEffect(() => {
-    if (!room) return;
-    return () => {
-      log.info('disconnecting on onmount');
-      room.disconnect();
-    };
-  }, [room]);
-
-  return { room, htmlProps };
-}
 
 /**
  * The LiveKitRoom component provides the room context to all its child components.

--- a/packages/react/src/components/RoomName.tsx
+++ b/packages/react/src/components/RoomName.tsx
@@ -1,26 +1,5 @@
-import { roomInfoObserver } from '@livekit/components-core';
-import type { Room } from 'livekit-client';
 import * as React from 'react';
-
-import { useEnsureRoom } from '../context';
-import { useObservableState } from '../hooks/internal/useObservableState';
-
-/** @public */
-export interface UseRoomInfoOptions {
-  room?: Room;
-}
-
-/** @public */
-export function useRoomInfo(options: UseRoomInfoOptions = {}) {
-  const room = useEnsureRoom(options.room);
-  const infoObserver = React.useMemo(() => roomInfoObserver(room), [room]);
-  const { name, metadata } = useObservableState(infoObserver, {
-    name: room.name,
-    metadata: room.metadata,
-  });
-
-  return { name, metadata };
-}
+import { useRoomInfo } from '../hooks';
 
 /** @public */
 export interface RoomNameProps extends React.HTMLAttributes<HTMLSpanElement> {

--- a/packages/react/src/components/Toast.tsx
+++ b/packages/react/src/components/Toast.tsx
@@ -3,7 +3,7 @@ import { ConnectionState } from 'livekit-client';
 import * as React from 'react';
 import { SpinnerIcon } from '../assets/icons';
 import { mergeProps } from '../utils';
-import { useConnectionState } from './ConnectionState';
+import { useConnectionState } from '../hooks';
 
 /** @public */
 export function Toast(props: React.HTMLAttributes<HTMLDivElement>) {

--- a/packages/react/src/components/controls/ChatToggle.tsx
+++ b/packages/react/src/components/controls/ChatToggle.tsx
@@ -1,33 +1,5 @@
-import { setupChatToggle } from '@livekit/components-core';
 import * as React from 'react';
-import { useLayoutContext } from '../../context';
-import { mergeProps } from '../../utils';
-
-interface UseToggleChatProps {
-  props: React.ButtonHTMLAttributes<HTMLButtonElement>;
-}
-
-function useToggleChat({ props }: UseToggleChatProps) {
-  const { dispatch, state } = useLayoutContext().widget;
-  const { className } = React.useMemo(() => setupChatToggle(), []);
-
-  const mergedProps = React.useMemo(() => {
-    return mergeProps(props, {
-      className,
-      onClick: () => {
-        if (dispatch) dispatch({ msg: 'toggle_chat' });
-      },
-      'aria-pressed': state?.showChat ? 'true' : 'false',
-      'data-lk-unread-msgs': state
-        ? state.unreadMessages < 10
-          ? state.unreadMessages.toFixed(0)
-          : '9+'
-        : 0,
-    });
-  }, [props, className, dispatch, state]);
-
-  return { mergedProps };
-}
+import { useToggleChat } from '../../hooks';
 
 /** @public */
 export interface ChatToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}

--- a/packages/react/src/components/controls/ChatToggle.tsx
+++ b/packages/react/src/components/controls/ChatToggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useToggleChat } from '../../hooks';
+import { useChatToggle } from '../../hooks';
 
 /** @public */
 export interface ChatToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
@@ -16,7 +16,7 @@ export interface ChatToggleProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * @public
  */
 export function ChatToggle(props: ChatToggleProps) {
-  const { mergedProps } = useToggleChat({ props });
+  const { mergedProps } = useChatToggle({ props });
 
   return <button {...mergedProps}>{props.children}</button>;
 }

--- a/packages/react/src/components/controls/ClearPinButton.tsx
+++ b/packages/react/src/components/controls/ClearPinButton.tsx
@@ -1,29 +1,8 @@
-import { setupClearPinButton } from '@livekit/components-core';
 import * as React from 'react';
-import { mergeProps } from '../../utils';
-import { useLayoutContext } from '../../context';
+import { useClearPinButton } from '../../hooks';
 
 /** @public */
 export interface ClearPinButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
-
-/** @public */
-export function useClearPinButton(props: ClearPinButtonProps) {
-  const { state, dispatch } = useLayoutContext().pin;
-
-  const buttonProps = React.useMemo(() => {
-    const { className } = setupClearPinButton();
-    const mergedProps = mergeProps(props, {
-      className,
-      disabled: !state?.length,
-      onClick: () => {
-        if (dispatch) dispatch({ msg: 'clear_pin' });
-      },
-    });
-    return mergedProps;
-  }, [props, dispatch, state]);
-
-  return { buttonProps };
-}
 
 /**
  * The ClearPinButton is a basic html button with the added ability to signal

--- a/packages/react/src/components/controls/DisconnectButton.tsx
+++ b/packages/react/src/components/controls/DisconnectButton.tsx
@@ -1,31 +1,9 @@
-import { ConnectionState } from 'livekit-client';
-import { setupDisconnectButton } from '@livekit/components-core';
 import * as React from 'react';
-import { useRoomContext } from '../../context';
-import { mergeProps } from '../../utils';
-import { useConnectionState } from '../../hooks';
+import { useDisconnectButton } from '../../hooks';
 
 /** @public */
 export interface DisconnectButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   stopTracks?: boolean;
-}
-
-/** @public */
-export function useDisconnectButton(props: DisconnectButtonProps) {
-  const room = useRoomContext();
-  const connectionState = useConnectionState(room);
-
-  const buttonProps = React.useMemo(() => {
-    const { className, disconnect } = setupDisconnectButton(room);
-    const mergedProps = mergeProps(props, {
-      className,
-      onClick: () => disconnect(props.stopTracks ?? true),
-      disabled: connectionState === ConnectionState.Disconnected,
-    });
-    return mergedProps;
-  }, [room, props, connectionState]);
-
-  return { buttonProps };
 }
 
 /**

--- a/packages/react/src/components/controls/DisconnectButton.tsx
+++ b/packages/react/src/components/controls/DisconnectButton.tsx
@@ -2,8 +2,8 @@ import { ConnectionState } from 'livekit-client';
 import { setupDisconnectButton } from '@livekit/components-core';
 import * as React from 'react';
 import { useRoomContext } from '../../context';
-import { useConnectionState } from '../ConnectionState';
 import { mergeProps } from '../../utils';
+import { useConnectionState } from '../../hooks';
 
 /** @public */
 export interface DisconnectButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -1,66 +1,9 @@
-import { isTrackReferencePinned, setupFocusToggle } from '@livekit/components-core';
 import type { Participant, Track } from 'livekit-client';
 import * as React from 'react';
-import { LayoutContext, useEnsureParticipant, useMaybeLayoutContext } from '../../context';
+import { LayoutContext } from '../../context';
 import { FocusToggleIcon, UnfocusToggleIcon } from '../../assets/icons';
-import { mergeProps } from '../../utils';
+import { useFocusToggle } from '../../hooks';
 
-interface useFocusToggleProps {
-  props: React.ButtonHTMLAttributes<HTMLButtonElement>;
-  trackSource: Track.Source;
-  participant?: Participant;
-}
-
-function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps) {
-  const p = useEnsureParticipant(participant);
-  const layoutContext = useMaybeLayoutContext();
-  const { className } = React.useMemo(() => setupFocusToggle(), []);
-
-  const inFocus: boolean = React.useMemo(() => {
-    const track = p.getTrack(trackSource);
-    if (layoutContext?.pin.state && track) {
-      return isTrackReferencePinned(
-        { participant: p, source: trackSource, publication: track },
-        layoutContext.pin.state,
-      );
-    } else {
-      return false;
-    }
-  }, [p, trackSource, layoutContext]);
-
-  const mergedProps = React.useMemo(
-    () =>
-      mergeProps(props, {
-        className,
-        onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-          // Call user defined on click callbacks.
-          props.onClick?.(event);
-
-          // Set or clear focus based on current focus state.
-          const track = p.getTrack(trackSource);
-          if (layoutContext?.pin.dispatch && track) {
-            if (inFocus) {
-              layoutContext.pin.dispatch({
-                msg: 'clear_pin',
-              });
-            } else {
-              layoutContext.pin.dispatch({
-                msg: 'set_pin',
-                trackReference: {
-                  participant: p,
-                  publication: track,
-                  source: track.source,
-                },
-              });
-            }
-          }
-        },
-      }),
-    [props, className, p, trackSource, inFocus, layoutContext],
-  );
-
-  return { mergedProps, inFocus };
-}
 /** @public */
 export interface FocusToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   trackSource: Track.Source;

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -1,67 +1,8 @@
 import * as React from 'react';
 import { useMaybeRoomContext } from '../../context';
-import { setupDeviceSelector, createMediaDeviceObserver, log } from '@livekit/components-core';
 import { mergeProps } from '../../utils';
-import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
-import { useObservableState } from '../../hooks/internal/useObservableState';
-
-/** @public */
-export function useMediaDevices({ kind }: { kind: MediaDeviceKind }) {
-  const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);
-  const devices = useObservableState(deviceObserver, []);
-  return devices;
-}
-
-/** @public */
-export interface UseMediaDeviceSelectProps {
-  kind: MediaDeviceKind;
-  room?: Room;
-  track?: LocalAudioTrack | LocalVideoTrack;
-  /**
-   * this will call getUserMedia if the permissions are not yet given to enumerate the devices with device labels.
-   * in some browsers multiple calls to getUserMedia result in multiple permission prompts.
-   * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
-   * appropriate permissions.
-   *
-   * @see {@link MediaDeviceMenu}
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices | MDN enumerateDevices}
-   */
-  requestPermissions?: boolean;
-}
-
-/** @public */
-export function useMediaDeviceSelect({
-  kind,
-  room,
-  track,
-  requestPermissions,
-}: UseMediaDeviceSelectProps) {
-  const roomContext = useMaybeRoomContext();
-  // List of all devices.
-  const deviceObserver = React.useMemo(
-    () => createMediaDeviceObserver(kind, requestPermissions),
-    [kind, requestPermissions],
-  );
-  const devices = useObservableState(deviceObserver, []);
-  // Active device management.
-  const [currentDeviceId, setCurrentDeviceId] = React.useState<string>('');
-  const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
-    () => setupDeviceSelector(kind, room ?? roomContext, track),
-    [kind, room, roomContext, track],
-  );
-
-  React.useEffect(() => {
-    const listener = activeDeviceObservable.subscribe((deviceId) => {
-      log.info('setCurrentDeviceId', deviceId);
-      if (deviceId) setCurrentDeviceId(deviceId);
-    });
-    return () => {
-      listener?.unsubscribe();
-    };
-  }, [activeDeviceObservable]);
-
-  return { devices, className, activeDeviceId: currentDeviceId, setActiveMediaDevice };
-}
+import type { LocalAudioTrack, LocalVideoTrack } from 'livekit-client';
+import { useMediaDeviceSelect } from '../../hooks';
 
 /** @public */
 export interface MediaDeviceSelectProps extends React.HTMLAttributes<HTMLUListElement> {

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -1,51 +1,6 @@
-import { setupStartAudio } from '@livekit/components-core';
-import type { Room } from 'livekit-client';
 import * as React from 'react';
-import { useEnsureRoom, useRoomContext } from '../../context';
-import { useObservableState } from '../../hooks/internal/useObservableState';
-import { mergeProps } from '../../utils';
-
-/** @alpha */
-export interface UseStartAudioProps {
-  room?: Room;
-  props: React.ButtonHTMLAttributes<HTMLButtonElement>;
-}
-
-/**
- * In many browsers to start audio playback, the user must perform a user-initiated event such as clicking a button.
- * The `useStatAudio` hook returns an object with a boolean `canPlayAudio` flag
- * that indicates whether audio playback is allowed in the current context,
- * as well as a `startAudio` function that can be called in a button `onClick` callback to start audio playback in the current context.
- *
- * @see Autoplay policy on MDN web docs for more info: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
- * @alpha
- */
-export function useStartAudio({ room, props }: UseStartAudioProps) {
-  const roomEnsured = useEnsureRoom(room);
-  const { className, roomAudioPlaybackAllowedObservable, handleStartAudioPlayback } = React.useMemo(
-    () => setupStartAudio(),
-    [],
-  );
-  const observable = React.useMemo(
-    () => roomAudioPlaybackAllowedObservable(roomEnsured),
-    [roomEnsured, roomAudioPlaybackAllowedObservable],
-  );
-  const { canPlayAudio } = useObservableState(observable, { canPlayAudio: false });
-
-  const mergedProps = React.useMemo(
-    () =>
-      mergeProps(props, {
-        className,
-        onClick: () => {
-          handleStartAudioPlayback(roomEnsured);
-        },
-        style: { display: canPlayAudio ? 'none' : 'block' },
-      }),
-    [props, className, canPlayAudio, handleStartAudioPlayback, roomEnsured],
-  );
-
-  return { mergedProps, canPlayAudio };
-}
+import { useRoomContext } from '../../context';
+import { useStartAudio } from '../../hooks';
 
 /** @public */
 export interface AllowAudioPlaybackProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -1,10 +1,7 @@
 import type { CaptureOptionsBySource, ToggleSource } from '@livekit/components-core';
-import { log, setupManualToggle, setupMediaToggle } from '@livekit/components-core';
 import * as React from 'react';
-import { mergeProps } from '../../mergeProps';
-import { useMaybeRoomContext } from '../../context';
 import { getSourceIcon } from '../../assets/icons/util';
-import { useObservableState } from '../../hooks/internal/useObservableState';
+import { useTrackToggle } from '../../hooks';
 
 /** @public */
 export interface TrackToggleProps<T extends ToggleSource>
@@ -14,68 +11,6 @@ export interface TrackToggleProps<T extends ToggleSource>
   initialState?: boolean;
   onChange?: (enabled: boolean) => void;
   captureOptions?: CaptureOptionsBySource<T>;
-}
-
-/** @public */
-export interface UseTrackToggleProps<T extends ToggleSource>
-  extends Omit<TrackToggleProps<T>, 'showIcon'> {}
-
-/** @public */
-export function useTrackToggle<T extends ToggleSource>({
-  source,
-  onChange,
-  initialState,
-  captureOptions,
-  ...rest
-}: UseTrackToggleProps<T>) {
-  const room = useMaybeRoomContext();
-  const track = room?.localParticipant?.getTrack(source);
-
-  const { toggle, className, pendingObserver, enabledObserver } = React.useMemo(
-    () => (room ? setupMediaToggle<T>(source, room, captureOptions) : setupManualToggle()),
-    [room, source, JSON.stringify(captureOptions)],
-  );
-
-  const pending = useObservableState(pendingObserver, false);
-  const enabled = useObservableState(enabledObserver, initialState ?? !!track?.isEnabled);
-
-  React.useEffect(() => {
-    onChange?.(enabled);
-  }, [enabled, onChange]);
-
-  React.useEffect(() => {
-    if (initialState !== undefined) {
-      log.debug('forcing initial toggle state', source, initialState);
-      toggle(initialState);
-    }
-    // only execute once at the beginning
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const newProps = React.useMemo(() => mergeProps(rest, { className }), [rest, className]);
-
-  const clickHandler: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
-    (evt) => {
-      toggle();
-      rest.onClick?.(evt);
-    },
-    [rest, toggle],
-  );
-
-  return {
-    toggle,
-    enabled,
-    pending,
-    track,
-    buttonProps: {
-      ...newProps,
-      'aria-pressed': enabled,
-      'data-lk-source': source,
-      'data-lk-enabled': enabled,
-      disabled: pending,
-      onClick: clickHandler,
-    } as React.ButtonHTMLAttributes<HTMLButtonElement>,
-  };
 }
 
 /**

--- a/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
+++ b/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
@@ -1,35 +1,13 @@
 import * as React from 'react';
-import { setupConnectionQualityIndicator } from '@livekit/components-core';
-import { useEnsureParticipant } from '../../context';
-import type { Participant } from 'livekit-client';
-import { ConnectionQuality } from 'livekit-client';
 import { mergeProps } from '../../utils';
 import { getConnectionQualityIcon } from '../../assets/icons/util';
-import { useObservableState } from '../../hooks/internal/useObservableState';
-
-/** @public */
-export interface ConnectionQualityIndicatorOptions {
-  participant?: Participant;
-}
+import type { ConnectionQualityIndicatorOptions } from '../../hooks';
+import { useConnectionQualityIndicator } from '../../hooks';
 
 /** @public */
 export interface ConnectionQualityIndicatorProps
   extends React.HTMLAttributes<HTMLDivElement>,
     ConnectionQualityIndicatorOptions {}
-
-/** @public */
-export function useConnectionQualityIndicator(options: ConnectionQualityIndicatorOptions = {}) {
-  const p = useEnsureParticipant(options.participant);
-
-  const { className, connectionQualityObserver } = React.useMemo(
-    () => setupConnectionQualityIndicator(p),
-    [p],
-  );
-
-  const quality = useObservableState(connectionQualityObserver, ConnectionQuality.Unknown);
-
-  return { className, quality };
-}
 
 /**
  * The ConnectionQualityIndicator shows the individual connection quality of a participant.

--- a/packages/react/src/components/participant/ParticipantAudioTile.tsx
+++ b/packages/react/src/components/participant/ParticipantAudioTile.tsx
@@ -8,8 +8,9 @@ import { useEnsureParticipant } from '../../context';
 
 import { AudioVisualizer } from './AudioVisualizer';
 import type { ParticipantTileProps } from './ParticipantTile';
-import { useParticipantTile, ParticipantContextIfNeeded } from './ParticipantTile';
+import { ParticipantContextIfNeeded } from './ParticipantTile';
 import { AudioTrack } from './AudioTrack';
+import { useParticipantTile } from '../../hooks';
 
 /**
  * The ParticipantAudioTile component is the base utility wrapper for displaying a visual representation of a participant.

--- a/packages/react/src/components/participant/ParticipantName.tsx
+++ b/packages/react/src/components/participant/ParticipantName.tsx
@@ -1,27 +1,9 @@
-import { participantInfoObserver, setupParticipantName } from '@livekit/components-core';
-import type { Participant } from 'livekit-client';
+import { setupParticipantName } from '@livekit/components-core';
 import * as React from 'react';
 import { useEnsureParticipant } from '../../context';
 import { useObservableState } from '../../hooks/internal/useObservableState';
 import { mergeProps } from '../../utils';
-
-/** @public */
-export function useParticipantInfo(props: UseParticipantInfoOptions = {}) {
-  const p = useEnsureParticipant(props.participant);
-  const infoObserver = React.useMemo(() => participantInfoObserver(p), [p]);
-  const { identity, name, metadata } = useObservableState(infoObserver, {
-    name: p.name,
-    identity: p.identity,
-    metadata: p.metadata,
-  });
-
-  return { identity, name, metadata };
-}
-
-/** @public */
-export type UseParticipantInfoOptions = {
-  participant?: Participant;
-};
+import type { UseParticipantInfoOptions } from '../../hooks';
 
 /** @public */
 export interface ParticipantNameProps

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -2,84 +2,23 @@ import * as React from 'react';
 import type { Participant, TrackPublication } from 'livekit-client';
 import { Track } from 'livekit-client';
 import type { ParticipantClickEvent, TrackReferenceOrPlaceholder } from '@livekit/components-core';
-import { isParticipantSourcePinned, setupParticipantTile } from '@livekit/components-core';
+import { isParticipantSourcePinned } from '@livekit/components-core';
 import { ConnectionQualityIndicator } from './ConnectionQualityIndicator';
 import { ParticipantName } from './ParticipantName';
 import { TrackMutedIndicator } from './TrackMutedIndicator';
 import {
-  useMaybeParticipantContext,
   ParticipantContext,
   useEnsureParticipant,
   useMaybeLayoutContext,
+  useMaybeParticipantContext,
   useMaybeTrackContext,
 } from '../../context';
-import { useFacingMode, useIsMuted, useIsSpeaking } from '../../hooks';
-import { mergeProps } from '../../utils';
 import { FocusToggle } from '../controls/FocusToggle';
 import { ParticipantPlaceholder } from '../../assets/images';
 import { ScreenShareIcon } from '../../assets/icons';
 import { VideoTrack } from './VideoTrack';
 import { AudioTrack } from './AudioTrack';
-
-/** @public */
-export interface ParticipantTileProps extends React.HTMLAttributes<HTMLDivElement> {
-  disableSpeakingIndicator?: boolean;
-  participant?: Participant;
-  source?: Track.Source;
-  publication?: TrackPublication;
-  onParticipantClick?: (event: ParticipantClickEvent) => void;
-}
-
-/** @public */
-export interface UseParticipantTileProps<T extends HTMLElement> extends React.HTMLAttributes<T> {
-  disableSpeakingIndicator?: boolean;
-  publication?: TrackPublication;
-  onParticipantClick?: (event: ParticipantClickEvent) => void;
-  htmlProps: React.HTMLAttributes<T>;
-  source: Track.Source;
-  participant: Participant;
-}
-
-/** @public */
-export function useParticipantTile<T extends HTMLElement>({
-  participant,
-  source,
-  publication,
-  onParticipantClick,
-  disableSpeakingIndicator,
-  htmlProps,
-}: UseParticipantTileProps<T>) {
-  const p = useEnsureParticipant(participant);
-  const mergedProps = React.useMemo(() => {
-    const { className } = setupParticipantTile();
-    return mergeProps(htmlProps, {
-      className,
-      onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-        // @ts-ignore
-        htmlProps.onClick?.(event);
-        if (typeof onParticipantClick === 'function') {
-          const track = publication ?? p.getTrack(source);
-          onParticipantClick({ participant: p, track });
-        }
-      },
-    });
-  }, [htmlProps, source, onParticipantClick, p, publication]);
-  const isVideoMuted = useIsMuted(Track.Source.Camera, { participant });
-  const isAudioMuted = useIsMuted(Track.Source.Microphone, { participant });
-  const isSpeaking = useIsSpeaking(participant);
-  const facingMode = useFacingMode({ participant, publication, source });
-  return {
-    elementProps: {
-      'data-lk-audio-muted': isAudioMuted,
-      'data-lk-video-muted': isVideoMuted,
-      'data-lk-speaking': disableSpeakingIndicator === true ? false : isSpeaking,
-      'data-lk-local-participant': participant.isLocal,
-      'data-lk-source': source,
-      'data-lk-facing-mode': facingMode,
-      ...mergedProps,
-    } as React.HTMLAttributes<HTMLDivElement>,
-  };
-}
+import { useParticipantTile } from '../../hooks';
 
 /** @public */
 export function ParticipantContextIfNeeded(
@@ -95,6 +34,15 @@ export function ParticipantContextIfNeeded(
   ) : (
     <>{props.children}</>
   );
+}
+
+/** @public */
+export interface ParticipantTileProps extends React.HTMLAttributes<HTMLDivElement> {
+  disableSpeakingIndicator?: boolean;
+  participant?: Participant;
+  source?: Track.Source;
+  publication?: TrackPublication;
+  onParticipantClick?: (event: ParticipantClickEvent) => void;
 }
 
 /**

--- a/packages/react/src/components/participant/TrackMutedIndicator.tsx
+++ b/packages/react/src/components/participant/TrackMutedIndicator.tsx
@@ -1,37 +1,14 @@
 import * as React from 'react';
 import { mergeProps } from '../../utils';
-import { setupTrackMutedIndicator } from '@livekit/components-core';
 import type { Participant, Track } from 'livekit-client';
-import { useEnsureParticipant } from '../../context';
 import { getSourceIcon } from '../../assets/icons/util';
-import { useObservableState } from '../../hooks/internal/useObservableState';
+import { useTrackMutedIndicator } from '../../hooks';
 
 /** @public */
 export interface TrackMutedIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
   source: Track.Source;
   participant?: Participant;
   show?: 'always' | 'muted' | 'unmuted';
-}
-
-/** @public */
-export interface UseTrackMutedIndicatorOptions {
-  participant?: Participant;
-}
-
-/** @public */
-export function useTrackMutedIndicator(
-  source: Track.Source,
-  options: UseTrackMutedIndicatorOptions = {},
-) {
-  const p = useEnsureParticipant(options.participant);
-  const { className, mediaMutedObserver } = React.useMemo(
-    () => setupTrackMutedIndicator(p, source),
-    [p, source],
-  );
-
-  const isMuted = useObservableState(mediaMutedObserver, !!p.getTrack(source)?.isMuted);
-
-  return { isMuted, className };
 }
 
 /**

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useParticipantInfo, UseParticipantInfoOptions } from './useParticipantInfo';
 export { useTrackToggle, UseTrackToggleProps } from './useTrackToggle';
 export { useStartAudio, UseStartAudioProps } from './useStartAudio';
 export { useMediaDevices } from './useMediaDevices';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,43 +1,43 @@
-export {
-  useConnectionQualityIndicator,
-  ConnectionQualityIndicatorOptions,
-} from './useConnectionQualityIndicator';
-export { useTrackMutedIndicator, UseTrackMutedIndicatorOptions } from './useTrackMutedIndicator';
-export { useParticipantTile, UseParticipantTileProps } from './useParticipantTile';
-export { useParticipantInfo, UseParticipantInfoOptions } from './useParticipantInfo';
-export { useTrackToggle, UseTrackToggleProps } from './useTrackToggle';
-export { useStartAudio, UseStartAudioProps } from './useStartAudio';
-export { useMediaDevices } from './useMediaDevices';
-export { useToggleChat, UseToggleChatProps } from './useToggleChat';
-export { useLiveKitRoom } from './useLiveKitRoom';
-export { useConnectionState } from './useConnectionStatus';
 export { useAudioPlayback } from './useAudioPlayback';
+export { useClearPinButton } from './useClearPinButton';
+export {
+  ConnectionQualityIndicatorOptions,
+  useConnectionQualityIndicator,
+} from './useConnectionQualityIndicator';
+export { useConnectionState } from './useConnectionStatus';
 export { useDataChannel } from './useDataChannel';
+export { useDisconnectButton } from './useDisconnectButton';
+export { useFacingMode } from './useFacingMode';
+export { UseFocusToggleProps, useFocusToggle } from './useFocusToggle';
 export { useGridLayout } from './useGridLayout';
-export { useIsMuted, UseIsMutedOptions } from './useIsMuted';
+export { UseIsMutedOptions, useIsMuted } from './useIsMuted';
 export { useIsSpeaking } from './useIsSpeaking';
-export { useLocalParticipant, UseLocalParticipantOptions } from './useLocalParticipant';
+export { useLiveKitRoom } from './useLiveKitRoom';
+export { UseLocalParticipantOptions, useLocalParticipant } from './useLocalParticipant';
 export { useLocalParticipantPermissions } from './useLocalParticipantPermissions';
-export { useMediaTrack, UseMediaTrackOptions } from './useMediaTrack';
+export { UseMediaDeviceSelectProps, useMediaDeviceSelect } from './useMediaDeviceSelect';
+export { useMediaDevices } from './useMediaDevices';
+export { UseMediaTrackOptions, useMediaTrack } from './useMediaTrack';
 export { useMediaTrackByName } from './useMediaTrackByName';
 export { usePagination } from './usePagination';
+export { UseParticipantInfoOptions, useParticipantInfo } from './useParticipantInfo';
 export {
-  useParticipantPermissions,
   UseParticipantPermissionsOptions,
+  useParticipantPermissions,
 } from './useParticipantPermissions';
-export { useParticipants, UseParticipantsOptions } from './useParticipants';
-export { useRemoteParticipant, UseRemoteParticipantOptions } from './useRemoteParticipant';
-export { useRemoteParticipants, UseRemoteParticipantsOptions } from './useRemoteParticipants';
+export { UseParticipantTileProps, useParticipantTile } from './useParticipantTile';
+export { UseParticipantsOptions, useParticipants } from './useParticipants';
+export { usePinnedTracks } from './usePinnedTracks';
+export { UseRemoteParticipantOptions, useRemoteParticipant } from './useRemoteParticipant';
+export { UseRemoteParticipantsOptions, useRemoteParticipants } from './useRemoteParticipants';
+export { UseRoomInfoOptions, useRoomInfo } from './useRoomInfo';
 export { useSortedParticipants } from './useSortedParticipants';
 export { useSpeakingParticipants } from './useSpeakingParticipants';
-export { useToken, UseTokenOptions, UserInfo } from './useToken';
-export { useTracks, UseTracksOptions, UseTracksHookReturnType } from './useTracks';
-export { useVisualStableUpdate, UseVisualStableUpdateOptions } from './useVisualStableUpdate';
-export { usePinnedTracks } from './usePinnedTracks';
-export { useSwipe, UseSwipeOptions } from './useSwipe';
-export { useFacingMode } from './useFacingMode';
-export { useRoomInfo, UseRoomInfoOptions } from './useRoomInfo';
-export { useClearPinButton } from './useClearPinButton';
-export { useDisconnectButton } from './useDisconnectButton';
-export { useFocusToggle, UseFocusToggleProps } from './useFocusToggle';
-export { useMediaDeviceSelect, UseMediaDeviceSelectProps } from './useMediaDeviceSelect';
+export { UseStartAudioProps, useStartAudio } from './useStartAudio';
+export { UseSwipeOptions, useSwipe } from './useSwipe';
+export { UseToggleChatProps, useToggleChat } from './useToggleChat';
+export { UseTokenOptions, UserInfo, useToken } from './useToken';
+export { UseTrackMutedIndicatorOptions, useTrackMutedIndicator } from './useTrackMutedIndicator';
+export { UseTrackToggleProps, useTrackToggle } from './useTrackToggle';
+export { UseTracksHookReturnType, UseTracksOptions, useTracks } from './useTracks';
+export { UseVisualStableUpdateOptions, useVisualStableUpdate } from './useVisualStableUpdate';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useToggleChat } from './useToggleChat';
 export { useLiveKitRoom } from './useLiveKitRoom';
 export { useConnectionState } from './useConnectionStatus';
 export { useAudioPlayback } from './useAudioPlayback';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -28,3 +28,4 @@ export { useSwipe, UseSwipeOptions } from './useSwipe';
 export { useFacingMode } from './useFacingMode';
 export { useRoomInfo } from './useRoomInfo';
 export { useClearPinButton } from './useClearPinButton';
+export { useDisconnectButton } from './useDisconnectButton';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,7 @@
+export {
+  useConnectionQualityIndicator,
+  ConnectionQualityIndicatorOptions,
+} from './useConnectionQualityIndicator';
 export { useTrackMutedIndicator, UseTrackMutedIndicatorOptions } from './useTrackMutedIndicator';
 export { useParticipantTile, UseParticipantTileProps } from './useParticipantTile';
 export { useParticipantInfo, UseParticipantInfoOptions } from './useParticipantInfo';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -8,7 +8,7 @@ export { useParticipantInfo, UseParticipantInfoOptions } from './useParticipantI
 export { useTrackToggle, UseTrackToggleProps } from './useTrackToggle';
 export { useStartAudio, UseStartAudioProps } from './useStartAudio';
 export { useMediaDevices } from './useMediaDevices';
-export { useToggleChat } from './useToggleChat';
+export { useToggleChat, UseToggleChatProps } from './useToggleChat';
 export { useLiveKitRoom } from './useLiveKitRoom';
 export { useConnectionState } from './useConnectionStatus';
 export { useAudioPlayback } from './useAudioPlayback';
@@ -36,8 +36,8 @@ export { useVisualStableUpdate, UseVisualStableUpdateOptions } from './useVisual
 export { usePinnedTracks } from './usePinnedTracks';
 export { useSwipe, UseSwipeOptions } from './useSwipe';
 export { useFacingMode } from './useFacingMode';
-export { useRoomInfo } from './useRoomInfo';
+export { useRoomInfo, UseRoomInfoOptions } from './useRoomInfo';
 export { useClearPinButton } from './useClearPinButton';
 export { useDisconnectButton } from './useDisconnectButton';
-export { useFocusToggle } from './useFocusToggle';
+export { useFocusToggle, UseFocusToggleProps } from './useFocusToggle';
 export { useMediaDeviceSelect, UseMediaDeviceSelectProps } from './useMediaDeviceSelect';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useMediaDevices } from './useMediaDevices';
 export { useToggleChat } from './useToggleChat';
 export { useLiveKitRoom } from './useLiveKitRoom';
 export { useConnectionState } from './useConnectionStatus';
@@ -30,3 +31,4 @@ export { useRoomInfo } from './useRoomInfo';
 export { useClearPinButton } from './useClearPinButton';
 export { useDisconnectButton } from './useDisconnectButton';
 export { useFocusToggle } from './useFocusToggle';
+export { useMediaDeviceSelect, UseMediaDeviceSelectProps } from './useMediaDeviceSelect';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useParticipantTile, UseParticipantTileProps } from './useParticipantTile';
 export { useParticipantInfo, UseParticipantInfoOptions } from './useParticipantInfo';
 export { useTrackToggle, UseTrackToggleProps } from './useTrackToggle';
 export { useStartAudio, UseStartAudioProps } from './useStartAudio';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -25,3 +25,4 @@ export { useVisualStableUpdate, UseVisualStableUpdateOptions } from './useVisual
 export { usePinnedTracks } from './usePinnedTracks';
 export { useSwipe, UseSwipeOptions } from './useSwipe';
 export { useFacingMode } from './useFacingMode';
+export { useRoomInfo } from './useRoomInfo';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -27,3 +27,4 @@ export { usePinnedTracks } from './usePinnedTracks';
 export { useSwipe, UseSwipeOptions } from './useSwipe';
 export { useFacingMode } from './useFacingMode';
 export { useRoomInfo } from './useRoomInfo';
+export { useClearPinButton } from './useClearPinButton';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useLiveKitRoom } from './useLiveKitRoom';
 export { useAudioPlayback } from './useAudioPlayback';
 export { useDataChannel } from './useDataChannel';
 export { useGridLayout } from './useGridLayout';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -29,3 +29,4 @@ export { useFacingMode } from './useFacingMode';
 export { useRoomInfo } from './useRoomInfo';
 export { useClearPinButton } from './useClearPinButton';
 export { useDisconnectButton } from './useDisconnectButton';
+export { useFocusToggle } from './useFocusToggle';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useTrackToggle, UseTrackToggleProps } from './useTrackToggle';
 export { useStartAudio, UseStartAudioProps } from './useStartAudio';
 export { useMediaDevices } from './useMediaDevices';
 export { useToggleChat } from './useToggleChat';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -35,7 +35,7 @@ export { useSortedParticipants } from './useSortedParticipants';
 export { useSpeakingParticipants } from './useSpeakingParticipants';
 export { UseStartAudioProps, useStartAudio } from './useStartAudio';
 export { UseSwipeOptions, useSwipe } from './useSwipe';
-export { UseToggleChatProps, useToggleChat } from './useToggleChat';
+export { UseChatToggleProps, useChatToggle } from './useChatToggle';
 export { UseTokenOptions, UserInfo, useToken } from './useToken';
 export { UseTrackMutedIndicatorOptions, useTrackMutedIndicator } from './useTrackMutedIndicator';
 export { UseTrackToggleProps, useTrackToggle } from './useTrackToggle';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useLiveKitRoom } from './useLiveKitRoom';
+export { useConnectionState } from './useConnectionStatus';
 export { useAudioPlayback } from './useAudioPlayback';
 export { useDataChannel } from './useDataChannel';
 export { useGridLayout } from './useGridLayout';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useTrackMutedIndicator, UseTrackMutedIndicatorOptions } from './useTrackMutedIndicator';
 export { useParticipantTile, UseParticipantTileProps } from './useParticipantTile';
 export { useParticipantInfo, UseParticipantInfoOptions } from './useParticipantInfo';
 export { useTrackToggle, UseTrackToggleProps } from './useTrackToggle';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useStartAudio, UseStartAudioProps } from './useStartAudio';
 export { useMediaDevices } from './useMediaDevices';
 export { useToggleChat } from './useToggleChat';
 export { useLiveKitRoom } from './useLiveKitRoom';

--- a/packages/react/src/hooks/useChatToggle.ts
+++ b/packages/react/src/hooks/useChatToggle.ts
@@ -4,12 +4,12 @@ import { mergeProps } from '../mergeProps';
 import * as React from 'react';
 
 /** @public */
-export interface UseToggleChatProps {
+export interface UseChatToggleProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
 /** @public */
-export function useToggleChat({ props }: UseToggleChatProps) {
+export function useChatToggle({ props }: UseChatToggleProps) {
   const { dispatch, state } = useLayoutContext().widget;
   const { className } = React.useMemo(() => setupChatToggle(), []);
 

--- a/packages/react/src/hooks/useClearPinButton.ts
+++ b/packages/react/src/hooks/useClearPinButton.ts
@@ -1,0 +1,24 @@
+import { setupClearPinButton } from '@livekit/components-core';
+import * as React from 'react';
+import { useLayoutContext } from '../context';
+import { mergeProps } from '../mergeProps';
+import type { ClearPinButtonProps } from '../components';
+
+/** @public */
+export function useClearPinButton(props: ClearPinButtonProps) {
+  const { state, dispatch } = useLayoutContext().pin;
+
+  const buttonProps = React.useMemo(() => {
+    const { className } = setupClearPinButton();
+    const mergedProps = mergeProps(props, {
+      className,
+      disabled: !state?.length,
+      onClick: () => {
+        if (dispatch) dispatch({ msg: 'clear_pin' });
+      },
+    });
+    return mergedProps;
+  }, [props, dispatch, state]);
+
+  return { buttonProps };
+}

--- a/packages/react/src/hooks/useConnectionQualityIndicator.ts
+++ b/packages/react/src/hooks/useConnectionQualityIndicator.ts
@@ -1,0 +1,25 @@
+import { setupConnectionQualityIndicator } from '@livekit/components-core';
+import type { Participant } from 'livekit-client';
+import { ConnectionQuality } from 'livekit-client';
+import React from 'react';
+import { useEnsureParticipant } from '../context';
+import { useObservableState } from './internal';
+
+/** @public */
+export interface ConnectionQualityIndicatorOptions {
+  participant?: Participant;
+}
+
+/** @public */
+export function useConnectionQualityIndicator(options: ConnectionQualityIndicatorOptions = {}) {
+  const p = useEnsureParticipant(options.participant);
+
+  const { className, connectionQualityObserver } = React.useMemo(
+    () => setupConnectionQualityIndicator(p),
+    [p],
+  );
+
+  const quality = useObservableState(connectionQualityObserver, ConnectionQuality.Unknown);
+
+  return { className, quality };
+}

--- a/packages/react/src/hooks/useConnectionQualityIndicator.ts
+++ b/packages/react/src/hooks/useConnectionQualityIndicator.ts
@@ -1,7 +1,7 @@
 import { setupConnectionQualityIndicator } from '@livekit/components-core';
 import type { Participant } from 'livekit-client';
 import { ConnectionQuality } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import { useEnsureParticipant } from '../context';
 import { useObservableState } from './internal';
 

--- a/packages/react/src/hooks/useConnectionStatus.ts
+++ b/packages/react/src/hooks/useConnectionStatus.ts
@@ -1,0 +1,22 @@
+import { connectionStateObserver } from '@livekit/components-core';
+import type { Room } from 'livekit-client';
+import * as React from 'react';
+import { useEnsureRoom } from '../context';
+import { useObservableState } from './internal';
+
+/**
+ * The `useConnectionState` hook allows you to simply implement your own `ConnectionState` component.
+ *
+ * @example
+ * ```tsx
+ * const connectionState = useConnectionState(room);
+ * ```
+ * @public
+ */
+export function useConnectionState(room?: Room) {
+  // passed room takes precedence, if not supplied get current room context
+  const r = useEnsureRoom(room);
+  const observable = React.useMemo(() => connectionStateObserver(r), [r]);
+  const connectionState = useObservableState(observable, r.state);
+  return connectionState;
+}

--- a/packages/react/src/hooks/useDisconnectButton.ts
+++ b/packages/react/src/hooks/useDisconnectButton.ts
@@ -1,6 +1,6 @@
 import { setupDisconnectButton } from '@livekit/components-core';
 import { ConnectionState } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import type { DisconnectButtonProps } from '../components';
 import { useRoomContext } from '../context';
 import { mergeProps } from '../mergeProps';

--- a/packages/react/src/hooks/useDisconnectButton.ts
+++ b/packages/react/src/hooks/useDisconnectButton.ts
@@ -1,0 +1,25 @@
+import { setupDisconnectButton } from '@livekit/components-core';
+import { ConnectionState } from 'livekit-client';
+import React from 'react';
+import type { DisconnectButtonProps } from '../components';
+import { useRoomContext } from '../context';
+import { mergeProps } from '../mergeProps';
+import { useConnectionState } from './useConnectionStatus';
+
+/** @public */
+export function useDisconnectButton(props: DisconnectButtonProps) {
+  const room = useRoomContext();
+  const connectionState = useConnectionState(room);
+
+  const buttonProps = React.useMemo(() => {
+    const { className, disconnect } = setupDisconnectButton(room);
+    const mergedProps = mergeProps(props, {
+      className,
+      onClick: () => disconnect(props.stopTracks ?? true),
+      disabled: connectionState === ConnectionState.Disconnected,
+    });
+    return mergedProps;
+  }, [room, props, connectionState]);
+
+  return { buttonProps };
+}

--- a/packages/react/src/hooks/useFocusToggle.ts
+++ b/packages/react/src/hooks/useFocusToggle.ts
@@ -4,13 +4,13 @@ import { useEnsureParticipant, useMaybeLayoutContext } from '../context';
 import { mergeProps } from '../mergeProps';
 import React from 'react';
 
-export interface useFocusToggleProps {
+export interface UseFocusToggleProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
   trackSource: Track.Source;
   participant?: Participant;
 }
 
-export function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps) {
+export function useFocusToggle({ trackSource, participant, props }: UseFocusToggleProps) {
   const p = useEnsureParticipant(participant);
   const layoutContext = useMaybeLayoutContext();
   const { className } = React.useMemo(() => setupFocusToggle(), []);

--- a/packages/react/src/hooks/useFocusToggle.ts
+++ b/packages/react/src/hooks/useFocusToggle.ts
@@ -4,12 +4,14 @@ import { useEnsureParticipant, useMaybeLayoutContext } from '../context';
 import { mergeProps } from '../mergeProps';
 import * as React from 'react';
 
+/** @public */
 export interface UseFocusToggleProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
   trackSource: Track.Source;
   participant?: Participant;
 }
 
+/** @public */
 export function useFocusToggle({ trackSource, participant, props }: UseFocusToggleProps) {
   const p = useEnsureParticipant(participant);
   const layoutContext = useMaybeLayoutContext();

--- a/packages/react/src/hooks/useFocusToggle.ts
+++ b/packages/react/src/hooks/useFocusToggle.ts
@@ -2,7 +2,7 @@ import { setupFocusToggle, isTrackReferencePinned } from '@livekit/components-co
 import type { Track, Participant } from 'livekit-client';
 import { useEnsureParticipant, useMaybeLayoutContext } from '../context';
 import { mergeProps } from '../mergeProps';
-import React from 'react';
+import * as React from 'react';
 
 export interface UseFocusToggleProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;

--- a/packages/react/src/hooks/useFocusToggle.ts
+++ b/packages/react/src/hooks/useFocusToggle.ts
@@ -1,0 +1,62 @@
+import { setupFocusToggle, isTrackReferencePinned } from '@livekit/components-core';
+import type { Track, Participant } from 'livekit-client';
+import { useEnsureParticipant, useMaybeLayoutContext } from '../context';
+import { mergeProps } from '../mergeProps';
+import React from 'react';
+
+export interface useFocusToggleProps {
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  trackSource: Track.Source;
+  participant?: Participant;
+}
+
+export function useFocusToggle({ trackSource, participant, props }: useFocusToggleProps) {
+  const p = useEnsureParticipant(participant);
+  const layoutContext = useMaybeLayoutContext();
+  const { className } = React.useMemo(() => setupFocusToggle(), []);
+
+  const inFocus: boolean = React.useMemo(() => {
+    const track = p.getTrack(trackSource);
+    if (layoutContext?.pin.state && track) {
+      return isTrackReferencePinned(
+        { participant: p, source: trackSource, publication: track },
+        layoutContext.pin.state,
+      );
+    } else {
+      return false;
+    }
+  }, [p, trackSource, layoutContext]);
+
+  const mergedProps = React.useMemo(
+    () =>
+      mergeProps(props, {
+        className,
+        onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+          // Call user defined on click callbacks.
+          props.onClick?.(event);
+
+          // Set or clear focus based on current focus state.
+          const track = p.getTrack(trackSource);
+          if (layoutContext?.pin.dispatch && track) {
+            if (inFocus) {
+              layoutContext.pin.dispatch({
+                msg: 'clear_pin',
+              });
+            } else {
+              layoutContext.pin.dispatch({
+                msg: 'set_pin',
+                trackReference: {
+                  participant: p,
+                  publication: track,
+                  source: track.source,
+                },
+              });
+            }
+          }
+        },
+      }),
+    [props, className, p, trackSource, inFocus, layoutContext],
+  );
+
+  return { mergedProps, inFocus };
+}

--- a/packages/react/src/hooks/useLiveKitRoom.ts
+++ b/packages/react/src/hooks/useLiveKitRoom.ts
@@ -1,6 +1,8 @@
 import { log, setupLiveKitRoom } from '@livekit/components-core';
 import { Room, MediaDeviceFailure, RoomEvent, ConnectionState } from 'livekit-client';
 import * as React from 'react';
+import type { HTMLAttributes } from 'react';
+
 import type { LiveKitRoomProps } from '../components';
 import { mergeProps } from '../mergeProps';
 
@@ -11,7 +13,12 @@ const defaultRoomProps: Partial<LiveKitRoomProps> = {
 };
 
 /** @public */
-export function useLiveKitRoom(props: LiveKitRoomProps) {
+export function useLiveKitRoom<T extends HTMLElement>(
+  props: LiveKitRoomProps,
+): {
+  room: Room | undefined;
+  htmlProps: HTMLAttributes<T>;
+} {
   const {
     token,
     serverUrl,
@@ -41,7 +48,10 @@ export function useLiveKitRoom(props: LiveKitRoomProps) {
     setRoom(passedRoom ?? new Room(options));
   }, [JSON.stringify(options), passedRoom]);
 
-  const htmlProps = React.useMemo(() => mergeProps(rest, setupLiveKitRoom()), [rest]);
+  const htmlProps = React.useMemo(() => {
+    const { className } = setupLiveKitRoom();
+    return mergeProps(rest, { className }) as HTMLAttributes<T>;
+  }, [rest]);
 
   React.useEffect(() => {
     if (!room) return;

--- a/packages/react/src/hooks/useLiveKitRoom.ts
+++ b/packages/react/src/hooks/useLiveKitRoom.ts
@@ -1,0 +1,149 @@
+import { log, setupLiveKitRoom } from '@livekit/components-core';
+import { Room, MediaDeviceFailure, RoomEvent, ConnectionState } from 'livekit-client';
+import React from 'react';
+import type { LiveKitRoomProps } from '../components';
+import { mergeProps } from '../mergeProps';
+
+const defaultRoomProps: Partial<LiveKitRoomProps> = {
+  connect: true,
+  audio: false,
+  video: false,
+};
+
+/** @public */
+export function useLiveKitRoom(props: LiveKitRoomProps) {
+  const {
+    token,
+    serverUrl,
+    options,
+    room: passedRoom,
+    connectOptions,
+    connect,
+    audio,
+    video,
+    screen,
+    onConnected,
+    onDisconnected,
+    onError,
+    onMediaDeviceFailure,
+    simulateParticipants,
+    ...rest
+  } = { ...defaultRoomProps, ...props };
+  if (options && passedRoom) {
+    log.warn(
+      'when using a manually created room, the options object will be ignored. set the desired options directly when creating the room instead.',
+    );
+  }
+
+  const [room, setRoom] = React.useState<Room | undefined>();
+
+  React.useEffect(() => {
+    setRoom(passedRoom ?? new Room(options));
+  }, [JSON.stringify(options), passedRoom]);
+
+  const htmlProps = React.useMemo(() => mergeProps(rest, setupLiveKitRoom()), [rest]);
+
+  React.useEffect(() => {
+    if (!room) return;
+    const onSignalConnected = () => {
+      const localP = room.localParticipant;
+
+      log.debug('trying to publish local tracks');
+      Promise.all([
+        localP.setMicrophoneEnabled(!!audio, typeof audio !== 'boolean' ? audio : undefined),
+        localP.setCameraEnabled(!!video, typeof video !== 'boolean' ? video : undefined),
+        localP.setScreenShareEnabled(!!screen, typeof screen !== 'boolean' ? screen : undefined),
+      ]).catch((e) => {
+        log.warn(e);
+        onError?.(e as Error);
+      });
+    };
+
+    const onMediaDeviceError = (e: Error) => {
+      const mediaDeviceFailure = MediaDeviceFailure.getFailure(e);
+      onMediaDeviceFailure?.(mediaDeviceFailure);
+    };
+    room.on(RoomEvent.SignalConnected, onSignalConnected);
+    room.on(RoomEvent.MediaDevicesError, onMediaDeviceError);
+
+    return () => {
+      room.off(RoomEvent.SignalConnected, onSignalConnected);
+      room.off(RoomEvent.MediaDevicesError, onMediaDeviceError);
+    };
+  }, [room, audio, video, screen, onError]);
+
+  React.useEffect(() => {
+    if (!room) return;
+
+    if (simulateParticipants) {
+      room.simulateParticipants({
+        participants: {
+          count: simulateParticipants,
+        },
+        publish: {
+          audio: true,
+          useRealTracks: true,
+        },
+      });
+      return;
+    }
+    if (!token) {
+      log.debug('no token yet');
+      return;
+    }
+    if (!serverUrl) {
+      log.warn('no livekit url provided');
+      onError?.(Error('no livekit url provided'));
+      return;
+    }
+    if (connect) {
+      log.debug('connecting');
+      room.connect(serverUrl, token, connectOptions).catch((e) => {
+        log.warn(e);
+        onError?.(e as Error);
+      });
+    } else {
+      log.debug('disconnecting because connect is false');
+      room.disconnect();
+    }
+  }, [
+    connect,
+    token,
+    JSON.stringify(connectOptions),
+    room,
+    onError,
+    serverUrl,
+    simulateParticipants,
+  ]);
+
+  React.useEffect(() => {
+    if (!room) return;
+    const connectionStateChangeListener = (state: ConnectionState) => {
+      switch (state) {
+        case ConnectionState.Disconnected:
+          if (onDisconnected) onDisconnected();
+          break;
+        case ConnectionState.Connected:
+          if (onConnected) onConnected();
+          break;
+
+        default:
+          break;
+      }
+    };
+    room.on(RoomEvent.ConnectionStateChanged, connectionStateChangeListener);
+    return () => {
+      room.off(RoomEvent.ConnectionStateChanged, connectionStateChangeListener);
+    };
+  }, [token, onConnected, onDisconnected, room]);
+
+  React.useEffect(() => {
+    if (!room) return;
+    return () => {
+      log.info('disconnecting on onmount');
+      room.disconnect();
+    };
+  }, [room]);
+
+  return { room, htmlProps };
+}

--- a/packages/react/src/hooks/useLiveKitRoom.ts
+++ b/packages/react/src/hooks/useLiveKitRoom.ts
@@ -1,6 +1,6 @@
 import { log, setupLiveKitRoom } from '@livekit/components-core';
 import { Room, MediaDeviceFailure, RoomEvent, ConnectionState } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import type { LiveKitRoomProps } from '../components';
 import { mergeProps } from '../mergeProps';
 

--- a/packages/react/src/hooks/useMediaDeviceSelect.ts
+++ b/packages/react/src/hooks/useMediaDeviceSelect.ts
@@ -1,6 +1,6 @@
 import { createMediaDeviceObserver, setupDeviceSelector, log } from '@livekit/components-core';
 import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import { useMaybeRoomContext } from '../context';
 import { useObservableState } from './internal';
 

--- a/packages/react/src/hooks/useMediaDeviceSelect.ts
+++ b/packages/react/src/hooks/useMediaDeviceSelect.ts
@@ -1,0 +1,56 @@
+import { createMediaDeviceObserver, setupDeviceSelector, log } from '@livekit/components-core';
+import { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
+import React from 'react';
+import { useMaybeRoomContext } from '../context';
+import { useObservableState } from './internal';
+
+/** @public */
+export interface UseMediaDeviceSelectProps {
+  kind: MediaDeviceKind;
+  room?: Room;
+  track?: LocalAudioTrack | LocalVideoTrack;
+  /**
+   * this will call getUserMedia if the permissions are not yet given to enumerate the devices with device labels.
+   * in some browsers multiple calls to getUserMedia result in multiple permission prompts.
+   * It's generally advised only flip this to true, once a (preview) track has been acquired successfully with the
+   * appropriate permissions.
+   *
+   * @see {@link MediaDeviceMenu}
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices | MDN enumerateDevices}
+   */
+  requestPermissions?: boolean;
+}
+
+/** @public */
+export function useMediaDeviceSelect({
+  kind,
+  room,
+  track,
+  requestPermissions,
+}: UseMediaDeviceSelectProps) {
+  const roomContext = useMaybeRoomContext();
+  // List of all devices.
+  const deviceObserver = React.useMemo(
+    () => createMediaDeviceObserver(kind, requestPermissions),
+    [kind, requestPermissions],
+  );
+  const devices = useObservableState(deviceObserver, []);
+  // Active device management.
+  const [currentDeviceId, setCurrentDeviceId] = React.useState<string>('');
+  const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
+    () => setupDeviceSelector(kind, room ?? roomContext, track),
+    [kind, room, roomContext, track],
+  );
+
+  React.useEffect(() => {
+    const listener = activeDeviceObservable.subscribe((deviceId) => {
+      log.info('setCurrentDeviceId', deviceId);
+      if (deviceId) setCurrentDeviceId(deviceId);
+    });
+    return () => {
+      listener?.unsubscribe();
+    };
+  }, [activeDeviceObservable]);
+
+  return { devices, className, activeDeviceId: currentDeviceId, setActiveMediaDevice };
+}

--- a/packages/react/src/hooks/useMediaDeviceSelect.ts
+++ b/packages/react/src/hooks/useMediaDeviceSelect.ts
@@ -1,5 +1,5 @@
 import { createMediaDeviceObserver, setupDeviceSelector, log } from '@livekit/components-core';
-import { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
+import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
 import React from 'react';
 import { useMaybeRoomContext } from '../context';
 import { useObservableState } from './internal';

--- a/packages/react/src/hooks/useMediaDevices.ts
+++ b/packages/react/src/hooks/useMediaDevices.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useObservableState } from './internal';
 import { createMediaDeviceObserver } from '@livekit/components-core';
 

--- a/packages/react/src/hooks/useMediaDevices.ts
+++ b/packages/react/src/hooks/useMediaDevices.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useObservableState } from './internal';
+import { createMediaDeviceObserver } from '@livekit/components-core';
+
+/** @public */
+export function useMediaDevices({ kind }: { kind: MediaDeviceKind }) {
+  const deviceObserver = React.useMemo(() => createMediaDeviceObserver(kind), [kind]);
+  const devices = useObservableState(deviceObserver, []);
+  return devices;
+}

--- a/packages/react/src/hooks/useMediaTrack.ts
+++ b/packages/react/src/hooks/useMediaTrack.ts
@@ -1,6 +1,7 @@
 import type { VideoSource, AudioSource } from '@livekit/components-core';
 import type { Participant } from 'livekit-client';
 import { useEnsureParticipant } from '../context/participant-context';
+import type * as React from 'react';
 import { useMediaTrackBySourceOrName } from './useMediaTrackBySourceOrName';
 
 /** @public */

--- a/packages/react/src/hooks/useParticipantInfo.ts
+++ b/packages/react/src/hooks/useParticipantInfo.ts
@@ -1,0 +1,23 @@
+import { participantInfoObserver } from '@livekit/components-core';
+import type { Participant } from 'livekit-client';
+import React from 'react';
+import { useEnsureParticipant } from '../context';
+import { useObservableState } from './internal';
+
+/** @public */
+export interface UseParticipantInfoOptions {
+  participant?: Participant;
+}
+
+/** @public */
+export function useParticipantInfo(props: UseParticipantInfoOptions = {}) {
+  const p = useEnsureParticipant(props.participant);
+  const infoObserver = React.useMemo(() => participantInfoObserver(p), [p]);
+  const { identity, name, metadata } = useObservableState(infoObserver, {
+    name: p.name,
+    identity: p.identity,
+    metadata: p.metadata,
+  });
+
+  return { identity, name, metadata };
+}

--- a/packages/react/src/hooks/useParticipantInfo.ts
+++ b/packages/react/src/hooks/useParticipantInfo.ts
@@ -1,6 +1,6 @@
 import { participantInfoObserver } from '@livekit/components-core';
 import type { Participant } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import { useEnsureParticipant } from '../context';
 import { useObservableState } from './internal';
 

--- a/packages/react/src/hooks/useParticipantTile.ts
+++ b/packages/react/src/hooks/useParticipantTile.ts
@@ -1,0 +1,61 @@
+import type { ParticipantClickEvent } from '@livekit/components-core';
+import { setupParticipantTile } from '@livekit/components-core';
+import type { TrackPublication, Participant } from 'livekit-client';
+import { Track } from 'livekit-client';
+import React from 'react';
+import { useEnsureParticipant } from '../context';
+import { mergeProps } from '../mergeProps';
+import { useFacingMode } from './useFacingMode';
+import { useIsMuted } from './useIsMuted';
+import { useIsSpeaking } from './useIsSpeaking';
+
+/** @public */
+export interface UseParticipantTileProps<T extends HTMLElement> extends React.HTMLAttributes<T> {
+  disableSpeakingIndicator?: boolean;
+  publication?: TrackPublication;
+  onParticipantClick?: (event: ParticipantClickEvent) => void;
+  htmlProps: React.HTMLAttributes<T>;
+  source: Track.Source;
+  participant: Participant;
+}
+
+/** @public */
+export function useParticipantTile<T extends HTMLElement>({
+  participant,
+  source,
+  publication,
+  onParticipantClick,
+  disableSpeakingIndicator,
+  htmlProps,
+}: UseParticipantTileProps<T>) {
+  const p = useEnsureParticipant(participant);
+  const mergedProps = React.useMemo(() => {
+    const { className } = setupParticipantTile();
+    return mergeProps(htmlProps, {
+      className,
+      onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+        // @ts-ignore
+        htmlProps.onClick?.(event);
+        if (typeof onParticipantClick === 'function') {
+          const track = publication ?? p.getTrack(source);
+          onParticipantClick({ participant: p, track });
+        }
+      },
+    });
+  }, [htmlProps, source, onParticipantClick, p, publication]);
+  const isVideoMuted = useIsMuted(Track.Source.Camera, { participant });
+  const isAudioMuted = useIsMuted(Track.Source.Microphone, { participant });
+  const isSpeaking = useIsSpeaking(participant);
+  const facingMode = useFacingMode({ participant, publication, source });
+  return {
+    elementProps: {
+      'data-lk-audio-muted': isAudioMuted,
+      'data-lk-video-muted': isVideoMuted,
+      'data-lk-speaking': disableSpeakingIndicator === true ? false : isSpeaking,
+      'data-lk-local-participant': participant.isLocal,
+      'data-lk-source': source,
+      'data-lk-facing-mode': facingMode,
+      ...mergedProps,
+    } as React.HTMLAttributes<T>,
+  };
+}

--- a/packages/react/src/hooks/useParticipantTile.ts
+++ b/packages/react/src/hooks/useParticipantTile.ts
@@ -2,7 +2,7 @@ import type { ParticipantClickEvent } from '@livekit/components-core';
 import { setupParticipantTile } from '@livekit/components-core';
 import type { TrackPublication, Participant } from 'livekit-client';
 import { Track } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import { useEnsureParticipant } from '../context';
 import { mergeProps } from '../mergeProps';
 import { useFacingMode } from './useFacingMode';

--- a/packages/react/src/hooks/useRoomInfo.ts
+++ b/packages/react/src/hooks/useRoomInfo.ts
@@ -1,0 +1,22 @@
+import { roomInfoObserver } from '@livekit/components-core';
+import type { Room } from 'livekit-client';
+import * as React from 'react';
+import { useEnsureRoom } from '../context';
+import { useObservableState } from './internal';
+
+/** @public */
+export interface UseRoomInfoOptions {
+  room?: Room;
+}
+
+/** @public */
+export function useRoomInfo(options: UseRoomInfoOptions = {}) {
+  const room = useEnsureRoom(options.room);
+  const infoObserver = React.useMemo(() => roomInfoObserver(room), [room]);
+  const { name, metadata } = useObservableState(infoObserver, {
+    name: room.name,
+    metadata: room.metadata,
+  });
+
+  return { name, metadata };
+}

--- a/packages/react/src/hooks/useStartAudio.ts
+++ b/packages/react/src/hooks/useStartAudio.ts
@@ -1,0 +1,48 @@
+import { setupStartAudio } from '@livekit/components-core';
+import type { Room } from 'livekit-client';
+import React from 'react';
+import { useEnsureRoom } from '../context';
+import { mergeProps } from '../mergeProps';
+import { useObservableState } from './internal';
+
+/** @alpha */
+export interface UseStartAudioProps {
+  room?: Room;
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>;
+}
+
+/**
+ * In many browsers to start audio playback, the user must perform a user-initiated event such as clicking a button.
+ * The `useStatAudio` hook returns an object with a boolean `canPlayAudio` flag
+ * that indicates whether audio playback is allowed in the current context,
+ * as well as a `startAudio` function that can be called in a button `onClick` callback to start audio playback in the current context.
+ *
+ * @see Autoplay policy on MDN web docs for more info: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
+ * @alpha
+ */
+export function useStartAudio({ room, props }: UseStartAudioProps) {
+  const roomEnsured = useEnsureRoom(room);
+  const { className, roomAudioPlaybackAllowedObservable, handleStartAudioPlayback } = React.useMemo(
+    () => setupStartAudio(),
+    [],
+  );
+  const observable = React.useMemo(
+    () => roomAudioPlaybackAllowedObservable(roomEnsured),
+    [roomEnsured, roomAudioPlaybackAllowedObservable],
+  );
+  const { canPlayAudio } = useObservableState(observable, { canPlayAudio: false });
+
+  const mergedProps = React.useMemo(
+    () =>
+      mergeProps(props, {
+        className,
+        onClick: () => {
+          handleStartAudioPlayback(roomEnsured);
+        },
+        style: { display: canPlayAudio ? 'none' : 'block' },
+      }),
+    [props, className, canPlayAudio, handleStartAudioPlayback, roomEnsured],
+  );
+
+  return { mergedProps, canPlayAudio };
+}

--- a/packages/react/src/hooks/useStartAudio.ts
+++ b/packages/react/src/hooks/useStartAudio.ts
@@ -1,6 +1,6 @@
 import { setupStartAudio } from '@livekit/components-core';
 import type { Room } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import { useEnsureRoom } from '../context';
 import { mergeProps } from '../mergeProps';
 import { useObservableState } from './internal';

--- a/packages/react/src/hooks/useToggleChat.ts
+++ b/packages/react/src/hooks/useToggleChat.ts
@@ -3,7 +3,7 @@ import { useLayoutContext } from '../context';
 import { mergeProps } from '../mergeProps';
 import * as React from 'react';
 
-interface UseToggleChatProps {
+export interface UseToggleChatProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 

--- a/packages/react/src/hooks/useToggleChat.ts
+++ b/packages/react/src/hooks/useToggleChat.ts
@@ -22,7 +22,7 @@ export function useToggleChat({ props }: UseToggleChatProps) {
         ? state.unreadMessages < 10
           ? state.unreadMessages.toFixed(0)
           : '9+'
-        : 0,
+        : '0',
     });
   }, [props, className, dispatch, state]);
 

--- a/packages/react/src/hooks/useToggleChat.ts
+++ b/packages/react/src/hooks/useToggleChat.ts
@@ -1,0 +1,30 @@
+import { setupChatToggle } from '@livekit/components-core';
+import { useLayoutContext } from '../context';
+import { mergeProps } from '../mergeProps';
+import * as React from 'react';
+
+interface UseToggleChatProps {
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>;
+}
+
+export function useToggleChat({ props }: UseToggleChatProps) {
+  const { dispatch, state } = useLayoutContext().widget;
+  const { className } = React.useMemo(() => setupChatToggle(), []);
+
+  const mergedProps = React.useMemo(() => {
+    return mergeProps(props, {
+      className,
+      onClick: () => {
+        if (dispatch) dispatch({ msg: 'toggle_chat' });
+      },
+      'aria-pressed': state?.showChat ? 'true' : 'false',
+      'data-lk-unread-msgs': state
+        ? state.unreadMessages < 10
+          ? state.unreadMessages.toFixed(0)
+          : '9+'
+        : 0,
+    });
+  }, [props, className, dispatch, state]);
+
+  return { mergedProps };
+}

--- a/packages/react/src/hooks/useToggleChat.ts
+++ b/packages/react/src/hooks/useToggleChat.ts
@@ -3,10 +3,12 @@ import { useLayoutContext } from '../context';
 import { mergeProps } from '../mergeProps';
 import * as React from 'react';
 
+/** @public */
 export interface UseToggleChatProps {
   props: React.ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
+/** @public */
 export function useToggleChat({ props }: UseToggleChatProps) {
   const { dispatch, state } = useLayoutContext().widget;
   const { className } = React.useMemo(() => setupChatToggle(), []);

--- a/packages/react/src/hooks/useTrackMutedIndicator.ts
+++ b/packages/react/src/hooks/useTrackMutedIndicator.ts
@@ -1,6 +1,6 @@
 import { setupTrackMutedIndicator } from '@livekit/components-core';
 import type { Participant, Track } from 'livekit-client';
-import React from 'react';
+import * as React from 'react';
 import { useEnsureParticipant } from '../context';
 import { useObservableState } from './internal';
 

--- a/packages/react/src/hooks/useTrackMutedIndicator.ts
+++ b/packages/react/src/hooks/useTrackMutedIndicator.ts
@@ -1,0 +1,26 @@
+import { setupTrackMutedIndicator } from '@livekit/components-core';
+import type { Participant, Track } from 'livekit-client';
+import React from 'react';
+import { useEnsureParticipant } from '../context';
+import { useObservableState } from './internal';
+
+/** @public */
+export interface UseTrackMutedIndicatorOptions {
+  participant?: Participant;
+}
+
+/** @public */
+export function useTrackMutedIndicator(
+  source: Track.Source,
+  options: UseTrackMutedIndicatorOptions = {},
+) {
+  const p = useEnsureParticipant(options.participant);
+  const { className, mediaMutedObserver } = React.useMemo(
+    () => setupTrackMutedIndicator(p, source),
+    [p, source],
+  );
+
+  const isMuted = useObservableState(mediaMutedObserver, !!p.getTrack(source)?.isMuted);
+
+  return { isMuted, className };
+}

--- a/packages/react/src/hooks/useTrackToggle.ts
+++ b/packages/react/src/hooks/useTrackToggle.ts
@@ -1,6 +1,6 @@
 import type { ToggleSource } from '@livekit/components-core';
 import { setupMediaToggle, setupManualToggle, log } from '@livekit/components-core';
-import React from 'react';
+import * as React from 'react';
 import type { TrackToggleProps } from '../components';
 import { useMaybeRoomContext } from '../context';
 import { mergeProps } from '../mergeProps';

--- a/packages/react/src/hooks/useTrackToggle.ts
+++ b/packages/react/src/hooks/useTrackToggle.ts
@@ -1,0 +1,69 @@
+import type { ToggleSource } from '@livekit/components-core';
+import { setupMediaToggle, setupManualToggle, log } from '@livekit/components-core';
+import React from 'react';
+import type { TrackToggleProps } from '../components';
+import { useMaybeRoomContext } from '../context';
+import { mergeProps } from '../mergeProps';
+import { useObservableState } from './internal';
+
+/** @public */
+export interface UseTrackToggleProps<T extends ToggleSource>
+  extends Omit<TrackToggleProps<T>, 'showIcon'> {}
+
+/** @public */
+export function useTrackToggle<T extends ToggleSource>({
+  source,
+  onChange,
+  initialState,
+  captureOptions,
+  ...rest
+}: UseTrackToggleProps<T>) {
+  const room = useMaybeRoomContext();
+  const track = room?.localParticipant?.getTrack(source);
+
+  const { toggle, className, pendingObserver, enabledObserver } = React.useMemo(
+    () => (room ? setupMediaToggle<T>(source, room, captureOptions) : setupManualToggle()),
+    [room, source, JSON.stringify(captureOptions)],
+  );
+
+  const pending = useObservableState(pendingObserver, false);
+  const enabled = useObservableState(enabledObserver, initialState ?? !!track?.isEnabled);
+
+  React.useEffect(() => {
+    onChange?.(enabled);
+  }, [enabled, onChange]);
+
+  React.useEffect(() => {
+    if (initialState !== undefined) {
+      log.debug('forcing initial toggle state', source, initialState);
+      toggle(initialState);
+    }
+    // only execute once at the beginning
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const newProps = React.useMemo(() => mergeProps(rest, { className }), [rest, className]);
+
+  const clickHandler: React.MouseEventHandler<HTMLButtonElement> = React.useCallback(
+    (evt) => {
+      toggle();
+      rest.onClick?.(evt);
+    },
+    [rest, toggle],
+  );
+
+  return {
+    toggle,
+    enabled,
+    pending,
+    track,
+    buttonProps: {
+      ...newProps,
+      'aria-pressed': enabled,
+      'data-lk-source': source,
+      'data-lk-enabled': enabled,
+      disabled: pending,
+      onClick: clickHandler,
+    } as React.ButtonHTMLAttributes<HTMLButtonElement>,
+  };
+}

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -14,10 +14,10 @@ import {
 } from 'livekit-client';
 import * as React from 'react';
 import { MediaDeviceMenu } from './MediaDeviceMenu';
-import { useMediaDevices } from '../components/controls/MediaDeviceSelect';
 import { TrackToggle } from '../components/controls/TrackToggle';
 import { log } from '@livekit/components-core';
 import { ParticipantPlaceholder } from '../assets/images';
+import { useMediaDevices } from '../hooks';
 
 /** @public */
 export type LocalUserChoices = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10809,15 +10809,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+typescript@5.0.4, typescript@~5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+
 typescript@^5.0.0:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
-typescript@~5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 ufo@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR:

- Move component hooks to the hooks folder.
- fixes and simplifies some TS types
- exposes the `useFocusToggle` and `useToggleChat` hooks