### PR TITLE
Only unsusbscribe if intersection is still false

### DIFF
--- a/.changeset/few-gifts-dress.md
+++ b/.changeset/few-gifts-dress.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix occasional black tiles, unsusbscribe if intersection entry is still not intersecting

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -53,7 +53,8 @@ export function VideoTrack({
     if (
       manageSubscription &&
       publication instanceof RemoteTrackPublication &&
-      debouncedIntersectionEntry?.isIntersecting === false
+      debouncedIntersectionEntry?.isIntersecting === false &&
+      intersectionEntry?.isIntersecting === false
     ) {
       publication.setSubscribed(false);
     }


### PR DESCRIPTION
This fixes a bug where tiles coming into view might be unsubscribed from after ~3s because a debounce handler was kicking in that is supposed to make sure that we only unsubscribe from tracks after a certain timeout. 
However that also led to the effect that if the tiles were changing back into view within those 3s they would still get unsubscribed. Fix is simply to check on both the debounced and non-debounced intersection handler whether or not the element is currently intersecting.