### PR TITLE
Fix: media tracks were memoized on participant identity

### DIFF
--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -24,7 +24,7 @@ export function useMediaTrackBySourceOrName(
   const { className, trackObserver } = React.useMemo(() => {
     return setupMediaTrack(observerOptions);
   }, [
-    observerOptions.participant.identity,
+    observerOptions.participant.sid ?? observerOptions.participant.identity,
     observerOptions.source,
     isTrackReference(observerOptions) && observerOptions.publication.trackSid,
   ]);


### PR DESCRIPTION
This uses the `sid` if available which will be unique between reconnects of a participant or switching between rooms (where in both cases the participant's track objects will change and need to be updated).