### PR TITLE
fix handling of multiple tracks of the same source from the same participant

### DIFF
--- a/.changeset/eight-nails-rush.md
+++ b/.changeset/eight-nails-rush.md
@@ -1,0 +1,6 @@
+---
+'@livekit/components-react': minor
+'@livekit/components-core': patch
+---
+
+fix handling of multiple tracks of the same source from the same participant

--- a/.changeset/quiet-yaks-argue.md
+++ b/.changeset/quiet-yaks-argue.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+fix handling of multiple tracks of the same source from the same participant

--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -184,8 +184,16 @@ export function isLocal(p: Participant): boolean;
 // @public
 export function isMobileBrowser(): boolean;
 
-// @public
+// @public @deprecated
 export function isParticipantSourcePinned(participant: Participant, source: Track.Source, pinState: PinState | undefined): boolean;
+
+// @public
+export function isParticipantTrackReferencePinned(trackRef: TrackReference, pinState: PinState | undefined): boolean;
+
+// Warning: (ae-internal-missing-underscore) The name "isPlaceholderReplacement" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function isPlaceholderReplacement(currentTrackRef: TrackReferenceOrPlaceholder, nextTrackRef: TrackReferenceOrPlaceholder): boolean;
 
 // @public (undocumented)
 export function isRemote(p: Participant): boolean;
@@ -500,6 +508,9 @@ export type TrackReference = {
 
 // @public (undocumented)
 export type TrackReferenceFilter = Parameters<TrackReferenceOrPlaceholder[]['filter']>['0'];
+
+// @public (undocumented)
+export type TrackReferenceId = ReturnType<typeof getTrackReferenceId>;
 
 // @public (undocumented)
 export type TrackReferenceOrPlaceholder = TrackReference | TrackReferencePlaceholder;

--- a/packages/core/src/sorting/tile-array-update.test.ts
+++ b/packages/core/src/sorting/tile-array-update.test.ts
@@ -5,7 +5,13 @@ import {
   mockTrackReferencePlaceholder,
   mockTrackReferenceSubscribed,
 } from '../track-reference/test-utils';
-import { divideIntoPages, swapItems, updatePages, visualPageChange } from './tile-array-update';
+import {
+  divideIntoPages,
+  placeholderReplacement,
+  swapItems,
+  updatePages,
+  visualPageChange,
+} from './tile-array-update';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
 
 const stateNextExpectedString = (text: string) =>
@@ -338,6 +344,7 @@ describe('Test updating the list based while considering pages.', () => {
     expect(flatTrackReferenceArray(result)).toStrictEqual(flatTrackReferenceArray(expected));
   });
 
+  // FIXME: mute for implementation unmute before production.
   test.each([
     {
       state: [mockTrackReferencePlaceholder('A', Track.Source.Camera)],

--- a/packages/core/src/sorting/tile-array-update.test.ts
+++ b/packages/core/src/sorting/tile-array-update.test.ts
@@ -5,13 +5,7 @@ import {
   mockTrackReferencePlaceholder,
   mockTrackReferenceSubscribed,
 } from '../track-reference/test-utils';
-import {
-  divideIntoPages,
-  swapItems,
-  updatePages,
-  isPlaceholderReplacement,
-  visualPageChange,
-} from './tile-array-update';
+import { divideIntoPages, swapItems, updatePages, visualPageChange } from './tile-array-update';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
 
 const stateNextExpectedString = (text: string) =>
@@ -360,41 +354,6 @@ describe('Test updating the list based while considering pages.', () => {
       expect(result).toHaveLength(next.length);
       expect(flatTrackReferenceArray(result)).toStrictEqual(flatTrackReferenceArray(expected));
       expect(result[0].publication).toBeDefined();
-    },
-  );
-});
-
-describe('Test if a trackReference is the migration of placeholder', () => {
-  test.each([
-    {
-      currentTrackRef: mockTrackReferencePlaceholder('Participant_A', Track.Source.Camera),
-      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
-        mockPublication: true,
-      }),
-      isPlaceholderReplacement: true,
-    },
-    {
-      currentTrackRef: mockTrackReferencePlaceholder('Participant_B', Track.Source.Camera),
-      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
-        mockPublication: true,
-      }),
-      isPlaceholderReplacement: false,
-    },
-    {
-      currentTrackRef: mockTrackReferencePlaceholder('Participant_A', Track.Source.ScreenShare),
-      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
-        mockPublication: true,
-      }),
-      isPlaceholderReplacement: false,
-    },
-  ])(
-    'Test if the current TrackReference was the placeholder for the next TrackReference.',
-    ({ nextTrackRef: trackRef, currentTrackRef: maybePlaceholder, isPlaceholderReplacement }) => {
-      const result = isPlaceholderReplacement(
-        maybePlaceholder as TrackReferenceOrPlaceholder,
-        trackRef,
-      );
-      expect(result).toBe(isPlaceholderReplacement);
     },
   );
 });

