### PR TITLE
Revert "Request device permissions when opening menu"

### DIFF
--- a/.changeset/witty-spoons-exercise.md
+++ b/.changeset/witty-spoons-exercise.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": major
+---
+
+Revert "Request device permissions when opening menu" due to change in behavior

--- a/packages/react/src/hooks/useMediaDeviceSelect.ts
+++ b/packages/react/src/hooks/useMediaDeviceSelect.ts
@@ -1,7 +1,7 @@
 import { createMediaDeviceObserver, setupDeviceSelector, log } from '@livekit/components-core';
 import type { LocalAudioTrack, LocalVideoTrack, Room } from 'livekit-client';
 import * as React from 'react';
-import { useEnsureRoom } from '../context';
+import { useMaybeRoomContext } from '../context';
 import { useObservableState } from './internal';
 
 /** @public */
@@ -45,7 +45,7 @@ export function useMediaDeviceSelect({
   requestPermissions,
   onError,
 }: UseMediaDeviceSelectProps) {
-  const roomContext = useEnsureRoom(room);
+  const roomContext = useMaybeRoomContext();
   // List of all devices.
   const deviceObserver = React.useMemo(
     () => createMediaDeviceObserver(kind, onError, requestPermissions),
@@ -55,8 +55,8 @@ export function useMediaDeviceSelect({
   // Active device management.
   const [currentDeviceId, setCurrentDeviceId] = React.useState<string>('');
   const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
-    () => setupDeviceSelector(kind, roomContext, track),
-    [kind, roomContext, track],
+    () => setupDeviceSelector(kind, room ?? roomContext, track),
+    [kind, room, roomContext, track],
   );
 
   React.useEffect(() => {

--- a/packages/react/src/prefabs/MediaDeviceMenu.tsx
+++ b/packages/react/src/prefabs/MediaDeviceMenu.tsx
@@ -2,7 +2,7 @@ import { computeMenuPosition, wasClickOutside } from '@livekit/components-core';
 import * as React from 'react';
 import { MediaDeviceSelect } from '../components/controls/MediaDeviceSelect';
 import { log } from '@livekit/components-core';
-import { type LocalAudioTrack, type LocalVideoTrack } from 'livekit-client';
+import type { LocalAudioTrack, LocalVideoTrack } from 'livekit-client';
 
 /** @public */
 export interface MediaDeviceMenuProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -48,7 +48,6 @@ export function MediaDeviceMenu({
   const [isOpen, setIsOpen] = React.useState(false);
   const [devices, setDevices] = React.useState<MediaDeviceInfo[]>([]);
   const [updateRequired, setUpdateRequired] = React.useState<boolean>(true);
-  const [needPermissions, setNeedPermissions] = React.useState(requestPermissions);
 
   const handleActiveDeviceChange = (kind: MediaDeviceKind, deviceId: string) => {
     log.debug('handle device change');
@@ -58,12 +57,6 @@ export function MediaDeviceMenu({
 
   const button = React.useRef<HTMLButtonElement>(null);
   const tooltip = React.useRef<HTMLDivElement>(null);
-
-  React.useLayoutEffect(() => {
-    if (isOpen) {
-      setNeedPermissions(true);
-    }
-  }, [isOpen]);
 
   React.useLayoutEffect(() => {
     if (button.current && tooltip.current && (devices || updateRequired)) {
@@ -125,7 +118,7 @@ export function MediaDeviceMenu({
               onDeviceListChange={setDevices}
               kind={kind}
               track={tracks?.[kind]}
-              requestPermissions={needPermissions}
+              requestPermissions={requestPermissions}
             />
           ) : (
             <>
@@ -137,7 +130,7 @@ export function MediaDeviceMenu({
                 }
                 onDeviceListChange={setDevices}
                 track={tracks?.audioinput}
-                requestPermissions={needPermissions}
+                requestPermissions={requestPermissions}
               />
               <div className="lk-device-menu-heading">Video inputs</div>
               <MediaDeviceSelect
@@ -147,7 +140,7 @@ export function MediaDeviceMenu({
                 }
                 onDeviceListChange={setDevices}
                 track={tracks?.videoinput}
-                requestPermissions={needPermissions}
+                requestPermissions={requestPermissions}
               />
             </>
           )}


### PR DESCRIPTION
Reverts livekit/components-js#800 since this breaks existing applications that are using `useMediaDeviceSelect` outside of a Room context (like LK Meet)