### PR TITLE
Gird layout tweaks

### DIFF
--- a/.changeset/serious-queens-drop.md
+++ b/.changeset/serious-queens-drop.md
@@ -1,0 +1,7 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Rename GridLayout to GridLayoutDefinition in core to resolve name overlap.
+Switch to the vertical 2x1 layout a bit earlier if reducing the width of the viewport.

--- a/packages/core/src/helper/grid-layouts.test.ts
+++ b/packages/core/src/helper/grid-layouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import type { GridLayout } from './grid-layouts';
+import type { GridLayoutDefinition } from './grid-layouts';
 import { GRID_LAYOUTS, selectGridLayout } from './grid-layouts';
 
 describe.concurrent('Test correct layout for participant count with no screen size limits:', () => {
@@ -48,7 +48,7 @@ describe.concurrent('Test correct layout for participant count with no screen si
   });
 });
 
-function is_same(array1: GridLayout[], array2: GridLayout[]) {
+function is_same(array1: GridLayoutDefinition[], array2: GridLayoutDefinition[]) {
   return (
     array1.length == array2.length &&
     array1.every((element, index) => {
@@ -71,7 +71,6 @@ describe.concurrent(
       { desiredLayoutName: '5x5', expected: '4x4' },
       { desiredLayoutName: '4x4', expected: '3x3' },
       { desiredLayoutName: '3x3', expected: '2x2' },
-      //TODO { desiredLayoutName: '2x2', expected: '2x1' },
       { desiredLayoutName: '2x1', expected: '1x2' },
     ])(
       'If the minimum width for the $desiredLayoutName layout is not satisfied switch to smaller layout ($expected).',

--- a/packages/core/src/helper/grid-layouts.ts
+++ b/packages/core/src/helper/grid-layouts.ts
@@ -1,8 +1,11 @@
 import { log } from '../logger';
 
-export type GridLayout = {
+export type GridLayoutDefinition = {
+  /** Layout name (convention `<column_count>x<row_count>`). */
   name: string;
+  /** Column count of the layout. */
   columns: number;
+  /** Row count of the layout. */
   rows: number;
   // # Constraints that have to be meet to use this layout.
   // ## 1. Participant range:
@@ -17,7 +20,7 @@ export type GridLayout = {
   minHeight: number;
 };
 
-export const GRID_LAYOUTS: GridLayout[] = [
+export const GRID_LAYOUTS: GridLayoutDefinition[] = [
   {
     columns: 1,
     rows: 1,
@@ -42,7 +45,7 @@ export const GRID_LAYOUTS: GridLayout[] = [
     name: '2x1',
     minTiles: 2,
     maxTiles: 2,
-    minWidth: 800,
+    minWidth: 900,
     minHeight: 0,
   },
   {
@@ -84,11 +87,11 @@ export const GRID_LAYOUTS: GridLayout[] = [
 ];
 
 export function selectGridLayout(
-  layouts: GridLayout[],
+  layouts: GridLayoutDefinition[],
   participantCount: number,
   width: number,
   height: number,
-): GridLayout {
+): GridLayoutDefinition {
   // Find the best layout to fit all participants.
   let currentLayoutIndex = 0;
   let layout = layouts.find((layout_, index, allLayouts) => {

--- a/packages/core/src/helper/index.ts
+++ b/packages/core/src/helper/index.ts
@@ -4,6 +4,6 @@ export * from './emailRegex';
 export * from './floating-menu';
 export * from './tokenizer';
 export * from './eventGroups';
-export { selectGridLayout, GRID_LAYOUTS } from './grid-layouts';
+export { selectGridLayout, GRID_LAYOUTS, type GridLayoutDefinition } from './grid-layouts';
 export { setDifference } from './set-helper';
 export { supportsScreenSharing } from './featureDetection';

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -14,7 +14,7 @@ import { ConnectionQuality } from 'livekit-client';
 import { ConnectionState as ConnectionState_2 } from 'livekit-client';
 import type { CreateLocalTracksOptions } from 'livekit-client';
 import type { DataSendOptions } from '@livekit/components-core';
-import type { GridLayout as GridLayout_2 } from '@livekit/components-core/dist/helper/grid-layouts';
+import type { GridLayoutDefinition } from '@livekit/components-core';
 import { HTMLAttributes } from 'react';
 import type { LocalAudioTrack } from 'livekit-client';
 import { LocalParticipant } from 'livekit-client';
@@ -534,7 +534,7 @@ export function useFacingMode(trackReference: TrackReferenceOrPlaceholder): 'use
 export function useGridLayout(
 gridElement: React_2.RefObject<HTMLDivElement>,
 trackCount: number): {
-    layout: GridLayout_2;
+    layout: GridLayoutDefinition;
 };
 
 // @public (undocumented)

--- a/packages/react/src/hooks/useGridLayout.ts
+++ b/packages/react/src/hooks/useGridLayout.ts
@@ -1,5 +1,5 @@
 import { GRID_LAYOUTS, selectGridLayout } from '@livekit/components-core';
-import type { GridLayout } from '@livekit/components-core/dist/helper/grid-layouts';
+import type { GridLayoutDefinition } from '@livekit/components-core';
 import * as React from 'react';
 import { useSize } from './internal';
 
@@ -16,7 +16,7 @@ export function useGridLayout(
   gridElement: React.RefObject<HTMLDivElement>,
   /** Count of tracks that should get layed out */
   trackCount: number,
-): { layout: GridLayout } {
+): { layout: GridLayoutDefinition } {
   const { width, height } = useSize(gridElement);
 
   const layout =


### PR DESCRIPTION
Change the naming of the GridLayout definition in core to avoid name overlap with the GridLayout component in the React package.

Change the GridLayout definitions to switch to the 2x1 vertical layout slightly earlier.