### PR TITLE
Add MediaDevicesError event for use local participant

### DIFF
--- a/.changeset/ninety-stingrays-join.md
+++ b/.changeset/ninety-stingrays-join.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Add MediaDevicesError event for use local participant

--- a/packages/core/src/observables/participant.ts
+++ b/packages/core/src/observables/participant.ts
@@ -56,6 +56,7 @@ export function observeParticipantMedia<T extends Participant>(participant: T) {
     ParticipantEvent.TrackUnsubscribed,
     ParticipantEvent.LocalTrackPublished,
     ParticipantEvent.LocalTrackUnpublished,
+    ParticipantEvent.MediaDevicesError,
     // ParticipantEvent.ConnectionQualityChanged,
   ).pipe(
     map((p) => {

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -565,6 +565,8 @@ export function useLocalParticipant(options?: UseLocalParticipantOptions): {
     isCameraEnabled: boolean;
     microphoneTrack: TrackPublication | undefined;
     cameraTrack: TrackPublication | undefined;
+    lastMicrophoneError: Error | undefined;
+    lastCameraError: Error | undefined;
     localParticipant: LocalParticipant;
 };
 

--- a/packages/react/src/hooks/useLocalParticipant.ts
+++ b/packages/react/src/hooks/useLocalParticipant.ts
@@ -25,6 +25,10 @@ export function useLocalParticipant(options: UseLocalParticipantOptions = {}) {
   const [isCameraEnabled, setIsCameraEnabled] = React.useState(
     localParticipant.isMicrophoneEnabled,
   );
+  const [lastMicrophoneError, setLastMicrophoneError] = React.useState(
+    localParticipant.lastMicrophoneError,
+  );
+  const [lastCameraError, setLastCameraError] = React.useState(localParticipant.lastCameraError);
   const [isScreenShareEnabled, setIsScreenShareEnabled] = React.useState(
     localParticipant.isMicrophoneEnabled,
   );
@@ -39,6 +43,8 @@ export function useLocalParticipant(options: UseLocalParticipantOptions = {}) {
     setIsScreenShareEnabled(media.isScreenShareEnabled);
     setCameraTrack(media.cameraTrack);
     setMicrophoneTrack(media.microphoneTrack);
+    setLastMicrophoneError(media.participant.lastMicrophoneError);
+    setLastCameraError(media.participant.lastCameraError);
     setLocalParticipant(media.participant);
   };
   React.useEffect(() => {
@@ -53,6 +59,8 @@ export function useLocalParticipant(options: UseLocalParticipantOptions = {}) {
     isCameraEnabled,
     microphoneTrack,
     cameraTrack,
+    lastMicrophoneError,
+    lastCameraError,
     localParticipant,
   };
 }


### PR DESCRIPTION
Hi.
#### Bug Description
Currently, if there is a problem with the microphone or camera after requesting access from the browser, the **component** using `useLocalParticipant` will not be aware of that and will not update the UI (until another event is called).

####  Fix
This change causes the `useLocalParticipant` hook to be updated in case of a problem accessing the microphone or camera (`MediaDevicesError` event) and deliver the relevant errors in the output.

