### PR TITLE
Fix useTrackRef

### DIFF
--- a/.changeset/olive-olives-flow.md
+++ b/.changeset/olive-olives-flow.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix `useTrackRef` for certain cases.

--- a/packages/react/src/hooks/useTrackMutedIndicator.ts
+++ b/packages/react/src/hooks/useTrackMutedIndicator.ts
@@ -42,7 +42,7 @@ export function useTrackMutedIndicator(
   options: UseTrackMutedIndicatorOptions = {},
 ): TrackMutedIndicatorReturnType {
   let ref = useMaybeTrackRefContext();
-  const p = useMaybeParticipantContext() ?? options.participant;
+  const p = useMaybeParticipantContext() ?? options.participant ?? ref?.participant;
 
   if (typeof trackRefOrSource === 'string') {
     if (!p) {


### PR DESCRIPTION
This pull request fixes the `useTrackRef` function.
When there is no `ParticipantContext`, only a `TrackRefContext` provided, and only the `source` is passed.