### PR TITLE
make source and participant optional

### DIFF
--- a/.changeset/breezy-rings-mate.md
+++ b/.changeset/breezy-rings-mate.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Make `source` and `participant` props optional for `UseParticipantTileProps`.

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -784,11 +784,11 @@ export interface UseParticipantTileProps<T extends HTMLElement> extends React_2.
     // (undocumented)
     onParticipantClick?: (event: ParticipantClickEvent) => void;
     // @deprecated (undocumented)
-    participant: Participant;
+    participant?: Participant;
     // @deprecated (undocumented)
     publication?: TrackPublication;
     // @deprecated (undocumented)
-    source: Track.Source;
+    source?: Track.Source;
     trackRef?: TrackReferenceOrPlaceholder;
 }
 

--- a/packages/react/src/hooks/useParticipantTile.ts
+++ b/packages/react/src/hooks/useParticipantTile.ts
@@ -19,9 +19,9 @@ export interface UseParticipantTileProps<T extends HTMLElement> extends React.HT
   onParticipantClick?: (event: ParticipantClickEvent) => void;
   htmlProps: React.HTMLAttributes<T>;
   /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
-  source: Track.Source;
+  source?: Track.Source;
   /** @deprecated This parameter will be removed in a future version use `trackRef` instead. */
-  participant: Participant;
+  participant?: Participant;
 }
 
 /** @public */
@@ -39,10 +39,16 @@ export function useParticipantTile<T extends HTMLElement>({
   const maybeTrackRef = useMaybeTrackRefContext();
   const p = useEnsureParticipant(participant);
   const trackReference = React.useMemo(() => {
+    const _source = trackRef?.source ?? maybeTrackRef?.source ?? source;
+    if (_source === undefined) {
+      throw new Error(
+        'Missing track `source`, provided it via `trackRef`, `source` property or via `TrackRefContext`.',
+      );
+    }
     return {
       participant: trackRef?.participant ?? maybeTrackRef?.participant ?? p,
-      source: trackRef?.source ?? maybeTrackRef?.source ?? source,
       publication: trackRef?.publication ?? maybeTrackRef?.publication ?? publication,
+      source: _source,
     };
   }, [
     trackRef?.participant,


### PR DESCRIPTION
Make source and participant optional, so users don't have to provide them if they already pass a `trackRef'.