### PR TITLE
Catch callback executions when chained as props

### DIFF
--- a/.changeset/four-yaks-grin.md
+++ b/.changeset/four-yaks-grin.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Do not crash in usePreviewDevice when user has not granted permission to media device

--- a/packages/react/src/mergeProps.ts
+++ b/packages/react/src/mergeProps.ts
@@ -20,7 +20,11 @@ export function chain(...callbacks: any[]): (...args: any[]) => void {
   return (...args: any[]) => {
     for (const callback of callbacks) {
       if (typeof callback === 'function') {
-        callback(...args);
+        try {
+          await callback(...args);
+        } catch (e) {
+          console.error(e);
+        }
       }
     }
   };

--- a/packages/react/src/mergeProps.ts
+++ b/packages/react/src/mergeProps.ts
@@ -21,7 +21,7 @@ export function chain(...callbacks: any[]): (...args: any[]) => void {
     for (const callback of callbacks) {
       if (typeof callback === 'function') {
         try {
-          await callback(...args);
+          callback(...args);
         } catch (e) {
           console.error(e);
         }

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -187,7 +187,7 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
   }, []);
 
   React.useEffect(() => {
-    setSelectedDevice(devices.find((dev) => dev.deviceId === localDeviceId));
+    setSelectedDevice(devices?.find((dev) => dev.deviceId === localDeviceId));
   }, [localDeviceId, devices]);
 
   return {


### PR DESCRIPTION
the `mergeProps` function loops over all callbacks that have been passed in. 

If there are two `onClick` callbacks and the first one throws an error, the second one wouldn't get called any more. This PR tries to fix that with a try ... catch clause. 