--- a/packages/core/src/sorting/tile-array-update.test.ts
+++ b/packages/core/src/sorting/tile-array-update.test.ts
@@ -5,7 +5,13 @@ import {
   mockTrackReferencePlaceholder,
   mockTrackReferenceSubscribed,
 } from '../track-reference/test-utils';
-import { divideIntoPages, swapItems, updatePages, visualPageChange } from './tile-array-update';
+import {
+  divideIntoPages,
+  swapItems,
+  updatePages,
+  isPlaceholderReplacement,
+  visualPageChange,
+} from './tile-array-update';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
 
 const stateNextExpectedString = (text: string) =>
@@ -354,6 +360,41 @@ describe('Test updating the list based while considering pages.', () => {
       expect(result).toHaveLength(next.length);
       expect(flatTrackReferenceArray(result)).toStrictEqual(flatTrackReferenceArray(expected));
       expect(result[0].publication).toBeDefined();
+    },
+  );
+});
+
+describe('Test if a trackReference is the migration of placeholder', () => {
+  test.each([
+    {
+      currentTrackRef: mockTrackReferencePlaceholder('Participant_A', Track.Source.Camera),
+      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
+        mockPublication: true,
+      }),
+      isPlaceholderReplacement: true,
+    },
+    {
+      currentTrackRef: mockTrackReferencePlaceholder('Participant_B', Track.Source.Camera),
+      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
+        mockPublication: true,
+      }),
+      isPlaceholderReplacement: false,
+    },
+    {
+      currentTrackRef: mockTrackReferencePlaceholder('Participant_A', Track.Source.ScreenShare),
+      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
+        mockPublication: true,
+      }),
+      isPlaceholderReplacement: false,
+    },
+  ])(
+    'Test if the current TrackReference was the placeholder for the next TrackReference.',
+    ({ nextTrackRef: trackRef, currentTrackRef: maybePlaceholder, isPlaceholderReplacement }) => {
+      const result = isPlaceholderReplacement(
+        maybePlaceholder as TrackReferenceOrPlaceholder,
+        trackRef,
+      );
+      expect(result).toBe(isPlaceholderReplacement);
     },
   );
 });

--- a/packages/core/src/sorting/tile-array-update.test.ts
+++ b/packages/core/src/sorting/tile-array-update.test.ts
@@ -5,13 +5,7 @@ import {
   mockTrackReferencePlaceholder,
   mockTrackReferenceSubscribed,
 } from '../track-reference/test-utils';
-import {
-  divideIntoPages,
-  placeholderReplacement,
-  swapItems,
-  updatePages,
-  visualPageChange,
-} from './tile-array-update';
+import { divideIntoPages, swapItems, updatePages, visualPageChange } from './tile-array-update';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
 
 const stateNextExpectedString = (text: string) =>

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -1,8 +1,14 @@
 import { differenceBy, chunk, zip } from '../helper/array-helper';
-import { log } from '../logger';
+import { log, setLogLevel } from '../logger';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
-import { getTrackReferenceId } from '../track-reference';
+import {
+  getTrackReferenceId,
+  isTrackReference,
+  isTrackReferencePlaceholder,
+} from '../track-reference';
 import { flatTrackReferenceArray } from '../track-reference/test-utils';
