### PR TITLE
Make sure dependencies stay external for esm builds

### DIFF
--- a/.changeset/wild-sloths-sip.md
+++ b/.changeset/wild-sloths-sip.md
@@ -1,0 +1,6 @@
+---
+'@livekit/components-core': patch
+'@livekit/components-react': patch
+---
+
+Make sure dependencies arent bundled for esm builds

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,5 +9,10 @@ const defaultOptions: Options = {
   dts: false,
   clean: true,
   target: 'es6',
+  esbuildOptions: (options, context) => {
+    if (context.format === 'esm') {
+      options.packages = 'external';
+    }
+  },
 };
 export default defaultOptions;


### PR DESCRIPTION
first attempt to solve #592 

the issue only manifested once the package was published, so guessing we'll have to do that again to verify if the fix actually works.

related issues:
https://github.com/juliencrn/usehooks-ts/issues/162
https://github.com/evanw/esbuild/issues/2164
