### PR TITLE
Fix versioning from major to patch

### DIFF
--- a/.changeset/witty-spoons-exercise.md
+++ b/.changeset/witty-spoons-exercise.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": major
+---
+
+Revert "Request device permissions when opening menu" due to change in behavior

--- a/.changeset/witty-spoons-exercise.md
+++ b/.changeset/witty-spoons-exercise.md
@@ -1,5 +1,5 @@
 ---
-"@livekit/components-react": major
+'@livekit/components-react': patch
 ---
 
 Revert "Request device permissions when opening menu" due to change in behavior

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @livekit/components-js-docs
 
-## 0.1.14
-
-### Patch Changes
-
-- Updated dependencies [[`9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1`](https://github.com/livekit/components-js/commit/9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1)]:
-  - @livekit/components-react@3.0.0
-
 ## 0.1.13
 
 ### Patch Changes

--- a/docs/docs/package.json
+++ b/docs/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/components-js-docs",
-  "version": "0.1.14",
+  "version": "0.1.13",
   "description": "Automatically generated documentation pages for LiveKit Components JS. Intended to be consumed by the documentation page.",
   "repository": {
     "type": "git",

--- a/docs/storybook/CHANGELOG.md
+++ b/docs/storybook/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @livekit/component-docs-storybook
 
-## 1.0.39
-
-### Patch Changes
-
-- Updated dependencies [[`9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1`](https://github.com/livekit/components-js/commit/9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1)]:
-  - @livekit/components-react@3.0.0
-
 ## 1.0.38
 
 ### Patch Changes

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@livekit/component-docs-storybook",
-  "version": "1.0.39",
+  "version": "1.0.38",
   "license": "Apache-2.0",
   "main": "index.js",
   "scripts": {

--- a/examples/nextjs/CHANGELOG.md
+++ b/examples/nextjs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @livekit/component-example-next
 
-## 0.2.12
-
-### Patch Changes
-
-- Updated dependencies [[`9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1`](https://github.com/livekit/components-js/commit/9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1)]:
-  - @livekit/components-react@3.0.0
-
 ## 0.2.11
 
 ### Patch Changes

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/component-example-next",
-  "version": "0.2.12",
+  "version": "0.2.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @livekit/components-react
 
-## 3.0.0
-
-### Major Changes
-
-- Revert "Request device permissions when opening menu" due to change in behavior - [#808](https://github.com/livekit/components-js/pull/808) ([@davidzhao](https://github.com/davidzhao))
-
 ## 2.0.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/components-react",
-  "version": "3.0.0",
+  "version": "2.0.4",
   "license": "Apache-2.0",
   "author": "LiveKit",
   "repository": {

--- a/tooling/docs-gen/CHANGELOG.md
+++ b/tooling/docs-gen/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @livekit/components-docs-gen
 
-## 0.0.36
-
-### Patch Changes
-
-- Updated dependencies [[`9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1`](https://github.com/livekit/components-js/commit/9cf6a7a73b11bbf0e1c5beb1248bafeade0211c1)]:
-  - @livekit/components-react@3.0.0
-
 ## 0.0.35
 
 ### Patch Changes

--- a/tooling/docs-gen/package.json
+++ b/tooling/docs-gen/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@livekit/components-docs-gen",
-  "version": "0.0.36",
+  "version": "0.0.35",
   "description": "Generate component docs.",
   "license": "Apache 2.0",
   "author": "LiveKit",


### PR DESCRIPTION
I made a mistake in the last changeset, indicating it was a major change when it's actually minor.

the npm package has been deprecated, and redoing this.