+
+setLogLevel('debug');
 
 type VisualChanges<T> = {
   dropped: T[];
@@ -39,6 +45,25 @@ export function findIndex<T extends UpdatableItem>(
     );
   }
   return indexToReplace;
+}
+
+/**
+ * Check if the current `currentTrackRef` was the placeholder for next `nextTrackRef`.
+ * Based on the participant identity and the source.
+ */
+export function isPlaceholderReplacement<T extends UpdatableItem>(
+  currentTrackRef: T,
+  nextTrackRef: T,
+) {
+  if (typeof nextTrackRef === 'number' || typeof currentTrackRef === 'number') {
+    return false;
+  }
+  return (
+    isTrackReferencePlaceholder(currentTrackRef) &&
+    isTrackReference(nextTrackRef) &&
+    nextTrackRef.participant.identity === currentTrackRef.participant.identity &&
+    nextTrackRef.source === currentTrackRef.source
+  );
 }
 
 /** Swap items in the complete list of all elements */

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -1,5 +1,5 @@
 import { differenceBy, chunk, zip } from '../helper/array-helper';
-import { log, setLogLevel } from '../logger';
+import { log } from '../logger';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
 import {
   getTrackReferenceId,
@@ -8,8 +8,6 @@ import {
   isTrackReferencePlaceholder,
 } from '../track-reference';
 import { flatTrackReferenceArray } from '../track-reference/test-utils';
-
-setLogLevel('debug');
 
 type VisualChanges<T> = {
   dropped: T[];

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -1,11 +1,7 @@
 import { differenceBy, chunk, zip } from '../helper/array-helper';
 import { log, setLogLevel } from '../logger';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
-import {
-  getTrackReferenceId,
-  isTrackReference,
-  isTrackReferencePlaceholder,
-} from '../track-reference';
+import { getTrackReferenceId } from '../track-reference';
 import { flatTrackReferenceArray } from '../track-reference/test-utils';
 
 setLogLevel('debug');
@@ -45,25 +41,6 @@ export function findIndex<T extends UpdatableItem>(
     );
   }
   return indexToReplace;
-}
-
-/**
- * Check if the current `currentTrackRef` was the placeholder for next `nextTrackRef`.
- * Based on the participant identity and the source.
- */
-export function isPlaceholderReplacement<T extends UpdatableItem>(
-  currentTrackRef: T,
-  nextTrackRef: T,
-) {
-  if (typeof nextTrackRef === 'number' || typeof currentTrackRef === 'number') {
-    return false;
-  }
-  return (
-    isTrackReferencePlaceholder(currentTrackRef) &&
-    isTrackReference(nextTrackRef) &&
-    nextTrackRef.participant.identity === currentTrackRef.participant.identity &&
-    nextTrackRef.source === currentTrackRef.source
-  );
 }
 
 /** Swap items in the complete list of all elements */

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -1,7 +1,12 @@
 import { differenceBy, chunk, zip } from '../helper/array-helper';
 import { log, setLogLevel } from '../logger';
 import type { TrackReferenceOrPlaceholder } from '../track-reference';
-import { getTrackReferenceId } from '../track-reference';
+import {
+  getTrackReferenceId,
+  isPlaceholderReplacement,
+  isTrackReference,
+  isTrackReferencePlaceholder,
+} from '../track-reference';
 import { flatTrackReferenceArray } from '../track-reference/test-utils';
 
 setLogLevel('debug');
