### PR TITLE
Add saveUsername and make PreJoin backwards compatible

### DIFF
--- a/examples/nextjs/pages/prejoin.tsx
+++ b/examples/nextjs/pages/prejoin.tsx
@@ -7,7 +7,19 @@ const PreJoinExample: NextPage = () => {
 
   return (
     <div data-lk-theme="default" style={{ height: '100vh' }}>
-      <PreJoin />
+      <PreJoin
+        defaults={{ e2ee: true, videoDeviceId: '' }}
+        onSubmit={(values) => {
+          values.audioDeviceId;
+          values.e2ee;
+          values.sharedPassphrase;
+        }}
+        onValidate={(values) => {
+          values.e2ee;
+          values.sharedPassphrase;
+          return true;
+        }}
+      />
     </div>
   );
 };

--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -219,11 +219,16 @@ export function isTrackReferencePlaceholder(trackReference?: TrackReferenceOrPla
 export function isWeb(): boolean;
 
 // @alpha
-export function loadUserChoices(defaults?: Partial<UserChoices>,
-preventLoad?: boolean): UserChoices;
+export function loadUserChoices(defaults?: Partial<LocalUserChoices>,
+preventLoad?: boolean): LocalUserChoices;
 
-// @public (undocumented)
-export type LocalUserChoices = UserChoices & {
+// @public
+export type LocalUserChoices = {
+    videoEnabled: boolean;
+    audioEnabled: boolean;
+    videoDeviceId: string;
+    audioDeviceId: string;
+    username: string;
     e2ee: boolean;
     sharedPassphrase: string;
 };
@@ -345,7 +350,7 @@ export function roomInfoObserver(room: Room): Observable<{
 export function roomObserver(room: Room): Observable<Room>;
 
 // @alpha
-export function saveUserChoices(userChoices: UserChoices,
+export function saveUserChoices(userChoices: LocalUserChoices,
 preventSave?: boolean): void;
 
 // @public (undocumented)
@@ -569,15 +574,6 @@ export type TrackSourceWithOptions = {
 //
 // @public
 export function updatePages<T extends UpdatableItem>(currentList: T[], nextList: T[], maxItemsOnPage: number): T[];
-
-// @public
-export type UserChoices = {
-    videoEnabled: boolean;
-    audioEnabled: boolean;
-    videoDeviceId: string;
-    audioDeviceId: string;
-    username: string;
-};
 
 // @public (undocumented)
 export type VideoSource = Track.Source.Camera | Track.Source.ScreenShare;

--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -223,6 +223,12 @@ export function loadUserChoices(defaults?: Partial<UserChoices>,
 preventLoad?: boolean): UserChoices;
 
 // @public (undocumented)
+export type LocalUserChoices = UserChoices & {
+    e2ee: boolean;
+    sharedPassphrase: string;
+};
+
+// @public (undocumented)
 export const log: loglevel.Logger;
 
 // @public (undocumented)
@@ -339,7 +345,7 @@ export function roomInfoObserver(room: Room): Observable<{
 export function roomObserver(room: Room): Observable<Room>;
 
 // @alpha
-export function saveUserChoices(deviceSettings: UserChoices,
+export function saveUserChoices(userChoices: UserChoices,
 preventSave?: boolean): void;
 
 // @public (undocumented)
@@ -566,10 +572,10 @@ export function updatePages<T extends UpdatableItem>(currentList: T[], nextList:
 
 // @public
 export type UserChoices = {
-    videoInputEnabled: boolean;
-    audioInputEnabled: boolean;
-    videoInputDeviceId: string;
-    audioInputDeviceId: string;
+    videoEnabled: boolean;
+    audioEnabled: boolean;
+    videoDeviceId: string;
+    audioDeviceId: string;
     username: string;
 };
 

--- a/packages/core/src/persistent-storage/index.ts
+++ b/packages/core/src/persistent-storage/index.ts
@@ -1,1 +1,6 @@
-export { saveUserChoices, loadUserChoices, type UserChoices } from './user-choices';
+export {
+  saveUserChoices,
+  loadUserChoices,
+  type UserChoices,
+  type LocalUserChoices,
+} from './user-choices';

--- a/packages/core/src/persistent-storage/index.ts
+++ b/packages/core/src/persistent-storage/index.ts
@@ -1,6 +1,1 @@
-export {
-  saveUserChoices,
-  loadUserChoices,
-  type UserChoices,
-  type LocalUserChoices,
-} from './user-choices';
+export { saveUserChoices, loadUserChoices, type LocalUserChoices } from './user-choices';

--- a/packages/core/src/persistent-storage/local-storage-helpers.ts
+++ b/packages/core/src/persistent-storage/local-storage-helpers.ts
@@ -1,12 +1,10 @@
 import { log } from '../logger';
 
 /**
- * Set an object to local storage by key
- * @param key - the key to set the object to local storage
- * @param value - the object to set to local storage
+ * Persists a serializable object to local storage associated with the specified key.
  * @internal
  */
-export function setLocalStorageObject<T extends object>(key: string, value: T): void {
+export function saveToLocalStorage<T extends object>(key: string, value: T): void {
   if (typeof localStorage === 'undefined') {
     log.error('Local storage is not available.');
     return;
@@ -20,12 +18,10 @@ export function setLocalStorageObject<T extends object>(key: string, value: T): 
 }
 
 /**
- * Get an object from local storage by key
- * @param key - the key to retrieve the object from local storage
- * @returns the object retrieved from local storage, or null if the key does not exist
+ * Retrieves a serializable object from local storage by its key.
  * @internal
  */
-export function getLocalStorageObject<T extends object>(key: string): T | undefined {
+export function loadFromLocalStorage<T extends object>(key: string): T | undefined {
   if (typeof localStorage === 'undefined') {
     log.error('Local storage is not available.');
     return undefined;

--- a/packages/core/src/persistent-storage/local-storage-helpers.ts
+++ b/packages/core/src/persistent-storage/local-storage-helpers.ts
@@ -9,7 +9,7 @@ type JsonValue = JsonPrimitive | JsonArray | JsonObject;
  * Persists a serializable object to local storage associated with the specified key.
  * @internal
  */
-export function saveToLocalStorage<T extends JsonValue>(key: string, value: T): void {
+function saveToLocalStorage<T extends JsonValue>(key: string, value: T): void {
   if (typeof localStorage === 'undefined') {
     log.error('Local storage is not available.');
     return;
@@ -26,7 +26,7 @@ export function saveToLocalStorage<T extends JsonValue>(key: string, value: T): 
  * Retrieves a serializable object from local storage by its key.
  * @internal
  */
-export function loadFromLocalStorage<T extends JsonValue>(key: string): T | undefined {
+function loadFromLocalStorage<T extends JsonValue>(key: string): T | undefined {
   if (typeof localStorage === 'undefined') {
     log.error('Local storage is not available.');
     return undefined;
@@ -43,4 +43,17 @@ export function loadFromLocalStorage<T extends JsonValue>(key: string): T | unde
     log.error(`Error getting item from local storage: ${error}`);
     return undefined;
   }
+}
+
+/**
+ * Generate a pair of functions to load and save a value of type T to local storage.
+ * @internal
+ */
+export function createLocalStorageInterface<T extends JsonValue>(
+  key: string,
+): { load: () => T | undefined; save: (value: T) => void } {
+  return {
+    load: () => loadFromLocalStorage<T>(key),
+    save: (value: T) => saveToLocalStorage<T>(key, value),
+  };
 }

--- a/packages/core/src/persistent-storage/local-storage-helpers.ts
+++ b/packages/core/src/persistent-storage/local-storage-helpers.ts
@@ -1,10 +1,15 @@
 import { log } from '../logger';
 
+type JsonPrimitive = string | number | boolean | null;
+type JsonArray = JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+
 /**
  * Persists a serializable object to local storage associated with the specified key.
  * @internal
  */
-export function saveToLocalStorage<T extends object>(key: string, value: T): void {
+export function saveToLocalStorage<T extends JsonValue>(key: string, value: T): void {
   if (typeof localStorage === 'undefined') {
     log.error('Local storage is not available.');
     return;
@@ -21,7 +26,7 @@ export function saveToLocalStorage<T extends object>(key: string, value: T): voi
  * Retrieves a serializable object from local storage by its key.
  * @internal
  */
-export function loadFromLocalStorage<T extends object>(key: string): T | undefined {
+export function loadFromLocalStorage<T extends JsonValue>(key: string): T | undefined {
   if (typeof localStorage === 'undefined') {
     log.error('Local storage is not available.');
     return undefined;

--- a/packages/core/src/persistent-storage/user-choices.ts
+++ b/packages/core/src/persistent-storage/user-choices.ts
@@ -12,22 +12,22 @@ export type UserChoices = {
    * Whether video input is enabled.
    * @defaultValue `true`
    */
-  videoInputEnabled: boolean;
+  videoEnabled: boolean;
   /**
    * Whether audio input is enabled.
    * @defaultValue `true`
    */
-  audioInputEnabled: boolean;
+  audioEnabled: boolean;
   /**
    * The device ID of the video input device to use.
    * @defaultValue `''`
    */
-  videoInputDeviceId: string;
+  videoDeviceId: string;
   /**
    * The device ID of the audio input device to use.
    * @defaultValue `''`
    */
-  audioInputDeviceId: string;
+  audioDeviceId: string;
   /**
    * The username to use.
    * @defaultValue `''`
@@ -35,21 +35,28 @@ export type UserChoices = {
   username: string;
 };
 
+export type LocalUserChoices = UserChoices & {
+  /** @deprecated This property will be removed without replacement. */
+  e2ee: boolean;
+  /** @deprecated This property will be removed without replacement. */
+  sharedPassphrase: string;
+};
+
 const defaultUserChoices: UserChoices = {
-  videoInputEnabled: true,
-  audioInputEnabled: true,
-  videoInputDeviceId: '',
-  audioInputDeviceId: '',
+  videoEnabled: true,
+  audioEnabled: true,
+  videoDeviceId: '',
+  audioDeviceId: '',
   username: '',
 } as const;
 
 /**
  * Saves user choices to local storage.
- * @param deviceSettings - The device settings to be stored.
+ * @param userChoices - The device settings to be stored.
  * @alpha
  */
 export function saveUserChoices(
-  deviceSettings: UserChoices,
+  userChoices: UserChoices,
   /**
    * Whether to prevent saving user choices to local storage.
    */
@@ -58,7 +65,7 @@ export function saveUserChoices(
   if (preventSave === true) {
     return;
   }
-  setLocalStorageObject(USER_CHOICES_KEY, deviceSettings);
+  setLocalStorageObject(USER_CHOICES_KEY, userChoices);
 }
 
 /**
@@ -77,10 +84,10 @@ export function loadUserChoices(
   preventLoad: boolean = false,
 ): UserChoices {
   const fallback: UserChoices = {
-    videoInputEnabled: defaults?.videoInputEnabled ?? defaultUserChoices.videoInputEnabled,
-    audioInputEnabled: defaults?.audioInputEnabled ?? defaultUserChoices.audioInputEnabled,
-    videoInputDeviceId: defaults?.videoInputDeviceId ?? defaultUserChoices.videoInputDeviceId,
-    audioInputDeviceId: defaults?.audioInputDeviceId ?? defaultUserChoices.audioInputDeviceId,
+    videoEnabled: defaults?.videoEnabled ?? defaultUserChoices.videoEnabled,
+    audioEnabled: defaults?.audioEnabled ?? defaultUserChoices.audioEnabled,
+    videoDeviceId: defaults?.videoDeviceId ?? defaultUserChoices.videoDeviceId,
+    audioDeviceId: defaults?.audioDeviceId ?? defaultUserChoices.audioDeviceId,
     username: defaults?.username ?? defaultUserChoices.username,
   };
 

--- a/packages/core/src/persistent-storage/user-choices.ts
+++ b/packages/core/src/persistent-storage/user-choices.ts
@@ -1,5 +1,5 @@
 import { cssPrefix } from '../constants';
-import { loadFromLocalStorage, saveToLocalStorage } from './local-storage-helpers';
+import { createLocalStorageInterface } from './local-storage-helpers';
 
 const USER_CHOICES_KEY = `${cssPrefix}-device-settings` as const;
 
@@ -39,14 +39,6 @@ export type LocalUserChoices = {
   sharedPassphrase: string;
 };
 
-/**
- * The type of the object stored in local storage.
- * @remarks
- * TODO: remove this after removing the deprecated properties from `LocalUserChoices`.
- * @internal
- */
-type TempStorageType = Omit<LocalUserChoices, 'e2ee' | 'sharedPassphrase'>;
-
 const defaultUserChoices: LocalUserChoices = {
   videoEnabled: true,
   audioEnabled: true,
@@ -56,6 +48,15 @@ const defaultUserChoices: LocalUserChoices = {
   e2ee: false,
   sharedPassphrase: '',
 } as const;
+
+/**
+ * The type of the object stored in local storage.
+ * @remarks
+ * TODO: Replace this type with `LocalUserChoices` after removing the deprecated properties from `LocalUserChoices`.
+ * @internal
+ */
+type TempStorageType = Omit<LocalUserChoices, 'e2ee' | 'sharedPassphrase'>;
+const { load, save } = createLocalStorageInterface<TempStorageType>(USER_CHOICES_KEY);
 
 /**
  * Saves user choices to local storage.
@@ -73,7 +74,7 @@ export function saveUserChoices(
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { e2ee, sharedPassphrase, ...toSave } = userChoices;
-  saveToLocalStorage(USER_CHOICES_KEY, toSave);
+  save(toSave);
 }
 
 /**
@@ -104,7 +105,7 @@ export function loadUserChoices(
   if (preventLoad) {
     return fallback;
   } else {
-    const maybeLoadedObject = loadFromLocalStorage<TempStorageType>(USER_CHOICES_KEY);
+    const maybeLoadedObject = load();
     const result = { ...fallback, ...(maybeLoadedObject ?? {}) };
     return result;
   }

--- a/packages/core/src/persistent-storage/user-choices.ts
+++ b/packages/core/src/persistent-storage/user-choices.ts
@@ -1,5 +1,5 @@
 import { cssPrefix } from '../constants';
-import { getLocalStorageObject, setLocalStorageObject } from './local-storage-helpers';
+import { loadFromLocalStorage, saveToLocalStorage } from './local-storage-helpers';
 
 const USER_CHOICES_KEY = `${cssPrefix}-device-settings` as const;
 
@@ -65,7 +65,7 @@ export function saveUserChoices(
   if (preventSave === true) {
     return;
   }
-  setLocalStorageObject(USER_CHOICES_KEY, userChoices);
+  saveToLocalStorage(USER_CHOICES_KEY, userChoices);
 }
 
 /**
@@ -94,6 +94,6 @@ export function loadUserChoices(
   if (preventLoad) {
     return fallback;
   } else {
-    return getLocalStorageObject(USER_CHOICES_KEY) ?? fallback;
+    return loadFromLocalStorage(USER_CHOICES_KEY) ?? fallback;
   }
 }

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -49,7 +49,6 @@ import { TrackPublication } from 'livekit-client';
 import type { TrackReference } from '@livekit/components-core';
 import { TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import type { TrackSourceWithOptions } from '@livekit/components-core';
-import { UserChoices } from '@livekit/components-core';
 import type { VideoCaptureOptions } from 'livekit-client';
 import type { VideoSource } from '@livekit/components-core';
 import type { WidgetState } from '@livekit/components-core';
@@ -827,7 +826,7 @@ export interface UseParticipantTileProps<T extends HTMLElement> extends React_2.
 
 // @alpha
 export function usePersistentUserChoices(options?: UsePersistentUserChoicesOptions): {
-    userChoices: UserChoices;
+    userChoices: LocalUserChoices;
     saveAudioInputEnabled: (isEnabled: boolean) => void;
     saveVideoInputEnabled: (isEnabled: boolean) => void;
     saveAudioInputDeviceId: (deviceId: string) => void;
@@ -837,7 +836,7 @@ export function usePersistentUserChoices(options?: UsePersistentUserChoicesOptio
 
 // @alpha
 export interface UsePersistentUserChoicesOptions {
-    defaults?: Partial<UserChoices>;
+    defaults?: Partial<LocalUserChoices>;
     preventLoad?: boolean;
     preventSave?: boolean;
 }
@@ -854,8 +853,6 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(en
 
 // @alpha (undocumented)
 export function usePreviewTracks(options: CreateLocalTracksOptions, onError?: (err: Error) => void): LocalTrack[] | undefined;
-
-export { UserChoices }
 
 // @public
 export function useRemoteParticipant(identity: string, options?: UseRemoteParticipantOptions): RemoteParticipant | undefined;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -20,6 +20,7 @@ import type { LocalAudioTrack } from 'livekit-client';
 import { LocalParticipant } from 'livekit-client';
 import type { LocalTrack } from 'livekit-client';
 import { LocalTrackPublication } from 'livekit-client';
+import { LocalUserChoices } from '@livekit/components-core';
 import type { LocalVideoTrack } from 'livekit-client';
 import type { MediaDeviceFailure } from 'livekit-client';
 import { MessageDecoder } from '@livekit/components-core';
@@ -327,16 +328,7 @@ export interface LiveKitRoomProps extends Omit<React_2.HTMLAttributes<HTMLDivEle
 // @internal (undocumented)
 export const LKFeatureContext: React_2.Context<FeatureFlags | undefined>;
 
-// @public @deprecated (undocumented)
-export type LocalUserChoices = {
-    username: string;
-    videoEnabled: boolean;
-    audioEnabled: boolean;
-    videoDeviceId: string;
-    audioDeviceId: string;
-    e2ee: boolean;
-    sharedPassphrase: string;
-};
+export { LocalUserChoices }
 
 // @public
 export function MediaDeviceMenu({ kind, initialSelection, onActiveDeviceChange, tracks, requestPermissions, ...props }: MediaDeviceMenuProps): React_2.JSX.Element;
@@ -840,6 +832,7 @@ export function usePersistentUserChoices(options?: UsePersistentUserChoicesOptio
     saveVideoInputEnabled: (isEnabled: boolean) => void;
     saveAudioInputDeviceId: (deviceId: string) => void;
     saveVideoInputDeviceId: (deviceId: string) => void;
+    saveUsername: (username: string) => void;
 };
 
 // @alpha

--- a/packages/react/src/hooks/usePersistentUserChoices.ts
+++ b/packages/react/src/hooks/usePersistentUserChoices.ts
@@ -1,4 +1,4 @@
-import type { UserChoices } from '@livekit/components-core';
+import type { LocalUserChoices } from '@livekit/components-core';
 import { loadUserChoices, saveUserChoices } from '@livekit/components-core';
 import * as React from 'react';
 
@@ -10,7 +10,7 @@ export interface UsePersistentUserChoicesOptions {
   /**
    * The default value to use if reading from local storage returns no results or fails.
    */
-  defaults?: Partial<UserChoices>;
+  defaults?: Partial<LocalUserChoices>;
   /**
    * Whether to prevent saving to persistent storage.
    * @defaultValue false
@@ -29,7 +29,7 @@ export interface UsePersistentUserChoicesOptions {
  * @alpha
  */
 export function usePersistentUserChoices(options: UsePersistentUserChoicesOptions = {}) {
-  const [userChoices, setSettings] = React.useState<UserChoices>(
+  const [userChoices, setSettings] = React.useState<LocalUserChoices>(
     loadUserChoices(options.defaults, options.preventLoad ?? false),
   );
 

--- a/packages/react/src/hooks/usePersistentUserChoices.ts
+++ b/packages/react/src/hooks/usePersistentUserChoices.ts
@@ -45,6 +45,9 @@ export function usePersistentUserChoices(options: UsePersistentUserChoicesOption
   const saveVideoInputDeviceId = React.useCallback((deviceId: string) => {
     setSettings((prev) => ({ ...prev, videoInputDeviceId: deviceId }));
   }, []);
+  const saveUsername = React.useCallback((username: string) => {
+    setSettings((prev) => ({ ...prev, username: username }));
+  }, []);
 
   React.useEffect(() => {
     saveUserChoices(userChoices, options.preventSave ?? false);
@@ -56,5 +59,6 @@ export function usePersistentUserChoices(options: UsePersistentUserChoicesOption
     saveVideoInputEnabled,
     saveAudioInputDeviceId,
     saveVideoInputDeviceId,
+    saveUsername,
   };
 }

--- a/packages/react/src/hooks/usePersistentUserChoices.ts
+++ b/packages/react/src/hooks/usePersistentUserChoices.ts
@@ -1,4 +1,4 @@
-import type { LocalUserChoices, UserChoices } from '@livekit/components-core';
+import type { UserChoices } from '@livekit/components-core';
 import { loadUserChoices, saveUserChoices } from '@livekit/components-core';
 import * as React from 'react';
 
@@ -10,7 +10,7 @@ export interface UsePersistentUserChoicesOptions {
   /**
    * The default value to use if reading from local storage returns no results or fails.
    */
-  defaults?: Partial<LocalUserChoices>;
+  defaults?: Partial<UserChoices>;
   /**
    * Whether to prevent saving to persistent storage.
    * @defaultValue false

--- a/packages/react/src/hooks/usePersistentUserChoices.ts
+++ b/packages/react/src/hooks/usePersistentUserChoices.ts
@@ -1,4 +1,4 @@
-import type { UserChoices } from '@livekit/components-core';
+import type { LocalUserChoices, UserChoices } from '@livekit/components-core';
 import { loadUserChoices, saveUserChoices } from '@livekit/components-core';
 import * as React from 'react';
 
@@ -10,7 +10,7 @@ export interface UsePersistentUserChoicesOptions {
   /**
    * The default value to use if reading from local storage returns no results or fails.
    */
-  defaults?: Partial<UserChoices>;
+  defaults?: Partial<LocalUserChoices>;
   /**
    * Whether to prevent saving to persistent storage.
    * @defaultValue false
@@ -34,16 +34,16 @@ export function usePersistentUserChoices(options: UsePersistentUserChoicesOption
   );
 
   const saveAudioInputEnabled = React.useCallback((isEnabled: boolean) => {
-    setSettings((prev) => ({ ...prev, audioInputEnabled: isEnabled }));
+    setSettings((prev) => ({ ...prev, audioEnabled: isEnabled }));
   }, []);
   const saveVideoInputEnabled = React.useCallback((isEnabled: boolean) => {
-    setSettings((prev) => ({ ...prev, videoInputEnabled: isEnabled }));
+    setSettings((prev) => ({ ...prev, videoEnabled: isEnabled }));
   }, []);
   const saveAudioInputDeviceId = React.useCallback((deviceId: string) => {
-    setSettings((prev) => ({ ...prev, audioInputDeviceId: deviceId }));
+    setSettings((prev) => ({ ...prev, audioDeviceId: deviceId }));
   }, []);
   const saveVideoInputDeviceId = React.useCallback((deviceId: string) => {
-    setSettings((prev) => ({ ...prev, videoInputDeviceId: deviceId }));
+    setSettings((prev) => ({ ...prev, videoDeviceId: deviceId }));
   }, []);
   const saveUsername = React.useCallback((username: string) => {
     setSettings((prev) => ({ ...prev, username: username }));

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,5 +13,6 @@ export type {
   ReceivedChatMessage,
   MessageDecoder,
   MessageEncoder,
+  LocalUserChoices,
   UserChoices,
 } from '@livekit/components-core';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,5 +14,4 @@ export type {
   MessageDecoder,
   MessageEncoder,
   LocalUserChoices,
-  UserChoices,
 } from '@livekit/components-core';

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -240,9 +240,6 @@ export function PreJoin({
   ...htmlProps
 }: PreJoinProps) {
   const [userChoices, setUserChoices] = React.useState(DEFAULT_USER_CHOICES);
-  const [username, setUsername] = React.useState(
-    defaults.username ?? DEFAULT_USER_CHOICES.username,
-  );
 
   // TODO: Remove and pipe `defaults` object directly into `usePersistentUserChoices` once we fully switch from type `LocalUserChoices` to `UserChoices`.
   const partialDefaults: Partial<UserChoices> = {
@@ -259,6 +256,7 @@ export function PreJoin({
     saveAudioInputEnabled,
     saveVideoInputDeviceId,
     saveVideoInputEnabled,
+    saveUsername,
   } = usePersistentUserChoices({
     defaults: partialDefaults,
     preventSave: !persistUserChoices,
@@ -267,24 +265,25 @@ export function PreJoin({
 
   // Initialize device settings
   const [audioEnabled, setAudioEnabled] = React.useState<boolean>(
-    defaults.audioEnabled ?? initialUserChoices.audioInputEnabled,
+    initialUserChoices.audioInputEnabled,
   );
   const [videoEnabled, setVideoEnabled] = React.useState<boolean>(
-    defaults.videoEnabled ?? initialUserChoices.videoInputEnabled,
+    initialUserChoices.videoInputEnabled,
   );
-
-  const initialAudioDeviceId = defaults.audioDeviceId ?? initialUserChoices.audioInputDeviceId;
-  const [audioDeviceId, setAudioDeviceId] = React.useState<string>(initialAudioDeviceId);
-
-  const initialVideoDeviceId = defaults.videoDeviceId ?? initialUserChoices.videoInputDeviceId;
-  const [videoDeviceId, setVideoDeviceId] = React.useState<string>(initialVideoDeviceId);
-
+  const [audioDeviceId, setAudioDeviceId] = React.useState<string>(
+    initialUserChoices.audioInputDeviceId,
+  );
+  const [videoDeviceId, setVideoDeviceId] = React.useState<string>(
+    initialUserChoices.videoInputDeviceId,
+  );
+  const [username, setUsername] = React.useState(initialUserChoices.username);
+  // TODO: Remove `e2ee` and `sharedPassphrase` once deprecated `LocalUserChoices` type is removed.
   const [e2ee, setE2ee] = React.useState<boolean>(defaults.e2ee ?? DEFAULT_USER_CHOICES.e2ee);
   const [sharedPassphrase, setSharedPassphrase] = React.useState<string>(
     defaults.sharedPassphrase ?? DEFAULT_USER_CHOICES.sharedPassphrase,
   );
 
-  // Update persistent device settings
+  // Save user choices to persistent storage.
   React.useEffect(() => {
     saveAudioInputEnabled(audioEnabled);
   }, [audioEnabled, saveAudioInputEnabled]);
@@ -297,11 +296,14 @@ export function PreJoin({
   React.useEffect(() => {
     saveVideoInputDeviceId(videoDeviceId);
   }, [videoDeviceId, saveVideoInputDeviceId]);
+  React.useEffect(() => {
+    saveUsername(username);
+  }, [username, saveUsername]);
 
   const tracks = usePreviewTracks(
     {
-      audio: audioEnabled ? { deviceId: initialAudioDeviceId } : false,
-      video: videoEnabled ? { deviceId: initialVideoDeviceId } : false,
+      audio: audioEnabled ? { deviceId: initialUserChoices.audioInputDeviceId } : false,
+      video: videoEnabled ? { deviceId: initialUserChoices.videoInputDeviceId } : false,
     },
     onError,
   );

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -229,10 +229,10 @@ export function PreJoin({
 
   // TODO: Remove and pipe `defaults` object directly into `usePersistentUserChoices` once we fully switch from type `LocalUserChoices` to `UserChoices`.
   const partialDefaults: Partial<LocalUserChoices> = {
-    ...(defaults.audioDeviceId !== undefined && { audioInputDeviceId: defaults.audioDeviceId }),
-    ...(defaults.videoDeviceId !== undefined && { videoInputDeviceId: defaults.videoDeviceId }),
+    ...(defaults.audioDeviceId !== undefined && { audioDeviceId: defaults.audioDeviceId }),
+    ...(defaults.videoDeviceId !== undefined && { videoDeviceId: defaults.videoDeviceId }),
     ...(defaults.audioEnabled !== undefined && { audioEnabled: defaults.audioEnabled }),
-    ...(defaults.videoEnabled !== undefined && { videoInputEnabled: defaults.videoEnabled }),
+    ...(defaults.videoEnabled !== undefined && { videoEnabled: defaults.videoEnabled }),
     ...(defaults.username !== undefined && { username: defaults.username }),
   };
 

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -15,24 +15,10 @@ import {
 import * as React from 'react';
 import { MediaDeviceMenu } from './MediaDeviceMenu';
 import { TrackToggle } from '../components/controls/TrackToggle';
-import type { UserChoices } from '@livekit/components-core';
+import type { LocalUserChoices } from '@livekit/components-core';
 import { log } from '@livekit/components-core';
 import { ParticipantPlaceholder } from '../assets/images';
 import { useMediaDevices, usePersistentUserChoices } from '../hooks';
-
-/**
- * @deprecated Use `UserChoices` instead.
- * @public
- */
-export type LocalUserChoices = {
-  username: string;
-  videoEnabled: boolean;
-  audioEnabled: boolean;
-  videoDeviceId: string;
-  audioDeviceId: string;
-  e2ee: boolean;
-  sharedPassphrase: string;
-};
 
 const DEFAULT_USER_CHOICES: LocalUserChoices = {
   username: '',
@@ -242,10 +228,10 @@ export function PreJoin({
   const [userChoices, setUserChoices] = React.useState(DEFAULT_USER_CHOICES);
 
   // TODO: Remove and pipe `defaults` object directly into `usePersistentUserChoices` once we fully switch from type `LocalUserChoices` to `UserChoices`.
-  const partialDefaults: Partial<UserChoices> = {
+  const partialDefaults: Partial<LocalUserChoices> = {
     ...(defaults.audioDeviceId !== undefined && { audioInputDeviceId: defaults.audioDeviceId }),
     ...(defaults.videoDeviceId !== undefined && { videoInputDeviceId: defaults.videoDeviceId }),
-    ...(defaults.audioEnabled !== undefined && { audioInputEnabled: defaults.audioEnabled }),
+    ...(defaults.audioEnabled !== undefined && { audioEnabled: defaults.audioEnabled }),
     ...(defaults.videoEnabled !== undefined && { videoInputEnabled: defaults.videoEnabled }),
     ...(defaults.username !== undefined && { username: defaults.username }),
   };
@@ -264,17 +250,13 @@ export function PreJoin({
   });
 
   // Initialize device settings
-  const [audioEnabled, setAudioEnabled] = React.useState<boolean>(
-    initialUserChoices.audioInputEnabled,
-  );
-  const [videoEnabled, setVideoEnabled] = React.useState<boolean>(
-    initialUserChoices.videoInputEnabled,
-  );
+  const [audioEnabled, setAudioEnabled] = React.useState<boolean>(initialUserChoices.audioEnabled);
+  const [videoEnabled, setVideoEnabled] = React.useState<boolean>(initialUserChoices.videoEnabled);
   const [audioDeviceId, setAudioDeviceId] = React.useState<string>(
-    initialUserChoices.audioInputDeviceId,
+    initialUserChoices.audioDeviceId,
   );
   const [videoDeviceId, setVideoDeviceId] = React.useState<string>(
-    initialUserChoices.videoInputDeviceId,
+    initialUserChoices.videoDeviceId,
   );
   const [username, setUsername] = React.useState(initialUserChoices.username);
   // TODO: Remove `e2ee` and `sharedPassphrase` once deprecated `LocalUserChoices` type is removed.
@@ -302,8 +284,8 @@ export function PreJoin({
 
   const tracks = usePreviewTracks(
     {
-      audio: audioEnabled ? { deviceId: initialUserChoices.audioInputDeviceId } : false,
-      video: videoEnabled ? { deviceId: initialUserChoices.videoInputDeviceId } : false,
+      audio: audioEnabled ? { deviceId: initialUserChoices.audioDeviceId } : false,
+      video: videoEnabled ? { deviceId: initialUserChoices.videoDeviceId } : false,
     },
     onError,
   );

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -65,8 +65,10 @@ export interface PreJoinProps
   micLabel?: string;
   camLabel?: string;
   userLabel?: string;
+  /**
+   * @deprecated Displaying e2ee options is no longer supported. Custom e2ee options have to be implemented by the user.
+   */
   showE2EEOptions?: boolean;
-
   /**
    * If true, user choices are persisted across sessions.
    * @defaultValue true

--- a/packages/react/src/prefabs/index.ts
+++ b/packages/react/src/prefabs/index.ts
@@ -1,11 +1,5 @@
 export { Chat, type ChatProps } from './Chat';
-export {
-  PreJoin,
-  PreJoinProps,
-  usePreviewDevice,
-  usePreviewTracks,
-  type LocalUserChoices,
-} from './PreJoin';
+export { PreJoin, PreJoinProps, usePreviewDevice, usePreviewTracks } from './PreJoin';
 export { VideoConference, type VideoConferenceProps } from './VideoConference';
 export { ControlBar, type ControlBarProps, type ControlBarControls } from './ControlBar';
 export { MediaDeviceMenu, type MediaDeviceMenuProps } from './MediaDeviceMenu';


### PR DESCRIPTION
This pull request adds a new function, `saveUsername`, to the `usePersistentUserChoices` hook. This function allows the user's chosen username to be saved to persistent storage.

For backward compatibility and simplicity, the properties of the UserChoices type have been updated to match the original LocalUserChoices type. To avoid TS-hell The goal now is to deprecate the `e2ee` and `sharedPassphrase` properties before changing the type to `UserChoices`.