### PR TITLE
Remove unnecessary props from audio and video elements

### DIFF
--- a/.changeset/brown-beers-share.md
+++ b/.changeset/brown-beers-share.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Remove unnecessary props from audio and video elements

--- a/packages/core/src/observables/track.ts
+++ b/packages/core/src/observables/track.ts
@@ -71,11 +71,10 @@ function getTrackReferences(
             // either return all or only the ones that are subscribed
             (!onlySubscribedTracks || track.track),
         )
-        .map((track) => {
+        .map((track): TrackReference => {
           return {
             participant: participant,
             publication: track,
-            track: track.track,
             source: track.source,
           };
         });

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -62,7 +62,7 @@ export interface AudioConferenceProps extends React_2.HTMLAttributes<HTMLDivElem
 }
 
 // @public
-export function AudioTrack({ onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps): React_2.JSX.Element;
+export function AudioTrack({ onSubscriptionStatusChanged, volume, source, name, publication, participant: p, ...props }: AudioTrackProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement> extends React_2.HTMLAttributes<T> {
@@ -909,7 +909,7 @@ export interface VideoConferenceProps extends React_2.HTMLAttributes<HTMLDivElem
 }
 
 // @public
-export function VideoTrack({ onTrackClick, onClick, onSubscriptionStatusChanged, name, publication, source, ...props }: VideoTrackProps): React_2.JSX.Element;
+export function VideoTrack({ onTrackClick, onClick, onSubscriptionStatusChanged, name, publication, source, participant: p, ...props }: VideoTrackProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface VideoTrackProps extends React_2.HTMLAttributes<HTMLVideoElement> {

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -31,10 +31,17 @@ export interface AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement>
  * @see `ParticipantTile` component
  * @public
  */
-export function AudioTrack({ onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps) {
-  const { source, name, publication } = props;
+export function AudioTrack({
+  onSubscriptionStatusChanged,
+  volume,
+  source,
+  name,
+  publication,
+  participant: p,
+  ...props
+}: AudioTrackProps) {
   const mediaEl = React.useRef<HTMLAudioElement>(null);
-  const participant = useEnsureParticipant(props.participant);
+  const participant = useEnsureParticipant(p);
 
   const { elementProps, isSubscribed, track } = useMediaTrackBySourceOrName(
     { source, name, participant, publication },

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -32,10 +32,11 @@ export function VideoTrack({
   name,
   publication,
   source,
+  participant: p,
   ...props
 }: VideoTrackProps) {
   const mediaEl = React.useRef<HTMLVideoElement>(null);
-  const participant = useEnsureParticipant(props.participant);
+  const participant = useEnsureParticipant(p);
   const {
     elementProps,
     publication: pub,

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -79,9 +79,8 @@ export function useTracks<T extends SourcesArray = Track.Source[]>(
   const maybeTrackReferences = React.useMemo(() => {
     if (isSourcesWithOptions(sources)) {
       const requirePlaceholder = requiredPlaceholders(sources, participants);
-      const trackReferencesWithPlaceholders = Array.from(
-        trackReferences,
-      ) as TrackReferenceOrPlaceholder[];
+      const trackReferencesWithPlaceholders: TrackReferenceOrPlaceholder[] =
+        Array.from(trackReferences);
       participants.forEach((participant) => {
         if (requirePlaceholder.has(participant.identity)) {
           const sourcesToAddPlaceholder = requirePlaceholder.get(participant.identity) ?? [];


### PR DESCRIPTION
Remove unnecessary props from audio and video elements in DOM by destructuring.
here is an example of an audio element in `livekit/examples/nextjs` which has unnecessarily attributes like `participant` or `publication`:

![media-props](https://github.com/livekit/components-js/assets/47795908/1eb0c2ef-75d8-4ab2-a1c8-85862eb82350)