@@ -143,19 +148,24 @@ export function updatePages<T extends UpdatableItem>(
 }
 
 /**
- * Update the first list with the items from the second list whenever the ids are the same.
+ * Update the current list with the items from the next list whenever the item ids are the same
+ * or the current item is a placeholder and we find a track reference in the next list
+ * to replace the placeholder with.
  * @remarks
  * This is needed because `TrackReference`s can change their internal state while keeping the same id.
  */
 function refreshList<T extends UpdatableItem>(currentList: T[], nextList: T[]): T[] {
   return currentList.map((currentItem) => {
     const updateForCurrentItem = nextList.find(
-      (newItem_) => getTrackReferenceId(currentItem) === getTrackReferenceId(newItem_),
+      (newItem_) =>
+        // If the IDs match or ..
+        getTrackReferenceId(currentItem) === getTrackReferenceId(newItem_) ||
+        // ... if the current item is a placeholder and the new item is the track reference can replace it.
+        (typeof currentItem !== 'number' &&
+          isTrackReferencePlaceholder(currentItem) &&
+          isTrackReference(newItem_) &&
+          isPlaceholderReplacement(currentItem, newItem_)),
     );
-    if (updateForCurrentItem) {
-      return updateForCurrentItem;
-    } else {
-      return currentItem;
-    }
+    return updateForCurrentItem ?? currentItem;
   });
 }

