### PR TITLE
Do not crash in usePreviewDevice when user has not granted permission to media device

### DIFF
--- a/.changeset/four-yaks-grin.md
+++ b/.changeset/four-yaks-grin.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Do not crash in usePreviewDevice when user has not granted permission to media device

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -187,7 +187,7 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
   }, []);
 
   React.useEffect(() => {
-    setSelectedDevice(devices.find((dev) => dev.deviceId === localDeviceId));
+    setSelectedDevice(devices?.find((dev) => dev.deviceId === localDeviceId));
   }, [localDeviceId, devices]);
 
   return {


### PR DESCRIPTION
When the user has not granted access to the media devices, the `usePreviewDevice` hook crashes on `devices.find()` This is particularly annoying because unhandled errors in hooks cannot be caught easily and will crash the whole application into the ErrorBoundary.