### PR TITLE
Fix duplicate chat messages

### DIFF
--- a/packages/core/src/components/chat.ts
+++ b/packages/core/src/components/chat.ts
@@ -49,12 +49,18 @@ export function setupChat(room: Room, options?: ChatOptions) {
 
   const topic = channelTopic ?? DataTopic.CHAT;
 
+  let needsSetup = false;
+  if (!topicSubjectMap.has(topic)) {
+    needsSetup = true;
+  }
   const messageSubject = topicSubjectMap.get(topic) ?? new Subject<RawMessage>();
   topicSubjectMap.set(topic, messageSubject);
 
-  /** Subscribe to all appropriate messages sent over the wire. */
-  const { messageObservable } = setupDataMessageHandler(room, topic);
-  messageObservable.pipe(takeUntil(onDestroyObservable)).subscribe(messageSubject);
+  if (needsSetup) {
+    /** Subscribe to all appropriate messages sent over the wire. */
+    const { messageObservable } = setupDataMessageHandler(room, topic);
+    messageObservable.pipe(takeUntil(onDestroyObservable)).subscribe(messageSubject);
+  }
 
   const finalMessageDecoder = messageDecoder ?? decode;
 


### PR DESCRIPTION
If the `messageSubject` existed previously already, we don't want to resubscribe to the message observable.
This has a potential downside, as we currently don't differentiate between different rooms, but only topics. 
So two parallel rooms, using the same topic, would fail to work. 

That's why I changed the mapId to consist of `room.name + localParticipant.identity + topic`. This gives us a unique identifier. However this approach falls short if the chat is being set up before the connection is established, as we only know the room name and identity once a user has connected. 

Another option would be to monkey-patch the room object and have the `topicSubjectMap` with only the topic as the map id. This would be a solution that works under all circumstances, but monkey patching it feels wrong. 