--- a/packages/core/src/sorting/tile-array-update.ts
+++ b/packages/core/src/sorting/tile-array-update.ts
@@ -82,12 +82,12 @@ export function updatePages<T extends UpdatableItem>(
 ): T[] {
   let updatedList: T[] = refreshList(currentList, nextList);
 
-  if (currentList.length < nextList.length) {
+  if (updatedList.length < nextList.length) {
     // Items got added: Find newly added items and add them to the end of the list.
-    const addedItems = differenceBy(nextList, currentList, getTrackReferenceId);
+    const addedItems = differenceBy(nextList, updatedList, getTrackReferenceId);
     updatedList = [...updatedList, ...addedItems];
   }
-  const currentPages = divideIntoPages(currentList, maxItemsOnPage);
+  const currentPages = divideIntoPages(updatedList, maxItemsOnPage);
   const nextPages = divideIntoPages(nextList, maxItemsOnPage);
 
   zip(currentPages, nextPages).forEach(([currentPage, nextPage], pageIndex) => {
@@ -133,7 +133,7 @@ export function updatePages<T extends UpdatableItem>(
 
   if (updatedList.length > nextList.length) {
     // Items got removed: Find items that got completely removed from the list.
-    const missingItems = differenceBy(currentList, nextList, getTrackReferenceId);
+    const missingItems = differenceBy(updatedList, nextList, getTrackReferenceId);
     updatedList = updatedList.filter(
       (item) => !missingItems.map(getTrackReferenceId).includes(getTrackReferenceId(item)),
     );

--- a/packages/core/src/track-reference/test-utils.test.ts
+++ b/packages/core/src/track-reference/test-utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, expectTypeOf } from 'vitest';
-import { mockTrackReferenceSubscribed } from './test-utils';
-import type { Participant, TrackPublication } from 'livekit-client';
+import { mockTrackReferencePlaceholder, mockTrackReferenceSubscribed } from './test-utils';
+import { Participant, TrackPublication } from 'livekit-client';
 import { Track } from 'livekit-client';
+import { getTrackReferenceId } from './track-reference.utils';
 
 describe('Test mocking functions ', () => {
   test('mockTrackReferenceSubscribed without options.', () => {
@@ -21,5 +22,38 @@ describe('Test mocking functions ', () => {
     expect(mock.source).toBeDefined();
     expect(mock.source).toBe(Track.Source.Camera);
     expectTypeOf(mock.source).toMatchTypeOf<Track.Source>();
+  });
+});
+
+describe('Test mockTrackReferencePlaceholder() produces valid id with getTrackReferenceId()', () => {
+  test.each([
+    {
+      participantId: 'participantA',
+      trackSource: Track.Source.Camera,
+      expected: 'participantA_camera_placeholder',
+    },
+  ])('mockTrackReferencePlaceholder id', ({ participantId, trackSource, expected }) => {
+    const mock = mockTrackReferencePlaceholder(participantId, trackSource);
+    const trackRefId = getTrackReferenceId(mock);
+    expect(trackRefId.startsWith(participantId));
+    expect(trackRefId.endsWith('_placeholder'));
+    expect(trackRefId).toBe(expected);
+  });
+});
+
+describe('Test mockTrackReferenceSubscribed() produces valid id with getTrackReferenceId()', () => {
+  test.each([
+    {
+      participantId: 'participantA',
+      trackSource: Track.Source.Camera,
+      expected: 'participantA_camera_publicationId(participantA)',
+    },
+  ])('mockTrackReferencePlaceholder id', ({ participantId, trackSource, expected }) => {
+    const mock = mockTrackReferenceSubscribed(participantId, trackSource, {
+      mockPublication: true,
+    });
+    const trackRefId = getTrackReferenceId(mock);
+    expect(trackRefId.startsWith(participantId));
+    expect(trackRefId).toBe(expected);
   });
 });

--- a/packages/core/src/track-reference/test-utils.ts
+++ b/packages/core/src/track-reference/test-utils.ts
@@ -51,7 +51,7 @@ export const mockTrackReferenceSubscribed = (
       ? (mockParticipant(id, options.mockIsLocal ?? false) as Participant)
       : new Participant(`${id}`, `${id}`),
     publication: options.mockPublication
-      ? (mockTrackPublication(id, kind, source) as TrackPublication)
+      ? (mockTrackPublication(`publicationId(${id})`, kind, source) as TrackPublication)
       : publication,
     source,
   };

--- a/packages/core/src/track-reference/track-reference.utils.test.ts
+++ b/packages/core/src/track-reference/track-reference.utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect, expectTypeOf } from 'vitest';
+import { mockTrackReferencePlaceholder, mockTrackReferenceSubscribed } from './test-utils';
+import type { Participant, TrackPublication } from 'livekit-client';
+import { Track } from 'livekit-client';
+import { isPlaceholderReplacement } from './track-reference.utils';
+
+describe('Test mocking functions ', () => {
+  test('mockTrackReferenceSubscribed without options.', () => {
+    const mock = mockTrackReferenceSubscribed('MOCK_ID', Track.Source.Camera);
+    expect(mock).toBeDefined();
+    // Check if the participant is mocked correctly:
+    expect(mock.participant).toBeDefined();
+    expect(mock.participant.identity).toBe('MOCK_ID');
+    expectTypeOf(mock.participant).toMatchTypeOf<Participant>();
+
+    // Check if the publication is mocked correctly:
+    expect(mock.publication).toBeDefined();
+    expect(mock.publication.kind).toBe(Track.Kind.Video);
+    expectTypeOf(mock.publication).toMatchTypeOf<TrackPublication>();
+
+    // Check if the source is mocked correctly:
+    expect(mock.source).toBeDefined();
+    expect(mock.source).toBe(Track.Source.Camera);
+    expectTypeOf(mock.source).toMatchTypeOf<Track.Source>();
+  });
+});
+
+describe('Test if the current TrackReferencePlaceholder can be replaced with the next TrackReference.', () => {
+  test.each([
+    {
+      currentTrackRef: mockTrackReferencePlaceholder('Participant_A', Track.Source.Camera),
+      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
+        mockPublication: true,
+      }),
+      isReplacement: true,
+    },
+    {
+      currentTrackRef: mockTrackReferencePlaceholder('Participant_B', Track.Source.Camera),
+      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
+        mockPublication: true,
+      }),
+      isReplacement: false,
+    },
+    {
+      currentTrackRef: mockTrackReferencePlaceholder('Participant_A', Track.Source.ScreenShare),
+      nextTrackRef: mockTrackReferenceSubscribed('Participant_A', Track.Source.Camera, {
+        mockPublication: true,
+      }),
+      isReplacement: false,
+    },
+  ])(
+    'Test if the current TrackReference was the placeholder for the next TrackReference.',
+    ({ nextTrackRef: trackRef, currentTrackRef: maybePlaceholder, isReplacement }) => {
+      const result = isPlaceholderReplacement(maybePlaceholder, trackRef);
+      expect(result).toBe(isReplacement);
+    },
+  );
+});

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -79,6 +79,7 @@ export function isTrackReferencePinned(
 /**
  * Check if the current `currentTrackRef` is the placeholder for next `nextTrackRef`.
  * Based on the participant identity and the source.
+ * @internal
  */
 export function isPlaceholderReplacement(
   currentTrackRef: TrackReferenceOrPlaceholder,

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -12,11 +12,11 @@ import { isTrackReference, isTrackReferencePlaceholder } from './track-reference
  */
 export function getTrackReferenceId(trackReference: TrackReferenceOrPlaceholder | number) {
   if (typeof trackReference === 'string' || typeof trackReference === 'number') {
-    return `${trackReference}` as const;
+    return `${trackReference}`;
   } else if (isTrackReferencePlaceholder(trackReference)) {
-    return `${trackReference.participant.identity}_${trackReference.source}_placeholder` as const;
+    return `${trackReference.participant.identity}_${trackReference.source}_placeholder`;
   } else if (isTrackReference(trackReference)) {
-    return `${trackReference.participant.identity}_${trackReference.publication.source}_${trackReference.publication.trackSid}` as const;
+    return `${trackReference.participant.identity}_${trackReference.publication.source}_${trackReference.publication.trackSid}`;
   } else {
     throw new Error(`Can't generate a id for the given track reference: ${trackReference}`);
   }

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -75,3 +75,22 @@ export function isTrackReferencePinned(
     return false;
   }
 }
+
+/**
+ * Check if the current `currentTrackRef` is the placeholder for next `nextTrackRef`.
+ * Based on the participant identity and the source.
+ */
+export function isPlaceholderReplacement(
+  currentTrackRef: TrackReferenceOrPlaceholder,
+  nextTrackRef: TrackReferenceOrPlaceholder,
+) {
+  // if (typeof nextTrackRef === 'number' || typeof currentTrackRef === 'number') {
+  //   return false;
+  // }
+  return (
+    isTrackReferencePlaceholder(currentTrackRef) &&
+    isTrackReference(nextTrackRef) &&
+    nextTrackRef.participant.identity === currentTrackRef.participant.identity &&
+    nextTrackRef.source === currentTrackRef.source
+  );
+}

--- a/packages/core/src/track-reference/track-reference.utils.ts
+++ b/packages/core/src/track-reference/track-reference.utils.ts
@@ -4,13 +4,15 @@ import type { TrackReferenceOrPlaceholder } from './track-reference.types';
 import { isTrackReference, isTrackReferencePlaceholder } from './track-reference.types';
 
 /** Returns a id to identify the `TrackReference` based on participant and source. */
-export function getTrackReferenceId(trackReference: TrackReferenceOrPlaceholder | number): string {
+export function getTrackReferenceId(trackReference: TrackReferenceOrPlaceholder | number) {
   if (typeof trackReference === 'string' || typeof trackReference === 'number') {
-    return `${trackReference}`;
+    return `${trackReference}` as const;
   } else if (isTrackReference(trackReference)) {
-    return `${trackReference.participant.identity}_${trackReference.publication.source}`;
+    return `${trackReference.participant.identity}_${trackReference.publication.source}_${
+      trackReference.publication.trackName ?? ''
+    }` as const;
   } else {
-    return `${trackReference.participant.identity}_${trackReference.source}`;
+    return `${trackReference.participant.identity}_${trackReference.source}` as const;
   }
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,6 +2,8 @@ import type { Participant, Track, TrackPublication } from 'livekit-client';
 import { LocalParticipant, RemoteParticipant } from 'livekit-client';
 
 import type { PinState } from './types';
+import type { TrackReference } from './track-reference';
+import { isEqualTrackRef } from './track-reference';
 
 export function isLocal(p: Participant) {
   return p instanceof LocalParticipant;
@@ -28,6 +30,7 @@ export const attachIfSubscribed = (
 
 /**
  * Check if the participant track source is pinned.
+ * @deprecated Use {@link isParticipantTrackReferencePinned} instead.
  */
 export function isParticipantSourcePinned(
   participant: Participant,
@@ -42,6 +45,20 @@ export function isParticipantSourcePinned(
     ({ source: pinnedSource, participant: pinnedParticipant }) =>
       pinnedSource === source && pinnedParticipant.identity === participant.identity,
   );
+}
+
+/**
+ * Check if the participant track reference is pinned.
+ */
+export function isParticipantTrackReferencePinned(
+  trackRef: TrackReference,
+  pinState: PinState | undefined,
+): boolean {
+  if (pinState === undefined) {
+    return false;
+  }
+
+  return pinState.some((pinnedTrackRef) => isEqualTrackRef(pinnedTrackRef, trackRef));
 }
 
 /**

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -222,14 +222,16 @@ export interface FocusLayoutProps extends React_2.HTMLAttributes<HTMLElement> {
 }
 
 // @public
-export function FocusToggle({ trackSource, participant, ...props }: FocusToggleProps): React_2.JSX.Element;
+export function FocusToggle({ trackRef, trackSource, participant, ...props }: FocusToggleProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface FocusToggleProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement> {
-    // (undocumented)
+    // @deprecated (undocumented)
     participant?: Participant;
     // (undocumented)
-    trackSource: Track.Source;
+    trackRef?: TrackReferenceOrPlaceholder;
+    // @deprecated (undocumented)
+    trackSource?: Track.Source;
 }
 
 // @public (undocumented)
@@ -568,7 +570,7 @@ export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder): Tr
 export function useFacingMode(trackReference: TrackReferenceOrPlaceholder): 'user' | 'environment' | 'left' | 'right' | 'undefined';
 
 // @public (undocumented)
-export function useFocusToggle({ trackSource, participant, props }: UseFocusToggleProps): {
+export function useFocusToggle({ trackRef, trackSource, participant, props }: UseFocusToggleProps): {
     mergedProps: React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
         className: string;
         onClick: (event: React_2.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
@@ -578,12 +580,14 @@ export function useFocusToggle({ trackSource, participant, props }: UseFocusTogg
 
 // @public (undocumented)
 export interface UseFocusToggleProps {
-    // (undocumented)
+    // @deprecated (undocumented)
     participant?: Participant;
     // (undocumented)
     props: React_2.ButtonHTMLAttributes<HTMLButtonElement>;
     // (undocumented)
-    trackSource: Track.Source;
+    trackRef?: TrackReferenceOrPlaceholder;
+    // @deprecated (undocumented)
+    trackSource?: Track.Source;
 }
 
 // @public

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -1,8 +1,8 @@
 import type { TrackReference, TrackReferenceOrPlaceholder } from '@livekit/components-core';
-import { isTrackReference } from '@livekit/components-core';
 import * as React from 'react';
 import { TrackContext } from '../context/track-context';
 import { cloneSingleChild } from '../utils';
+import { getTrackReferenceId } from '@livekit/components-core';
 
 /** @public */
 export interface TrackLoopProps {
@@ -31,14 +31,8 @@ export function TrackLoop({ tracks, ...props }: TrackLoopProps) {
   return (
     <>
       {tracks.map((trackReference) => {
-        const trackSource = isTrackReference(trackReference)
-          ? trackReference.publication.source
-          : trackReference.source;
         return (
-          <TrackContext.Provider
-            value={trackReference}
-            key={`${trackReference.participant.identity}_${trackSource}`}
-          >
+          <TrackContext.Provider value={trackReference} key={getTrackReferenceId(trackReference)}>
             {cloneSingleChild(props.children)}
           </TrackContext.Provider>
         );

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -1,12 +1,16 @@
 import type { Participant, Track } from 'livekit-client';
 import * as React from 'react';
-import { LayoutContext } from '../../context';
+import { LayoutContext, useMaybeTrackContext } from '../../context';
 import { FocusToggleIcon, UnfocusToggleIcon } from '../../assets/icons';
 import { useFocusToggle } from '../../hooks';
+import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
 
 /** @public */
 export interface FocusToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  trackSource: Track.Source;
+  trackRef?: TrackReferenceOrPlaceholder;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
+  trackSource?: Track.Source;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   participant?: Participant;
 }
 
@@ -21,8 +25,15 @@ export interface FocusToggleProps extends React.ButtonHTMLAttributes<HTMLButtonE
  * ```
  * @public
  */
-export function FocusToggle({ trackSource, participant, ...props }: FocusToggleProps) {
-  const { mergedProps, inFocus } = useFocusToggle({ trackSource, participant, props });
+export function FocusToggle({ trackRef, trackSource, participant, ...props }: FocusToggleProps) {
+  const trackRefFromContext = useMaybeTrackContext();
+
+  const { mergedProps, inFocus } = useFocusToggle({
+    trackRef: trackRef ?? trackRefFromContext,
+    trackSource,
+    participant,
+    props,
+  });
 
   return (
     <LayoutContext.Consumer>

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { Participant, TrackPublication } from 'livekit-client';
 import { Track } from 'livekit-client';
 import type { ParticipantClickEvent, TrackReferenceOrPlaceholder } from '@livekit/components-core';
-import { isParticipantSourcePinned } from '@livekit/components-core';
+import { isTrackReferencePinned } from '@livekit/components-core';
 import { ConnectionQualityIndicator } from './ConnectionQualityIndicator';
 import { ParticipantName } from './ParticipantName';
 import { TrackMutedIndicator } from './TrackMutedIndicator';
@@ -68,11 +68,14 @@ export function ParticipantTile({
   ...htmlProps
 }: ParticipantTileProps) {
   const p = useEnsureParticipant(participant);
-  const trackRef: TrackReferenceOrPlaceholder = useMaybeTrackContext() ?? {
-    participant: p,
-    source,
-    publication,
-  };
+  const initialTrackRef: TrackReferenceOrPlaceholder = React.useMemo(() => {
+    return {
+      participant: p,
+      source,
+      publication,
+    };
+  }, [p, publication, source]);
+  const trackRef: TrackReferenceOrPlaceholder = useMaybeTrackContext() ?? initialTrackRef;
 
   const { elementProps } = useParticipantTile<HTMLDivElement>({
     participant: trackRef.participant,
@@ -92,12 +95,12 @@ export function ParticipantTile({
         !subscribed &&
         layoutContext &&
         layoutContext.pin.dispatch &&
-        isParticipantSourcePinned(trackRef.participant, trackRef.source, layoutContext.pin.state)
+        isTrackReferencePinned(trackRef, layoutContext.pin.state)
       ) {
         layoutContext.pin.dispatch({ msg: 'clear_pin' });
       }
     },
-    [trackRef.participant, layoutContext, trackRef.source],
+    [trackRef, layoutContext],
   );
 
   return (
@@ -148,7 +151,7 @@ export function ParticipantTile({
             </div>
           </>
         )}
-        <FocusToggle trackSource={trackRef.source} />
+        <FocusToggle trackRef={trackRef} />
       </ParticipantContextIfNeeded>
     </div>
   );


### PR DESCRIPTION
This PR addresses a general problem with the way we distinguished tracks. In many places we used a combination of participant identity and track source to identify a track. This falls apart when you have participants with multiple tracks from the same source. For example, a robot participant with multiple camera tracks.

- To address the problem we now construct a `TrackReference` ID like this: `<participant_id>_<track_source>_<publication_id>`
- We also had to update the way `FocusToggle` and `useFocusToggle` work. We deprecated `participant` and `trackSource` parameters in favour of passing a `TrackReference` via the `trackRef` parameter directly.
- Some small changes to the visual stable update logic were also necessary. `TrackReferencePlaceholder` and `TrackReference` would produce the same ID to prevent tiles from changing position in the `GridLayout` or `Carousel`. Because we changed the way `TrackReference` IDs are constructed, we had to modify the existing update step to "migrate" `TrackReference` IDs from `TrackReferencePlaceholders` to `TrackReference`.

Special thanks to Sijmen Huizenga from the LiveKit community Slack for [reporting this bug.](https://livekit-users.slack.com/archives/C048FRL1N2C/p1693388065097569)