### PR TITLE
Add an `isUserInitiated` argument to the `onChange` callback on the `TrackToggle` component.

### DIFF
--- a/.changeset/modern-rings-invite.md
+++ b/.changeset/modern-rings-invite.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": minor
+---
+
+Add an `isUserInitiated` argument to the `onChange` callback on the `TrackToggle` component.

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -650,10 +650,7 @@ export interface TrackToggleProps<T extends ToggleSource> extends Omit<React_2.B
     captureOptions?: CaptureOptionsBySource<T>;
     // (undocumented)
     initialState?: boolean;
-    // (undocumented)
-    onChange?: (enabled: boolean) => void;
-    // @alpha
-    onUserInitiatedChange?: (enabled: boolean) => void;
+    onChange?: (enabled: boolean, isUserInitiated: boolean) => void;
     // (undocumented)
     showIcon?: boolean;
     // (undocumented)
@@ -1177,7 +1174,7 @@ export type UseTracksOptions = {
 };
 
 // @public
-export function useTrackToggle<T extends ToggleSource>({ source, onChange, initialState, captureOptions, onUserInitiatedChange, ...rest }: UseTrackToggleProps<T>): {
+export function useTrackToggle<T extends ToggleSource>({ source, onChange, initialState, captureOptions, ...rest }: UseTrackToggleProps<T>): {
     toggle: ((forceState?: boolean | undefined) => void) | ((forceState?: boolean | undefined, captureOptions?: CaptureOptionsBySource<T> | undefined) => Promise<void>);
     enabled: boolean;
     pending: boolean;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -652,6 +652,8 @@ export interface TrackToggleProps<T extends ToggleSource> extends Omit<React_2.B
     initialState?: boolean;
     // (undocumented)
     onChange?: (enabled: boolean) => void;
+    // @alpha
+    onUserInitiatedChange?: (enabled: boolean) => void;
     // (undocumented)
     showIcon?: boolean;
     // (undocumented)
@@ -1175,7 +1177,7 @@ export type UseTracksOptions = {
 };
 
 // @public
-export function useTrackToggle<T extends ToggleSource>({ source, onChange, initialState, captureOptions, ...rest }: UseTrackToggleProps<T>): {
+export function useTrackToggle<T extends ToggleSource>({ source, onChange, initialState, captureOptions, onUserInitiatedChange, ...rest }: UseTrackToggleProps<T>): {
     toggle: ((forceState?: boolean | undefined) => void) | ((forceState?: boolean | undefined, captureOptions?: CaptureOptionsBySource<T> | undefined) => Promise<void>);
     enabled: boolean;
     pending: boolean;

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -11,7 +11,10 @@ export interface TrackToggleProps<T extends ToggleSource>
   initialState?: boolean;
   onChange?: (enabled: boolean) => void;
   captureOptions?: CaptureOptionsBySource<T>;
-  /** Function that is only called if the button state change was triggered by a user interaction like a click. */
+  /**
+   * Function that is only called if the button state change was triggered by a user interaction like a click.
+   * @alpha
+   */
   onUserInitiatedChange?: (enabled: boolean) => void;
 }
 

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -11,6 +11,8 @@ export interface TrackToggleProps<T extends ToggleSource>
   initialState?: boolean;
   onChange?: (enabled: boolean) => void;
   captureOptions?: CaptureOptionsBySource<T>;
+  /** Function that is only called if the button state change was triggered by a user interaction like a click. */
+  onUserInitiatedChange?: (enabled: boolean) => void;
 }
 
 /**

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -9,13 +9,12 @@ export interface TrackToggleProps<T extends ToggleSource>
   source: T;
   showIcon?: boolean;
   initialState?: boolean;
-  onChange?: (enabled: boolean) => void;
-  captureOptions?: CaptureOptionsBySource<T>;
   /**
-   * Function that is only called if the button state change was triggered by a user interaction like a click.
-   * @alpha
+   * Function that is called when the enabled state of the toggle changes.
+   * The second function argument `isUserInitiated` is `true` if the change was initiated by a user interaction, such as a click.
    */
-  onUserInitiatedChange?: (enabled: boolean) => void;
+  onChange?: (enabled: boolean, isUserInitiated: boolean) => void;
+  captureOptions?: CaptureOptionsBySource<T>;
 }
 
 /**

--- a/packages/react/src/hooks/useTrackToggle.ts
+++ b/packages/react/src/hooks/useTrackToggle.ts
@@ -26,7 +26,6 @@ export function useTrackToggle<T extends ToggleSource>({
   onChange,
   initialState,
   captureOptions,
-  onUserInitiatedChange,
   ...rest
 }: UseTrackToggleProps<T>) {
   const room = useMaybeRoomContext();
@@ -43,13 +42,8 @@ export function useTrackToggle<T extends ToggleSource>({
   const enabled = useObservableState(enabledObserver, initialState ?? !!track?.isEnabled);
 
   React.useEffect(() => {
-    onChange?.(enabled);
-    if (onUserInitiatedChange !== undefined && userInteractionRef.current === true) {
-      log.debug(`onUserInitiatedChange: toggle state ${enabled}`);
-      onUserInitiatedChange(enabled);
-      userInteractionRef.current = false;
-    }
-  }, [enabled, onChange, onUserInitiatedChange]);
+    onChange?.(enabled, userInteractionRef.current);
+  }, [enabled, onChange]);
 
   React.useEffect(() => {
     if (initialState !== undefined) {

--- a/packages/react/src/prefabs/ControlBar.tsx
+++ b/packages/react/src/prefabs/ControlBar.tsx
@@ -117,7 +117,9 @@ export function ControlBar({
           <TrackToggle
             source={Track.Source.Microphone}
             showIcon={showIcon}
-            onUserInitiatedChange={saveAudioInputEnabled}
+            onChange={(enabled, isUserInitiated) =>
+              isUserInitiated ? saveAudioInputEnabled(enabled) : null
+            }
           >
             {showText && 'Microphone'}
           </TrackToggle>
@@ -134,7 +136,9 @@ export function ControlBar({
           <TrackToggle
             source={Track.Source.Camera}
             showIcon={showIcon}
-            onUserInitiatedChange={saveVideoInputEnabled}
+            onChange={(enabled, isUserInitiated) =>
+              isUserInitiated ? saveVideoInputEnabled(enabled) : null
+            }
           >
             {showText && 'Camera'}
           </TrackToggle>

--- a/packages/react/src/prefabs/ControlBar.tsx
+++ b/packages/react/src/prefabs/ControlBar.tsx
@@ -117,7 +117,7 @@ export function ControlBar({
           <TrackToggle
             source={Track.Source.Microphone}
             showIcon={showIcon}
-            onChange={saveAudioInputEnabled}
+            onUserInitiatedChange={saveAudioInputEnabled}
           >
             {showText && 'Microphone'}
           </TrackToggle>
@@ -134,7 +134,7 @@ export function ControlBar({
           <TrackToggle
             source={Track.Source.Camera}
             showIcon={showIcon}
-            onChange={saveVideoInputEnabled}
+            onUserInitiatedChange={saveVideoInputEnabled}
           >
             {showText && 'Camera'}
           </TrackToggle>


### PR DESCRIPTION
This pull request adds a new prop called `onUserInitiatedChange` to the `TrackToggle` component. This prop is a function that is only called if the button state change was triggered by a user interaction like a click.
The existing `onChange` callback, on the other hand, is called many times even when there is no user interaction, for example, when a user enters the room or leaves.