### PR TITLE
Fix start audio component flash issue

### DIFF
--- a/.changeset/light-spies-brake.md
+++ b/.changeset/light-spies-brake.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Set the default value for `canPlayAudio` returned by the `useStartAudio` hook to `true` to avoid flashing issues.

--- a/packages/react/src/hooks/useStartAudio.ts
+++ b/packages/react/src/hooks/useStartAudio.ts
@@ -30,7 +30,7 @@ export function useStartAudio({ room, props }: UseStartAudioProps) {
     () => roomAudioPlaybackAllowedObservable(roomEnsured),
     [roomEnsured, roomAudioPlaybackAllowedObservable],
   );
-  const { canPlayAudio } = useObservableState(observable, { canPlayAudio: false });
+  const { canPlayAudio } = useObservableState(observable, { canPlayAudio: true });
 
   const mergedProps = React.useMemo(
     () =>


### PR DESCRIPTION
Fix start audio component flash issue with canPlayAudio set to true by default until detected otherwise