### PR TITLE
Add setLogExtension to core

### DIFF
--- a/.changeset/curly-papayas-bow.md
+++ b/.changeset/curly-papayas-bow.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-core": patch
+---
+
+Add setLogExtension to core

--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -387,6 +387,12 @@ export function sendMessage(localParticipant: LocalParticipant, payload: Uint8Ar
 // @public (undocumented)
 export function setDifference<T>(setA: Set<T>, setB: Set<T>): Set<T>;
 
+// Warning: (ae-forgotten-export) The symbol "LogExtension" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SetLogExtensionOptions" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function setLogExtension(extension: LogExtension, options?: SetLogExtensionOptions): void;
+
 // Warning: (ae-forgotten-export) The symbol "LogLevel" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "SetLogLevelOptions" needs to be exported by the entry point index.d.ts
 //

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,4 +30,4 @@ export * from './observables/dom-event';
 
 export * from './persistent-storage';
 
-export { log, setLogLevel } from './logger';
+export { log, setLogLevel, setLogExtension } from './logger';

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,4 +1,8 @@
-import { setLogLevel as setClientSdkLogLevel } from 'livekit-client';
+import {
+  setLogLevel as setClientSdkLogLevel,
+  setLogExtension as setClientSdkLogExtension,
+  LogLevel as LogLevelEnum,
+} from 'livekit-client';
 import loglevel from 'loglevel';
 
 export const log = loglevel.getLogger('lk-components-js');
@@ -17,4 +21,35 @@ type SetLogLevelOptions = {
 export function setLogLevel(level: LogLevel, options: SetLogLevelOptions = {}): void {
   log.setLevel(level);
   setClientSdkLogLevel(options.liveKitClientLogLevel ?? level);
+}
+
+type LogExtension = (level: LogLevel, msg: string, context?: object) => void;
+type SetLogExtensionOptions = {
+  liveKitClientLogExtension?: LogExtension;
+};
+
+/**
+ * Set the log extension for both the `@livekit/components-react` package and the `@livekit-client` package.
+ * To set the `@livekit-client` log extension, use the `liveKitClientLogExtension` prop on the `options` object.
+ * @public
+ */
+export function setLogExtension(extension: LogExtension, options: SetLogExtensionOptions = {}) {
+  const originalFactory = log.methodFactory;
+
+  log.methodFactory = (methodName, configLevel, loggerName) => {
+    const rawMethod = originalFactory(methodName, configLevel, loggerName);
+
+    const logLevel = LogLevelEnum[methodName];
+    const needLog = logLevel >= configLevel && logLevel < LogLevelEnum.silent;
+
+    return (msg, context?: [msg: string, context: object]) => {
+      if (context) rawMethod(msg, context);
+      else rawMethod(msg);
+      if (needLog) {
+        extension(logLevel, msg, context);
+      }
+    };
+  };
+  log.setLevel(log.getLevel()); // Be sure to call setLevel method in order to apply plugin
+  setClientSdkLogExtension(options.liveKitClientLogExtension ?? extension);
 }

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -578,6 +578,12 @@ export const ScreenShareIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.El
 // @internal (undocumented)
 export const ScreenShareStopIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
+// Warning: (ae-forgotten-export) The symbol "LogExtension" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SetLogExtensionOptions" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function setLogExtension(extension: LogExtension, options?: SetLogExtensionOptions): void;
+
 // Warning: (ae-forgotten-export) The symbol "LogLevel" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "SetLogLevelOptions" needs to be exported by the entry point index.d.ts
 //

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -11,7 +11,7 @@ export * from './assets/icons';
 export * from './assets/images';
 
 // Re-exports from core
-export { setLogLevel, isTrackReference } from '@livekit/components-core';
+export { setLogLevel, setLogExtension, isTrackReference } from '@livekit/components-core';
 export type {
   ChatMessage,
   ReceivedChatMessage,


### PR DESCRIPTION
Add the `setLogExtension` function for setting extension for both `livekit-client`, and `@livekit/components-core`: just like the `setLogLevel` function.