### PR TITLE
Add controls to RoomAudioRenderer

### DIFF
--- a/.changeset/quick-crabs-retire.md
+++ b/.changeset/quick-crabs-retire.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": minor
+---
+
+Add `volume` and `muted` control to `RoomAudioRenderer` and `AudioTrack`. Include to render `Track.Source.Unknown` in `RoomAudioRenderer` as long as they are of king `Track.Kind.Audio`.

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -65,12 +65,12 @@ export interface AudioConferenceProps extends React_2.HTMLAttributes<HTMLDivElem
 }
 
 // @public
-export function AudioTrack({ trackRef, onSubscriptionStatusChanged, volume, isMuted, source, name, publication, participant: p, ...props }: AudioTrackProps): React_2.JSX.Element;
+export function AudioTrack({ trackRef, onSubscriptionStatusChanged, volume, source, name, publication, participant: p, ...props }: AudioTrackProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement> extends React_2.HTMLAttributes<T> {
     // @alpha
-    isMuted?: boolean;
+    muted?: boolean;
     // @deprecated (undocumented)
     name?: string;
     // (undocumented)
@@ -449,12 +449,12 @@ export interface PreJoinProps extends Omit<React_2.HTMLAttributes<HTMLDivElement
 export { ReceivedChatMessage }
 
 // @public
-export function RoomAudioRenderer({ volume, isMuted }: RoomAudioRendererProps): React_2.JSX.Element;
+export function RoomAudioRenderer({ volume, muted }: RoomAudioRendererProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface RoomAudioRendererProps {
     // @alpha
-    isMuted?: boolean;
+    muted?: boolean;
     volume?: number;
 }
 

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -453,6 +453,7 @@ export function RoomAudioRenderer({ volume, isMuted }: RoomAudioRendererProps): 
 
 // @public (undocumented)
 export interface RoomAudioRendererProps {
+    // @alpha
     isMuted?: boolean;
     volume?: number;
 }

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -65,10 +65,12 @@ export interface AudioConferenceProps extends React_2.HTMLAttributes<HTMLDivElem
 }
 
 // @public
-export function AudioTrack({ trackRef, onSubscriptionStatusChanged, volume, source, name, publication, participant: p, ...props }: AudioTrackProps): React_2.JSX.Element;
+export function AudioTrack({ trackRef, onSubscriptionStatusChanged, volume, isMuted, source, name, publication, participant: p, ...props }: AudioTrackProps): React_2.JSX.Element;
 
 // @public (undocumented)
 export interface AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement> extends React_2.HTMLAttributes<T> {
+    // @alpha
+    isMuted?: boolean;
     // @deprecated (undocumented)
     name?: string;
     // (undocumented)
@@ -447,7 +449,13 @@ export interface PreJoinProps extends Omit<React_2.HTMLAttributes<HTMLDivElement
 export { ReceivedChatMessage }
 
 // @public
-export function RoomAudioRenderer(): React_2.JSX.Element;
+export function RoomAudioRenderer({ volume, isMuted }: RoomAudioRendererProps): React_2.JSX.Element;
+
+// @public (undocumented)
+export interface RoomAudioRendererProps {
+    isMuted?: boolean;
+    volume?: number;
+}
 
 // @public (undocumented)
 export const RoomContext: React_2.Context<Room | undefined>;

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -8,6 +8,8 @@ import { AudioTrack } from './participant/AudioTrack';
 export interface RoomAudioRendererProps {
   /** Sets the volume for all audio tracks rendered by this component. By default, the range is between `0.0` and `1.0`. */
   volume?: number;
+  /** If set to true, mutes all audio tracks rendered by the component. */
+  isMuted?: boolean;
 }
 
 /**
@@ -22,7 +24,7 @@ export interface RoomAudioRendererProps {
  * ```
  * @public
  */
-export function RoomAudioRenderer({ volume }: RoomAudioRendererProps) {
+export function RoomAudioRenderer({ volume, isMuted }: RoomAudioRendererProps) {
   const tracks = useTracks(
     [Track.Source.Microphone, Track.Source.ScreenShareAudio, Track.Source.Unknown],
     {
@@ -40,7 +42,12 @@ export function RoomAudioRenderer({ volume }: RoomAudioRendererProps) {
   return (
     <div style={{ display: 'none' }}>
       {tracks.map((trackRef) => (
-        <AudioTrack key={getTrackReferenceId(trackRef)} trackRef={trackRef} volume={volume} />
+        <AudioTrack
+          key={getTrackReferenceId(trackRef)}
+          trackRef={trackRef}
+          volume={volume}
+          isMuted={isMuted}
+        />
       ))}
     </div>
   );

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -5,6 +5,11 @@ import * as React from 'react';
 import { useTracks } from '../hooks';
 import { AudioTrack } from './participant/AudioTrack';
 
+export interface RoomAudioRendererProps {
+  /** Sets the volume for all audio tracks rendered by this component. By default, the range is between `0.0` and `1.0`. */
+  volume?: number;
+}
+
 /**
  * The `RoomAudioRenderer` component is a drop-in solution for adding audio to your LiveKit app.
  * It takes care of handling remote participants’ audio tracks and makes sure that microphones and screen share are audible.
@@ -17,20 +22,22 @@ import { AudioTrack } from './participant/AudioTrack';
  * ```
  * @public
  */
-export function RoomAudioRenderer() {
+export function RoomAudioRenderer({ volume }: RoomAudioRendererProps) {
   const tracks = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio], {
     updateOnlyOn: [],
     onlySubscribed: false,
   }).filter((ref) => !isLocal(ref.participant));
 
   React.useEffect(() => {
-    tracks.forEach((track) => (track.publication as RemoteTrackPublication).setSubscribed(true));
+    for (const track of tracks) {
+      (track.publication as RemoteTrackPublication).setSubscribed(true);
+    }
   }, [tracks]);
 
   return (
     <div style={{ display: 'none' }}>
       {tracks.map((trackRef) => (
-        <AudioTrack key={getTrackReferenceId(trackRef)} trackRef={trackRef} />
+        <AudioTrack key={getTrackReferenceId(trackRef)} trackRef={trackRef} volume={volume} />
       ))}
     </div>
   );

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -12,11 +12,10 @@ export interface RoomAudioRendererProps {
   /**
    * If set to `true`, mutes all audio tracks rendered by the component.
    * @remarks
-   * Does not currently support the Web Audio API. A workaround is to
-   * set the volume to `0` instead.
+   * If set to `true`, the server will stop sending audio track data to the client.
    * @alpha
    */
-  isMuted?: boolean;
+  muted?: boolean;
 }
 
 /**
@@ -31,7 +30,7 @@ export interface RoomAudioRendererProps {
  * ```
  * @public
  */
-export function RoomAudioRenderer({ volume, isMuted }: RoomAudioRendererProps) {
+export function RoomAudioRenderer({ volume, muted }: RoomAudioRendererProps) {
   const tracks = useTracks(
     [Track.Source.Microphone, Track.Source.ScreenShareAudio, Track.Source.Unknown],
     {
@@ -53,7 +52,7 @@ export function RoomAudioRenderer({ volume, isMuted }: RoomAudioRendererProps) {
           key={getTrackReferenceId(trackRef)}
           trackRef={trackRef}
           volume={volume}
-          isMuted={isMuted}
+          muted={muted}
         />
       ))}
     </div>

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -23,10 +23,13 @@ export interface RoomAudioRendererProps {
  * @public
  */
 export function RoomAudioRenderer({ volume }: RoomAudioRendererProps) {
-  const tracks = useTracks([Track.Source.Microphone, Track.Source.ScreenShareAudio], {
-    updateOnlyOn: [],
-    onlySubscribed: false,
-  }).filter((ref) => !isLocal(ref.participant));
+  const tracks = useTracks(
+    [Track.Source.Microphone, Track.Source.ScreenShareAudio, Track.Source.Unknown],
+    {
+      updateOnlyOn: [],
+      onlySubscribed: false,
+    },
+  ).filter((ref) => !isLocal(ref.participant) && ref.publication.kind === Track.Kind.Audio);
 
   React.useEffect(() => {
     for (const track of tracks) {

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { useTracks } from '../hooks';
 import { AudioTrack } from './participant/AudioTrack';
 
+/** @public */
 export interface RoomAudioRendererProps {
   /** Sets the volume for all audio tracks rendered by this component. By default, the range is between `0.0` and `1.0`. */
   volume?: number;

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -8,7 +8,13 @@ import { AudioTrack } from './participant/AudioTrack';
 export interface RoomAudioRendererProps {
   /** Sets the volume for all audio tracks rendered by this component. By default, the range is between `0.0` and `1.0`. */
   volume?: number;
-  /** If set to true, mutes all audio tracks rendered by the component. */
+  /**
+   * If set to `true`, mutes all audio tracks rendered by the component.
+   * @remarks
+   * Does not currently support the Web Audio API. A workaround is to
+   * set the volume to `0` instead.
+   * @alpha
+   */
   isMuted?: boolean;
 }
 

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -16,7 +16,7 @@ export * from './participant/VideoTrack';
 export * from './participant/ParticipantName';
 export * from './participant/TrackMutedIndicator';
 export * from './ParticipantLoop';
-export { RoomAudioRenderer } from './RoomAudioRenderer';
+export { RoomAudioRenderer, type RoomAudioRendererProps } from './RoomAudioRenderer';
 export * from './RoomName';
 export { Toast } from './Toast';
 export * from './TrackLoop';

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -20,7 +20,7 @@ export interface AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement>
   /** @deprecated This property will be removed in a future version use `trackRef` instead. */
   publication?: TrackPublication;
   onSubscriptionStatusChanged?: (subscribed: boolean) => void;
-  /** by the default the range is between 0 and 1 */
+  /** Sets the volume of the audio track. By default, the range is between `0.0` and `1.0`. */
   volume?: number;
 }
 

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -22,6 +22,14 @@ export interface AudioTrackProps<T extends HTMLMediaElement = HTMLMediaElement>
   onSubscriptionStatusChanged?: (subscribed: boolean) => void;
   /** Sets the volume of the audio track. By default, the range is between `0.0` and `1.0`. */
   volume?: number;
+  /**
+   * Mutes the audio track if set to `true`.
+   * @remarks
+   * Does not currently support the Web Audio API.
+   * A workaround is to set the volume to `0` instead.
+   * @alpha
+   */
+  isMuted?: boolean;
 }
 
 /**
@@ -42,6 +50,7 @@ export function AudioTrack({
   trackRef,
   onSubscriptionStatusChanged,
   volume,
+  isMuted,
   source,
   name,
   publication,
@@ -84,5 +93,5 @@ export function AudioTrack({
     }
   }, [volume, track]);
 
-  return <audio ref={mediaEl} {...elementProps} />;
+  return <audio ref={mediaEl} muted={isMuted} {...elementProps} />;
 }


### PR DESCRIPTION
- add `volume` control to `RoomAudioRenderer`
- add `muted` control to `RoomAudioRenderer` and `AudioTrack`
- include to render `Track.Source.Unknown` in `RoomAudioRenderer` as long as they are of king `Track.Kind.Audio`