### PR TITLE
refactor ParticipantTile and useParticipantTile to trackRef and rename TrackContext to TrackRefContext

### DIFF
--- a/.changeset/strong-plums-nail.md
+++ b/.changeset/strong-plums-nail.md
@@ -1,0 +1,6 @@
+---
+'@livekit/components-react': minor
+'@livekit/component-example-next': patch
+---
+
+refactor `ParticipantTile` and `useParticipantTile` to trackRef and rename `TrackContext` to `TrackRefContext`.

--- a/examples/nextjs/pages/clubhouse.tsx
+++ b/examples/nextjs/pages/clubhouse.tsx
@@ -8,7 +8,7 @@ import {
   useIsMuted,
   useIsSpeaking,
   useToken,
-  useTrackContext,
+  useTrackRefContext,
   useTracks,
 } from '@livekit/components-react';
 import styles from '../styles/Clubhouse.module.scss';
@@ -86,7 +86,7 @@ const Stage = () => {
 };
 
 const CustomParticipantTile = () => {
-  const { participant, source } = useTrackContext();
+  const { participant, source } = useTrackRefContext();
   const isSpeaking = useIsSpeaking(participant);
   const isMuted = useIsMuted(source);
 

--- a/examples/nextjs/pages/customize.tsx
+++ b/examples/nextjs/pages/customize.tsx
@@ -9,7 +9,7 @@ import {
   ControlBar,
   GridLayout,
   useTracks,
-  TrackContext,
+  TrackRefContext,
 } from '@livekit/components-react';
 import { ConnectionQuality, Room, Track } from 'livekit-client';
 import styles from '../styles/Simple.module.css';
@@ -78,7 +78,7 @@ export function Stage() {
     <>
       <div className={styles.participantGrid}>
         <GridLayout tracks={tracks}>
-          <TrackContext.Consumer>
+          <TrackRefContext.Consumer>
             {(track) =>
               track && (
                 <div className="my-tile">
@@ -100,7 +100,7 @@ export function Stage() {
                 </div>
               )
             }
-          </TrackContext.Consumer>
+          </TrackRefContext.Consumer>
         </GridLayout>
       </div>
     </>

--- a/examples/nextjs/pages/simple.tsx
+++ b/examples/nextjs/pages/simple.tsx
@@ -5,7 +5,7 @@ import {
   LiveKitRoom,
   ParticipantTile,
   RoomName,
-  TrackContext,
+  TrackRefContext,
   useToken,
   useTracks,
 } from '@livekit/components-react';
@@ -72,7 +72,9 @@ function Stage() {
     <>
       {screenShareTrack && <ParticipantTile {...screenShareTrack} />}
       <GridLayout tracks={cameraTracks}>
-        <TrackContext.Consumer>{(track) => <ParticipantTile {...track} />}</TrackContext.Consumer>
+        <TrackRefContext.Consumer>
+          {(track) => <ParticipantTile {...track} />}
+        </TrackRefContext.Consumer>
       </GridLayout>
     </>
   );

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -381,7 +381,7 @@ export interface ParticipantNameProps extends React_2.HTMLAttributes<HTMLSpanEle
 }
 
 // @public
-export function ParticipantTile({ participant, children, source, onParticipantClick, publication, disableSpeakingIndicator, ...htmlProps }: ParticipantTileProps): React_2.JSX.Element;
+export function ParticipantTile({ trackRef, participant, children, source, onParticipantClick, publication, disableSpeakingIndicator, ...htmlProps }: ParticipantTileProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface ParticipantTileProps extends React_2.HTMLAttributes<HTMLDivElement> {
@@ -389,12 +389,13 @@ export interface ParticipantTileProps extends React_2.HTMLAttributes<HTMLDivElem
     disableSpeakingIndicator?: boolean;
     // (undocumented)
     onParticipantClick?: (event: ParticipantClickEvent) => void;
-    // (undocumented)
+    // @deprecated (undocumented)
     participant?: Participant;
-    // (undocumented)
+    // @deprecated (undocumented)
     publication?: TrackPublication;
-    // (undocumented)
+    // @deprecated (undocumented)
     source?: Track.Source;
+    trackRef?: TrackReferenceOrPlaceholder;
 }
 
 // @public
@@ -441,7 +442,7 @@ export function StartAudio({ label, ...props }: AllowAudioPlaybackProps): React_
 // @public (undocumented)
 export function Toast(props: React_2.HTMLAttributes<HTMLDivElement>): React_2.JSX.Element;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const TrackContext: React_2.Context<TrackReferenceOrPlaceholder | undefined>;
 
 // @public
@@ -465,6 +466,9 @@ export interface TrackMutedIndicatorProps extends React_2.HTMLAttributes<HTMLDiv
     // (undocumented)
     source: Track.Source;
 }
+
+// @public
+export const TrackRefContext: React_2.Context<TrackReferenceOrPlaceholder | undefined>;
 
 // @public
 export function TrackToggle<T extends ToggleSource>({ showIcon, ...props }: TrackToggleProps<T>): React_2.JSX.Element;
@@ -566,6 +570,9 @@ export function useEnsureParticipant(participant?: Participant): Participant;
 export function useEnsureRoom(room?: Room): Room;
 
 // @public
+export function useEnsureTrackRef(trackRef?: TrackReferenceOrPlaceholder): void;
+
+// @public @deprecated
 export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder): TrackReferenceOrPlaceholder;
 
 // @alpha
@@ -649,8 +656,11 @@ export function useMaybeParticipantContext(): Participant | undefined;
 // @public
 export function useMaybeRoomContext(): Room | undefined;
 
-// @public
+// @public @deprecated
 export function useMaybeTrackContext(): TrackReferenceOrPlaceholder | undefined;
+
+// @public
+export function useMaybeTrackRefContext(): TrackReferenceOrPlaceholder | undefined;
 
 // @public (undocumented)
 export function useMediaDevices({ kind }: {
@@ -749,7 +759,7 @@ export interface UseParticipantsOptions {
 }
 
 // @public (undocumented)
-export function useParticipantTile<T extends HTMLElement>({ participant, source, publication, onParticipantClick, disableSpeakingIndicator, htmlProps, }: UseParticipantTileProps<T>): {
+export function useParticipantTile<T extends HTMLElement>({ trackRef, participant, source, publication, onParticipantClick, disableSpeakingIndicator, htmlProps, }: UseParticipantTileProps<T>): {
     elementProps: React_2.HTMLAttributes<T>;
 };
 
@@ -761,12 +771,13 @@ export interface UseParticipantTileProps<T extends HTMLElement> extends React_2.
     htmlProps: React_2.HTMLAttributes<T>;
     // (undocumented)
     onParticipantClick?: (event: ParticipantClickEvent) => void;
-    // (undocumented)
+    // @deprecated (undocumented)
     participant: Participant;
-    // (undocumented)
+    // @deprecated (undocumented)
     publication?: TrackPublication;
-    // (undocumented)
+    // @deprecated (undocumented)
     source: Track.Source;
+    trackRef?: TrackReferenceOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -870,7 +881,7 @@ export interface UseTokenOptions {
     userInfo?: UserInfo;
 }
 
-// @public
+// @public @deprecated
 export function useTrackContext(): TrackReferenceOrPlaceholder;
 
 // @public (undocumented)
@@ -884,6 +895,9 @@ export interface UseTrackMutedIndicatorOptions {
     // (undocumented)
     participant?: Participant;
 }
+
+// @public
+export function useTrackRefContext(): TrackReferenceOrPlaceholder;
 
 // @public
 export function useTracks<T extends SourcesArray = Track.Source[]>(sources?: T, options?: UseTracksOptions): UseTracksHookReturnType<T>;

--- a/packages/react/src/components/TrackLoop.tsx
+++ b/packages/react/src/components/TrackLoop.tsx
@@ -1,6 +1,6 @@
 import type { TrackReference, TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import * as React from 'react';
-import { TrackContext } from '../context/track-reference-context';
+import { TrackRefContext } from '../context/track-reference-context';
 import { cloneSingleChild } from '../utils';
 import { getTrackReferenceId } from '@livekit/components-core';
 
@@ -14,15 +14,15 @@ export interface TrackLoopProps {
 
 /**
  * The TrackLoop component loops over tracks. It is for example a easy way to loop over all participant camera and screen share tracks.
- * TrackLoop creates a TrackContext for each track that you can use to e.g. render the track.
+ * TrackLoop creates a TrackRefContext for each track that you can use to e.g. render the track.
  *
  * @example
  * ```tsx
  * const trackRefs = useTracks([Track.Source.Camera]);
  * <TrackLoop tracks={trackRefs} >
- *  <TrackContext.Consumer>
+ *  <TrackRefContext.Consumer>
  *    {(trackRef) => trackRef && <VideoTrack trackRef={trackRef}/>}
- *  </TrackContext.Consumer>
+ *  </TrackRefContext.Consumer>
  * <TrackLoop />
  * ```
  * @public
@@ -32,9 +32,12 @@ export function TrackLoop({ tracks, ...props }: TrackLoopProps) {
     <>
       {tracks.map((trackReference) => {
         return (
-          <TrackContext.Provider value={trackReference} key={getTrackReferenceId(trackReference)}>
+          <TrackRefContext.Provider
+            value={trackReference}
+            key={getTrackReferenceId(trackReference)}
+          >
             {cloneSingleChild(props.children)}
-          </TrackContext.Provider>
+          </TrackRefContext.Provider>
         );
       })}
     </>

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -1,6 +1,6 @@
 import type { Participant, Track } from 'livekit-client';
 import * as React from 'react';
-import { LayoutContext, useMaybeTrackContext } from '../../context';
+import { LayoutContext, useMaybeTrackRefContext } from '../../context';
 import { FocusToggleIcon, UnfocusToggleIcon } from '../../assets/icons';
 import { useFocusToggle } from '../../hooks';
 import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
@@ -26,7 +26,7 @@ export interface FocusToggleProps extends React.ButtonHTMLAttributes<HTMLButtonE
  * @public
  */
 export function FocusToggle({ trackRef, trackSource, participant, ...props }: FocusToggleProps) {
-  const trackRefFromContext = useMaybeTrackContext();
+  const trackRefFromContext = useMaybeTrackRefContext();
 
   const { mergedProps, inFocus } = useFocusToggle({
     trackRef: trackRef ?? trackRefFromContext,

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useMediaTrackBySourceOrName } from '../../hooks/useMediaTrackBySourceOrName';
 import type { TrackReference } from '@livekit/components-core';
 import { log } from '@livekit/components-core';
-import { useEnsureParticipant, useMaybeTrackContext } from '../../context';
+import { useEnsureParticipant, useMaybeTrackRefContext } from '../../context';
 import { RemoteAudioTrack } from 'livekit-client';
 
 /** @public */
@@ -49,7 +49,7 @@ export function AudioTrack({
   ...props
 }: AudioTrackProps) {
   // TODO: Remove and refactor all variables with underscore in a future version after the deprecation period.
-  const maybeTrackRef = useMaybeTrackContext();
+  const maybeTrackRef = useMaybeTrackRefContext();
   const _name = trackRef?.publication?.trackName ?? maybeTrackRef?.publication?.trackName ?? name;
   const _source = trackRef?.source ?? maybeTrackRef?.source ?? source;
   const _publication = trackRef?.publication ?? maybeTrackRef?.publication ?? publication;

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -8,11 +8,11 @@ import { ParticipantName } from './ParticipantName';
 import { TrackMutedIndicator } from './TrackMutedIndicator';
 import {
   ParticipantContext,
-  TrackContext,
+  TrackRefContext,
   useEnsureParticipant,
   useMaybeLayoutContext,
   useMaybeParticipantContext,
-  useMaybeTrackContext,
+  useMaybeTrackRefContext,
 } from '../../context';
 import { FocusToggle } from '../controls/FocusToggle';
 import { ParticipantPlaceholder } from '../../assets/images';
@@ -46,9 +46,9 @@ function TrackRefContextIfNeeded(
     trackRef?: TrackReferenceOrPlaceholder;
   }>,
 ) {
-  const hasContext = !!useMaybeTrackContext();
+  const hasContext = !!useMaybeTrackRefContext();
   return props.trackRef && !hasContext ? (
-    <TrackContext.Provider value={props.trackRef}>{props.children}</TrackContext.Provider>
+    <TrackRefContext.Provider value={props.trackRef}>{props.children}</TrackRefContext.Provider>
   ) : (
     <>{props.children}</>
   );
@@ -95,7 +95,7 @@ export function ParticipantTile({
   ...htmlProps
 }: ParticipantTileProps) {
   // TODO: remove deprecated props and refactor in a future version.
-  const maybeTrackRef = useMaybeTrackContext();
+  const maybeTrackRef = useMaybeTrackRefContext();
   const p = useEnsureParticipant(participant);
   const trackReference: TrackReferenceOrPlaceholder = React.useMemo(() => {
     return {

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -8,6 +8,7 @@ import { ParticipantName } from './ParticipantName';
 import { TrackMutedIndicator } from './TrackMutedIndicator';
 import {
   ParticipantContext,
+  TrackContext,
   useEnsureParticipant,
   useMaybeLayoutContext,
   useMaybeParticipantContext,
@@ -37,28 +38,54 @@ export function ParticipantContextIfNeeded(
   );
 }
 
+/**
+ * Only create a `TrackRefContext` if there is no `TrackRefContext` already.
+ */
+function TrackRefContextIfNeeded(
+  props: React.PropsWithChildren<{
+    trackRef?: TrackReferenceOrPlaceholder;
+  }>,
+) {
+  const hasContext = !!useMaybeTrackContext();
+  return props.trackRef && !hasContext ? (
+    <TrackContext.Provider value={props.trackRef}>{props.children}</TrackContext.Provider>
+  ) : (
+    <>{props.children}</>
+  );
+}
+
 /** @public */
 export interface ParticipantTileProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** The track reference to display. */
+  trackRef?: TrackReferenceOrPlaceholder;
   disableSpeakingIndicator?: boolean;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   participant?: Participant;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   source?: Track.Source;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   publication?: TrackPublication;
   onParticipantClick?: (event: ParticipantClickEvent) => void;
 }
 
 /**
  * The ParticipantTile component is the base utility wrapper for displaying a visual representation of a participant.
- * This component can be used as a child of the `TrackLoop` component or by spreading a track reference as properties.
+ * This component can be used as a child of the `TrackLoop` component or by passing a track reference as property.
  *
- * @example
+ * @example Using the `ParticipantTile` component with a track reference:
  * ```tsx
- * <ParticipantTile source={Track.Source.Camera} />
- *
- * <ParticipantTile {...trackReference} />
+ * <ParticipantTile trackRef={trackRef} />
+ * ```
+ * @example Using the `ParticipantTile` component as a child of the `TrackLoop` component:
+ * ```tsx
+ * <TrackLoop>
+ *  <ParticipantTile />
+ * </TrackLoop>
  * ```
  * @public
  */
 export function ParticipantTile({
+  trackRef,
   participant,
   children,
   source = Track.Source.Camera,
@@ -67,21 +94,22 @@ export function ParticipantTile({
   disableSpeakingIndicator,
   ...htmlProps
 }: ParticipantTileProps) {
+  // TODO: remove deprecated props and refactor in a future version.
+  const maybeTrackRef = useMaybeTrackContext();
   const p = useEnsureParticipant(participant);
-  const initialTrackRef: TrackReferenceOrPlaceholder = React.useMemo(() => {
+  const trackReference: TrackReferenceOrPlaceholder = React.useMemo(() => {
     return {
-      participant: p,
-      source,
-      publication,
+      participant: trackRef?.participant ?? maybeTrackRef?.participant ?? p,
+      source: trackRef?.source ?? maybeTrackRef?.source ?? source,
+      publication: trackRef?.publication ?? maybeTrackRef?.publication ?? publication,
     };
-  }, [p, publication, source]);
-  const trackRef: TrackReferenceOrPlaceholder = useMaybeTrackContext() ?? initialTrackRef;
+  }, [maybeTrackRef, p, publication, source, trackRef]);
 
   const { elementProps } = useParticipantTile<HTMLDivElement>({
-    participant: trackRef.participant,
+    participant: trackReference.participant,
     htmlProps,
-    source: trackRef.source,
-    publication: trackRef.publication,
+    source: trackReference.source,
+    publication: trackReference.publication,
     disableSpeakingIndicator,
     onParticipantClick,
   });
@@ -91,64 +119,69 @@ export function ParticipantTile({
   const handleSubscribe = React.useCallback(
     (subscribed: boolean) => {
       if (
-        trackRef.source &&
+        trackReference.source &&
         !subscribed &&
         layoutContext &&
         layoutContext.pin.dispatch &&
-        isTrackReferencePinned(trackRef, layoutContext.pin.state)
+        isTrackReferencePinned(trackReference, layoutContext.pin.state)
       ) {
         layoutContext.pin.dispatch({ msg: 'clear_pin' });
       }
     },
-    [trackRef, layoutContext],
+    [trackReference, layoutContext],
   );
 
   return (
     <div style={{ position: 'relative' }} {...elementProps}>
-      <ParticipantContextIfNeeded participant={trackRef.participant}>
-        {children ?? (
-          <>
-            {isTrackReference(trackRef) &&
-            (trackRef.publication?.kind === 'video' ||
-              trackRef.source === Track.Source.Camera ||
-              trackRef.source === Track.Source.ScreenShare) ? (
-              <VideoTrack
-                trackRef={trackRef}
-                onSubscriptionStatusChanged={handleSubscribe}
-                manageSubscription={true}
-              />
-            ) : (
-              isTrackReference(trackRef) && (
-                <AudioTrack trackRef={trackRef} onSubscriptionStatusChanged={handleSubscribe} />
-              )
-            )}
-            <div className="lk-participant-placeholder">
-              <ParticipantPlaceholder />
-            </div>
-            <div className="lk-participant-metadata">
-              <div className="lk-participant-metadata-item">
-                {trackRef.source === Track.Source.Camera ? (
-                  <>
-                    {isEncrypted && <LockLockedIcon style={{ marginRight: '0.25rem' }} />}
-                    <TrackMutedIndicator
-                      source={Track.Source.Microphone}
-                      show={'muted'}
-                    ></TrackMutedIndicator>
-                    <ParticipantName />
-                  </>
-                ) : (
-                  <>
-                    <ScreenShareIcon style={{ marginRight: '0.25rem' }} />
-                    <ParticipantName>&apos;s screen</ParticipantName>
-                  </>
-                )}
+      <TrackRefContextIfNeeded trackRef={trackReference}>
+        <ParticipantContextIfNeeded participant={trackReference.participant}>
+          {children ?? (
+            <>
+              {isTrackReference(trackReference) &&
+              (trackReference.publication?.kind === 'video' ||
+                trackReference.source === Track.Source.Camera ||
+                trackReference.source === Track.Source.ScreenShare) ? (
+                <VideoTrack
+                  trackRef={trackReference}
+                  onSubscriptionStatusChanged={handleSubscribe}
+                  manageSubscription={true}
+                />
+              ) : (
+                isTrackReference(trackReference) && (
+                  <AudioTrack
+                    trackRef={trackReference}
+                    onSubscriptionStatusChanged={handleSubscribe}
+                  />
+                )
+              )}
+              <div className="lk-participant-placeholder">
+                <ParticipantPlaceholder />
               </div>
-              <ConnectionQualityIndicator className="lk-participant-metadata-item" />
-            </div>
-          </>
-        )}
-        <FocusToggle trackRef={trackRef} />
-      </ParticipantContextIfNeeded>
+              <div className="lk-participant-metadata">
+                <div className="lk-participant-metadata-item">
+                  {trackReference.source === Track.Source.Camera ? (
+                    <>
+                      {isEncrypted && <LockLockedIcon style={{ marginRight: '0.25rem' }} />}
+                      <TrackMutedIndicator
+                        source={Track.Source.Microphone}
+                        show={'muted'}
+                      ></TrackMutedIndicator>
+                      <ParticipantName />
+                    </>
+                  ) : (
+                    <>
+                      <ScreenShareIcon style={{ marginRight: '0.25rem' }} />
+                      <ParticipantName>&apos;s screen</ParticipantName>
+                    </>
+                  )}
+                </div>
+                <ConnectionQualityIndicator className="lk-participant-metadata-item" />
+              </div>
+            </>
+          )}
+          <FocusToggle trackRef={trackReference} />
+        </ParticipantContextIfNeeded>
+      </TrackRefContextIfNeeded>
     </div>
   );
 }

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -7,7 +7,7 @@ import {
 import * as React from 'react';
 import { useMediaTrackBySourceOrName } from '../../hooks/useMediaTrackBySourceOrName';
 import type { ParticipantClickEvent, TrackReference } from '@livekit/components-core';
-import { useEnsureParticipant, useMaybeTrackContext } from '../../context';
+import { useEnsureParticipant, useMaybeTrackRefContext } from '../../context';
 import * as useHooks from 'usehooks-ts';
 
 /** @public */
@@ -51,7 +51,7 @@ export function VideoTrack({
   ...props
 }: VideoTrackProps) {
   // TODO: Remove and refactor all variables with underscore in a future version after the deprecation period.
-  const maybeTrackRef = useMaybeTrackContext();
+  const maybeTrackRef = useMaybeTrackRefContext();
   const _name = trackRef?.publication?.trackName ?? maybeTrackRef?.publication?.trackName ?? name;
   const _source = trackRef?.source ?? maybeTrackRef?.source ?? source;
   const _publication = trackRef?.publication ?? maybeTrackRef?.publication ?? publication;

--- a/packages/react/src/context/index.ts
+++ b/packages/react/src/context/index.ts
@@ -18,7 +18,11 @@ export {} from './pin-context';
 export { RoomContext, useEnsureRoom, useMaybeRoomContext, useRoomContext } from './room-context';
 export {
   TrackContext,
+  TrackRefContext,
   useEnsureTrackReference,
+  useEnsureTrackRef,
   useMaybeTrackContext,
+  useMaybeTrackRefContext,
   useTrackContext,
+  useTrackRefContext,
 } from './track-reference-context';

--- a/packages/react/src/context/participant-context.ts
+++ b/packages/react/src/context/participant-context.ts
@@ -1,6 +1,6 @@
 import type { Participant } from 'livekit-client';
 import * as React from 'react';
-import { useMaybeTrackContext } from './track-reference-context';
+import { useMaybeTrackRefContext } from './track-reference-context';
 
 /** @public */
 export const ParticipantContext = React.createContext<Participant | undefined>(undefined);
@@ -33,7 +33,7 @@ export function useMaybeParticipantContext() {
  */
 export function useEnsureParticipant(participant?: Participant) {
   const context = useMaybeParticipantContext();
-  const trackContext = useMaybeTrackContext();
+  const trackContext = useMaybeTrackRefContext();
   const p = participant ?? context ?? trackContext?.participant;
   if (!p) {
     throw new Error(

--- a/packages/react/src/context/track-reference-context.ts
+++ b/packages/react/src/context/track-reference-context.ts
@@ -1,13 +1,23 @@
 import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import * as React from 'react';
 
-/** @public */
+/**
+ * @public
+ * @deprecated `TrackContext` has been to `TrackRefContext`, use this as a drop in replacement.
+ */
 export const TrackContext = React.createContext<TrackReferenceOrPlaceholder | undefined>(undefined);
 
 /**
- * Ensures that a track reference is provided via context.
- * If not inside a `TrackContext`, an error is thrown.
+ * This context provides a `TrackReferenceOrPlaceholder` to all child components.
  * @public
+ */
+export const TrackRefContext = TrackContext;
+
+/**
+ * Ensures that a track reference is provided via context.
+ * If not inside a `TrackRefContext`, an error is thrown.
+ * @public
+ * @deprecated `useTrackContext` has been to `useTrackRefContext`, use this as a drop in replacement.
  */
 export function useTrackContext() {
   const trackReference = React.useContext(TrackContext);
@@ -18,25 +28,53 @@ export function useTrackContext() {
 }
 
 /**
+ * Ensures that a track reference is provided via context.
+ * If not inside a `TrackRefContext`, an error is thrown.
+ * @public
+ */
+export function useTrackRefContext() {
+  return useTrackContext();
+}
+
+/**
  * Returns a track reference from the `TrackContext` if it exists, otherwise `undefined`.
  * @public
+ * @deprecated `useMaybeTrackContext` has been to `useMaybeTrackRefContext`, use this as a drop in replacement.
  */
 export function useMaybeTrackContext() {
   return React.useContext(TrackContext);
 }
 
 /**
+ * Returns a track reference from the `TrackRefContext` if it exists, otherwise `undefined`.
+ * @public
+ */
+export function useMaybeTrackRefContext() {
+  return useMaybeTrackContext();
+}
+
+/**
  * Ensures that a track reference is provided, either via context or explicitly as a parameter.
  * If not inside a `TrackContext` and no track reference is provided, an error is thrown.
  * @public
+ * @deprecated `useEnsureTrackReference` has been to `useEnsureTrackRef`, use this as a drop in replacement.
  */
 export function useEnsureTrackReference(track?: TrackReferenceOrPlaceholder) {
   const context = useMaybeTrackContext();
   const trackRef = track ?? context;
   if (!trackRef) {
     throw new Error(
-      'No TrackReference provided, make sure you are inside a track context or pass the track reference explicitly',
+      'No TrackRef, make sure you are inside a TrackRefContext or pass the TrackRef explicitly',
     );
   }
   return trackRef;
+}
+
+/**
+ * Ensures that a track reference is provided, either via context or explicitly as a parameter.
+ * If not inside a `TrackRefContext` and no track reference is provided, an error is thrown.
+ * @public
+ */
+export function useEnsureTrackRef(trackRef?: TrackReferenceOrPlaceholder) {
+  useEnsureTrackReference(trackRef);
 }

--- a/packages/react/src/hooks/useParticipantTile.ts
+++ b/packages/react/src/hooks/useParticipantTile.ts
@@ -3,7 +3,7 @@ import { setupParticipantTile } from '@livekit/components-core';
 import type { TrackPublication, Participant } from 'livekit-client';
 import { Track } from 'livekit-client';
 import * as React from 'react';
-import { useEnsureParticipant, useMaybeTrackContext } from '../context';
+import { useEnsureParticipant, useMaybeTrackRefContext } from '../context';
 import { mergeProps } from '../mergeProps';
 import { useFacingMode } from './useFacingMode';
 import { useIsMuted } from './useIsMuted';
@@ -36,7 +36,7 @@ export function useParticipantTile<T extends HTMLElement>({
 }: UseParticipantTileProps<T>) {
   // TODO: Remove and refactor after deprecation period to use:
   // const trackReference = useEnsureTrackRefContext(trackRef)`.
-  const maybeTrackRef = useMaybeTrackContext();
+  const maybeTrackRef = useMaybeTrackRefContext();
   const p = useEnsureParticipant(participant);
   const trackReference = React.useMemo(() => {
     return {

--- a/packages/react/src/hooks/useParticipantTile.ts
+++ b/packages/react/src/hooks/useParticipantTile.ts
@@ -34,9 +34,10 @@ export function useParticipantTile<T extends HTMLElement>({
   disableSpeakingIndicator,
   htmlProps,
 }: UseParticipantTileProps<T>) {
+  // TODO: Remove and refactor after deprecation period to use:
+  // const trackReference = useEnsureTrackRefContext(trackRef)`.
   const maybeTrackRef = useMaybeTrackContext();
   const p = useEnsureParticipant(participant);
-
   const trackReference = React.useMemo(() => {
     return {
       participant: trackRef?.participant ?? maybeTrackRef?.participant ?? p,

--- a/packages/react/src/hooks/useParticipantTile.ts
+++ b/packages/react/src/hooks/useParticipantTile.ts
@@ -1,9 +1,9 @@
-import type { ParticipantClickEvent } from '@livekit/components-core';
+import type { ParticipantClickEvent, TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import { setupParticipantTile } from '@livekit/components-core';
 import type { TrackPublication, Participant } from 'livekit-client';
 import { Track } from 'livekit-client';
 import * as React from 'react';
-import { useEnsureParticipant } from '../context';
+import { useEnsureParticipant, useMaybeTrackContext } from '../context';
 import { mergeProps } from '../mergeProps';
 import { useFacingMode } from './useFacingMode';
 import { useIsMuted } from './useIsMuted';
@@ -11,16 +11,22 @@ import { useIsSpeaking } from './useIsSpeaking';
 
 /** @public */
 export interface UseParticipantTileProps<T extends HTMLElement> extends React.HTMLAttributes<T> {
+  /** The track reference to display. */
+  trackRef?: TrackReferenceOrPlaceholder;
   disableSpeakingIndicator?: boolean;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   publication?: TrackPublication;
   onParticipantClick?: (event: ParticipantClickEvent) => void;
   htmlProps: React.HTMLAttributes<T>;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   source: Track.Source;
+  /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
   participant: Participant;
 }
 
 /** @public */
 export function useParticipantTile<T extends HTMLElement>({
+  trackRef,
   participant,
   source,
   publication,
@@ -28,7 +34,27 @@ export function useParticipantTile<T extends HTMLElement>({
   disableSpeakingIndicator,
   htmlProps,
 }: UseParticipantTileProps<T>) {
+  const maybeTrackRef = useMaybeTrackContext();
   const p = useEnsureParticipant(participant);
+
+  const trackReference = React.useMemo(() => {
+    return {
+      participant: trackRef?.participant ?? maybeTrackRef?.participant ?? p,
+      source: trackRef?.source ?? maybeTrackRef?.source ?? source,
+      publication: trackRef?.publication ?? maybeTrackRef?.publication ?? publication,
+    };
+  }, [
+    trackRef?.participant,
+    trackRef?.source,
+    trackRef?.publication,
+    maybeTrackRef?.participant,
+    maybeTrackRef?.source,
+    maybeTrackRef?.publication,
+    p,
+    source,
+    publication,
+  ]);
+
   const mergedProps = React.useMemo(() => {
     const { className } = setupParticipantTile();
     return mergeProps(htmlProps, {
@@ -36,23 +62,33 @@ export function useParticipantTile<T extends HTMLElement>({
       onClick: (event: React.MouseEvent<T, MouseEvent>) => {
         htmlProps.onClick?.(event);
         if (typeof onParticipantClick === 'function') {
-          const track = publication ?? p.getTrack(source);
-          onParticipantClick({ participant: p, track });
+          const track =
+            trackReference.publication ??
+            trackReference.participant.getTrack(trackReference.source);
+          onParticipantClick({ participant: trackReference.participant, track });
         }
       },
     });
-  }, [htmlProps, source, onParticipantClick, p, publication]);
-  const isVideoMuted = useIsMuted(Track.Source.Camera, { participant });
-  const isAudioMuted = useIsMuted(Track.Source.Microphone, { participant });
-  const isSpeaking = useIsSpeaking(participant);
-  const facingMode = useFacingMode({ participant, publication, source });
+  }, [
+    htmlProps,
+    onParticipantClick,
+    trackReference.publication,
+    trackReference.source,
+    trackReference.participant,
+  ]);
+  const isVideoMuted = useIsMuted(Track.Source.Camera, { participant: trackReference.participant });
+  const isAudioMuted = useIsMuted(Track.Source.Microphone, {
+    participant: trackReference.participant,
+  });
+  const isSpeaking = useIsSpeaking(trackReference.participant);
+  const facingMode = useFacingMode(trackReference);
   return {
     elementProps: {
       'data-lk-audio-muted': isAudioMuted,
       'data-lk-video-muted': isVideoMuted,
       'data-lk-speaking': disableSpeakingIndicator === true ? false : isSpeaking,
-      'data-lk-local-participant': participant.isLocal,
-      'data-lk-source': source,
+      'data-lk-local-participant': trackReference.participant.isLocal,
+      'data-lk-source': trackReference.source,
       'data-lk-facing-mode': facingMode,
       ...mergedProps,
     } as React.HTMLAttributes<T>,


### PR DESCRIPTION
- deprecate `participant`, `source` and `publication` in favour of `trackRef` `parameter` for `useParticipantTile` and `ParticipantTile`
- Rename and deprecate `TrackContext` and derived hooks to `TrackRefContext`. Replace use of the deprecated version in the codebase.

> **Note**
> All changes should be non-breaking.