### PR TITLE
Support referencing components via refs

### DIFF
--- a/.changeset/moody-steaks-drop.md
+++ b/.changeset/moody-steaks-drop.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": minor
+---
+
+Support referencing components via refs

--- a/.github/workflows/size-limit.yaml
+++ b/.github/workflows/size-limit.yaml
@@ -21,7 +21,7 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - uses: andresz1/size-limit-action@35ea3c74377213d727b88532229d467a849345f4 # with pnpm support
+      - uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           script: pnpm --filter @livekit/components-react exec size-limit --json

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -48,7 +48,7 @@ export interface AudioConferenceProps extends React_2.HTMLAttributes<HTMLDivElem
 }
 
 // @public
-export function AudioTrack({ trackRef, onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps): React_2.JSX.Element;
+export const AudioTrack: (props: AudioTrackProps & React_2.RefAttributes<HTMLAudioElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface AudioTrackProps extends React_2.AudioHTMLAttributes<HTMLAudioElement> {
@@ -61,7 +61,7 @@ export interface AudioTrackProps extends React_2.AudioHTMLAttributes<HTMLAudioEl
 }
 
 // @public
-export function AudioVisualizer({ trackRef, ...props }: AudioVisualizerProps): React_2.JSX.Element;
+export const AudioVisualizer: (props: AudioVisualizerProps & React_2.RefAttributes<SVGSVGElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface AudioVisualizerProps extends React_2.HTMLAttributes<SVGElement> {
@@ -100,7 +100,7 @@ export function Chat({ messageFormatter, messageDecoder, messageEncoder, channel
 export const ChatCloseIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
 // @public
-export function ChatEntry({ entry, hideName, hideTimestamp, messageFormatter, ...props }: ChatEntryProps): React_2.JSX.Element;
+export const ChatEntry: (props: ChatEntryProps & React_2.RefAttributes<HTMLLIElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public
 export interface ChatEntryProps extends React_2.HTMLAttributes<HTMLLIElement> {
@@ -134,7 +134,7 @@ export interface ChatProps extends React_2.HTMLAttributes<HTMLDivElement>, ChatO
 }
 
 // @public
-export function ChatToggle(props: ChatToggleProps): React_2.JSX.Element;
+export const ChatToggle: (props: ChatToggleProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface ChatToggleProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -146,14 +146,14 @@ export interface ChatToggleProps extends React_2.ButtonHTMLAttributes<HTMLButton
 export const Chevron: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
 // @public
-export function ClearPinButton(props: ClearPinButtonProps): React_2.JSX.Element;
+export const ClearPinButton: (props: ClearPinButtonProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface ClearPinButtonProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 // @public
-export function ConnectionQualityIndicator(props: ConnectionQualityIndicatorProps): React_2.JSX.Element;
+export const ConnectionQualityIndicator: (props: ConnectionQualityIndicatorProps & React_2.RefAttributes<HTMLDivElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface ConnectionQualityIndicatorOptions {
@@ -166,7 +166,7 @@ export interface ConnectionQualityIndicatorProps extends React_2.HTMLAttributes<
 }
 
 // @public
-export function ConnectionState({ room, ...props }: ConnectionStatusProps): React_2.JSX.Element;
+export const ConnectionState: (props: ConnectionStatusProps & React_2.RefAttributes<HTMLDivElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public
 export function ConnectionStateToast(props: ConnectionStateToastProps): React_2.JSX.Element;
@@ -206,7 +206,7 @@ export interface ControlBarProps extends React_2.HTMLAttributes<HTMLDivElement> 
 }
 
 // @public
-export function DisconnectButton(props: DisconnectButtonProps): React_2.JSX.Element;
+export const DisconnectButton: (props: DisconnectButtonProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface DisconnectButtonProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -242,7 +242,7 @@ export interface FocusLayoutProps extends React_2.HTMLAttributes<HTMLElement> {
 }
 
 // @public
-export function FocusToggle({ trackRef, ...props }: FocusToggleProps): React_2.JSX.Element;
+export const FocusToggle: (props: FocusToggleProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // Warning: (ae-internal-missing-underscore) The name "FocusToggleIcon" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -307,7 +307,9 @@ export type LayoutContextType = {
 export const LeaveIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
 // @public
-export function LiveKitRoom(props: React_2.PropsWithChildren<LiveKitRoomProps>): React_2.JSX.Element;
+export const LiveKitRoom: (props: LiveKitRoomProps & {
+    children?: React_2.ReactNode;
+} & React_2.RefAttributes<HTMLDivElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface LiveKitRoomProps extends Omit<React_2.HTMLAttributes<HTMLDivElement>, 'onError'> {
@@ -372,7 +374,7 @@ export interface MediaDeviceMenuProps extends React_2.ButtonHTMLAttributes<HTMLB
 }
 
 // @public
-export function MediaDeviceSelect({ kind, initialSelection, onActiveDeviceChange, onDeviceListChange, onDeviceSelectError, exactMatch, track, requestPermissions, onError, ...props }: MediaDeviceSelectProps): React_2.JSX.Element;
+export const MediaDeviceSelect: (props: MediaDeviceSelectProps & React_2.RefAttributes<HTMLUListElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface MediaDeviceSelectProps extends Omit<React_2.HTMLAttributes<HTMLUListElement>, 'onError'> {
@@ -425,7 +427,7 @@ export interface MultiBandTrackVolumeOptions {
 }
 
 // @public
-export function ParticipantAudioTile({ children, disableSpeakingIndicator, onParticipantClick, trackRef, ...htmlProps }: ParticipantTileProps): React_2.JSX.Element;
+export const ParticipantAudioTile: (props: ParticipantTileProps & React_2.RefAttributes<HTMLDivElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // Warning: (ae-internal-missing-underscore) The name "ParticipantClickEvent" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -455,7 +457,7 @@ export interface ParticipantLoopProps {
 }
 
 // @public
-export function ParticipantName({ participant, ...props }: ParticipantNameProps): React_2.JSX.Element;
+export const ParticipantName: (props: ParticipantNameProps & React_2.RefAttributes<HTMLSpanElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface ParticipantNameProps extends React_2.HTMLAttributes<HTMLSpanElement>, UseParticipantInfoOptions {
@@ -467,7 +469,7 @@ export interface ParticipantNameProps extends React_2.HTMLAttributes<HTMLSpanEle
 export const ParticipantPlaceholder: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
 // @public
-export function ParticipantTile({ trackRef, children, onParticipantClick, disableSpeakingIndicator, ...htmlProps }: ParticipantTileProps): React_2.JSX.Element;
+export const ParticipantTile: (props: ParticipantTileProps & React_2.RefAttributes<HTMLDivElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface ParticipantTileProps extends React_2.HTMLAttributes<HTMLDivElement> {
@@ -548,7 +550,7 @@ export interface RoomAudioRendererProps {
 export const RoomContext: React_2.Context<Room | undefined>;
 
 // @public
-export function RoomName({ childrenPosition, children, ...htmlAttributes }: RoomNameProps): React_2.JSX.Element;
+export const RoomName: (props: RoomNameProps & React_2.RefAttributes<HTMLSpanElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface RoomNameProps extends React_2.HTMLAttributes<HTMLSpanElement> {
@@ -584,7 +586,7 @@ export function setLogLevel(level: LogLevel, options?: SetLogLevelOptions): void
 export const SpinnerIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
 // @public
-export function StartAudio({ label, ...props }: AllowAudioPlaybackProps): React_2.JSX.Element;
+export const StartAudio: (props: AllowAudioPlaybackProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public
 export function Toast(props: React_2.HTMLAttributes<HTMLDivElement>): React_2.JSX.Element;
@@ -599,7 +601,7 @@ export interface TrackLoopProps {
 }
 
 // @public
-export function TrackMutedIndicator({ trackRef, show, ...props }: TrackMutedIndicatorProps): React_2.JSX.Element | null;
+export const TrackMutedIndicator: (props: TrackMutedIndicatorProps & React_2.RefAttributes<HTMLDivElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface TrackMutedIndicatorProps extends React_2.HTMLAttributes<HTMLDivElement> {
@@ -627,7 +629,7 @@ export type TrackReferenceOrPlaceholder = TrackReference | TrackReferencePlaceho
 // Warning: (ae-forgotten-export) The symbol "ToggleSource" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function TrackToggle<T extends ToggleSource>({ showIcon, ...props }: TrackToggleProps<T>): React_2.JSX.Element;
+export const TrackToggle: <T extends ToggleSource>(props: TrackToggleProps<T> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement | null;
 
 // @public (undocumented)
 export interface TrackToggleProps<T extends ToggleSource> extends Omit<React_2.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
@@ -1124,7 +1126,7 @@ export interface VideoConferenceProps extends React_2.HTMLAttributes<HTMLDivElem
 }
 
 // @public
-export function VideoTrack({ onTrackClick, onClick, onSubscriptionStatusChanged, trackRef, manageSubscription, ...props }: VideoTrackProps): React_2.JSX.Element;
+export const VideoTrack: (props: VideoTrackProps & React_2.RefAttributes<HTMLVideoElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 // @public (undocumented)
 export interface VideoTrackProps extends React_2.VideoHTMLAttributes<HTMLVideoElement> {

--- a/packages/react/src/components/ChatEntry.tsx
+++ b/packages/react/src/components/ChatEntry.tsx
@@ -33,46 +33,48 @@ export interface ChatEntryProps extends React.HTMLAttributes<HTMLLIElement> {
  * @see `Chat`
  * @public
  */
-export const ChatEntry = React.forwardRef<HTMLLIElement, ChatEntryProps>(function ChatEntry(
-  { entry, hideName = false, hideTimestamp = false, messageFormatter, ...props }: ChatEntryProps,
-  ref,
-) {
-  const formattedMessage = React.useMemo(() => {
-    return messageFormatter ? messageFormatter(entry.message) : entry.message;
-  }, [entry.message, messageFormatter]);
-  const hasBeenEdited = !!entry.editTimestamp;
-  const time = new Date(entry.timestamp);
-  const locale = navigator ? navigator.language : 'en-US';
+export const ChatEntry = /* @__PURE__ */ React.forwardRef<HTMLLIElement, ChatEntryProps>(
+  function ChatEntry(
+    { entry, hideName = false, hideTimestamp = false, messageFormatter, ...props }: ChatEntryProps,
+    ref,
+  ) {
+    const formattedMessage = React.useMemo(() => {
+      return messageFormatter ? messageFormatter(entry.message) : entry.message;
+    }, [entry.message, messageFormatter]);
+    const hasBeenEdited = !!entry.editTimestamp;
+    const time = new Date(entry.timestamp);
+    const locale = navigator ? navigator.language : 'en-US';
 
-  return (
-    <li
-      ref={ref}
-      className="lk-chat-entry"
-      title={time.toLocaleTimeString(locale, { timeStyle: 'full' })}
-      data-lk-message-origin={entry.from?.isLocal ? 'local' : 'remote'}
-      {...props}
-    >
-      {(!hideTimestamp || !hideName || hasBeenEdited) && (
-        <span className="lk-meta-data">
-          {!hideName && (
-            <strong className="lk-participant-name">
-              {entry.from?.name ?? entry.from?.identity}
-            </strong>
-          )}
+    return (
+      <li
+        ref={ref}
+        className="lk-chat-entry"
+        title={time.toLocaleTimeString(locale, { timeStyle: 'full' })}
+        data-lk-message-origin={entry.from?.isLocal ? 'local' : 'remote'}
+        {...props}
+      >
+        {(!hideTimestamp || !hideName || hasBeenEdited) && (
+          <span className="lk-meta-data">
+            {!hideName && (
+              <strong className="lk-participant-name">
+                {entry.from?.name ?? entry.from?.identity}
+              </strong>
+            )}
 
-          {(!hideTimestamp || hasBeenEdited) && (
-            <span className="lk-timestamp">
-              {hasBeenEdited && 'edited '}
-              {time.toLocaleTimeString(locale, { timeStyle: 'short' })}
-            </span>
-          )}
-        </span>
-      )}
+            {(!hideTimestamp || hasBeenEdited) && (
+              <span className="lk-timestamp">
+                {hasBeenEdited && 'edited '}
+                {time.toLocaleTimeString(locale, { timeStyle: 'short' })}
+              </span>
+            )}
+          </span>
+        )}
 
-      <span className="lk-message-body">{formattedMessage}</span>
-    </li>
-  );
-});
+        <span className="lk-message-body">{formattedMessage}</span>
+      </li>
+    );
+  },
+);
 
 /** @public */
 export function formatChatMessageLinks(message: string): React.ReactNode {

--- a/packages/react/src/components/ChatEntry.tsx
+++ b/packages/react/src/components/ChatEntry.tsx
@@ -33,13 +33,10 @@ export interface ChatEntryProps extends React.HTMLAttributes<HTMLLIElement> {
  * @see `Chat`
  * @public
  */
-export function ChatEntry({
-  entry,
-  hideName = false,
-  hideTimestamp = false,
-  messageFormatter,
-  ...props
-}: ChatEntryProps) {
+export const ChatEntry = React.forwardRef<HTMLLIElement, ChatEntryProps>(function ChatEntry(
+  { entry, hideName = false, hideTimestamp = false, messageFormatter, ...props }: ChatEntryProps,
+  ref,
+) {
   const formattedMessage = React.useMemo(() => {
     return messageFormatter ? messageFormatter(entry.message) : entry.message;
   }, [entry.message, messageFormatter]);
@@ -49,6 +46,7 @@ export function ChatEntry({
 
   return (
     <li
+      ref={ref}
       className="lk-chat-entry"
       title={time.toLocaleTimeString(locale, { timeStyle: 'full' })}
       data-lk-message-origin={entry.from?.isLocal ? 'local' : 'remote'}
@@ -74,7 +72,7 @@ export function ChatEntry({
       <span className="lk-message-body">{formattedMessage}</span>
     </li>
   );
-}
+});
 
 /** @public */
 export function formatChatMessageLinks(message: string): React.ReactNode {

--- a/packages/react/src/components/ConnectionState.tsx
+++ b/packages/react/src/components/ConnectionState.tsx
@@ -22,13 +22,14 @@ export interface ConnectionStatusProps extends React.HTMLAttributes<HTMLDivEleme
  * ```
  * @public
  */
-export const ConnectionState = React.forwardRef<HTMLDivElement, ConnectionStatusProps>(
-  function ConnectionState({ room, ...props }: ConnectionStatusProps, ref) {
-    const connectionState = useConnectionState(room);
-    return (
-      <div ref={ref} {...props}>
-        {connectionState}
-      </div>
-    );
-  },
-);
+export const ConnectionState = /* @__PURE__ */ React.forwardRef<
+  HTMLDivElement,
+  ConnectionStatusProps
+>(function ConnectionState({ room, ...props }: ConnectionStatusProps, ref) {
+  const connectionState = useConnectionState(room);
+  return (
+    <div ref={ref} {...props}>
+      {connectionState}
+    </div>
+  );
+});

--- a/packages/react/src/components/ConnectionState.tsx
+++ b/packages/react/src/components/ConnectionState.tsx
@@ -22,7 +22,13 @@ export interface ConnectionStatusProps extends React.HTMLAttributes<HTMLDivEleme
  * ```
  * @public
  */
-export function ConnectionState({ room, ...props }: ConnectionStatusProps) {
-  const connectionState = useConnectionState(room);
-  return <div {...props}>{connectionState}</div>;
-}
+export const ConnectionState = React.forwardRef<HTMLDivElement, ConnectionStatusProps>(
+  function ConnectionState({ room, ...props }: ConnectionStatusProps, ref) {
+    const connectionState = useConnectionState(room);
+    return (
+      <div ref={ref} {...props}>
+        {connectionState}
+      </div>
+    );
+  },
+);

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -100,7 +100,7 @@ export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivEleme
  * ```
  * @public
  */
-export const LiveKitRoom = React.forwardRef<
+export const LiveKitRoom = /* @__PURE__ */ React.forwardRef<
   HTMLDivElement,
   React.PropsWithChildren<LiveKitRoomProps>
 >(function LiveKitRoom(props: React.PropsWithChildren<LiveKitRoomProps>, ref) {

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -100,10 +100,13 @@ export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivEleme
  * ```
  * @public
  */
-export function LiveKitRoom(props: React.PropsWithChildren<LiveKitRoomProps>) {
+export const LiveKitRoom = React.forwardRef<
+  HTMLDivElement,
+  React.PropsWithChildren<LiveKitRoomProps>
+>(function LiveKitRoom(props: React.PropsWithChildren<LiveKitRoomProps>, ref) {
   const { room, htmlProps } = useLiveKitRoom(props);
   return (
-    <div {...htmlProps}>
+    <div ref={ref} {...htmlProps}>
       {room && (
         <RoomContext.Provider value={room}>
           <LKFeatureContext.Provider value={props.featureFlags}>
@@ -113,4 +116,4 @@ export function LiveKitRoom(props: React.PropsWithChildren<LiveKitRoomProps>) {
       )}
     </div>
   );
-}
+});

--- a/packages/react/src/components/RoomName.tsx
+++ b/packages/react/src/components/RoomName.tsx
@@ -17,17 +17,19 @@ export interface RoomNameProps extends React.HTMLAttributes<HTMLSpanElement> {
  * ```
  * @public
  */
-export const RoomName = React.forwardRef<HTMLSpanElement, RoomNameProps>(function RoomName(
-  { childrenPosition = 'before', children, ...htmlAttributes }: RoomNameProps,
-  ref,
-) {
-  const { name } = useRoomInfo();
+export const RoomName = /* @__PURE__ */ React.forwardRef<HTMLSpanElement, RoomNameProps>(
+  function RoomName(
+    { childrenPosition = 'before', children, ...htmlAttributes }: RoomNameProps,
+    ref,
+  ) {
+    const { name } = useRoomInfo();
 
-  return (
-    <span ref={ref} {...htmlAttributes}>
-      {childrenPosition === 'before' && children}
-      {name}
-      {childrenPosition === 'after' && children}
-    </span>
-  );
-});
+    return (
+      <span ref={ref} {...htmlAttributes}>
+        {childrenPosition === 'before' && children}
+        {name}
+        {childrenPosition === 'after' && children}
+      </span>
+    );
+  },
+);

--- a/packages/react/src/components/RoomName.tsx
+++ b/packages/react/src/components/RoomName.tsx
@@ -17,18 +17,17 @@ export interface RoomNameProps extends React.HTMLAttributes<HTMLSpanElement> {
  * ```
  * @public
  */
-export function RoomName({
-  childrenPosition = 'before',
-  children,
-  ...htmlAttributes
-}: RoomNameProps) {
+export const RoomName = React.forwardRef<HTMLSpanElement, RoomNameProps>(function RoomName(
+  { childrenPosition = 'before', children, ...htmlAttributes }: RoomNameProps,
+  ref,
+) {
   const { name } = useRoomInfo();
 
   return (
-    <span {...htmlAttributes}>
+    <span ref={ref} {...htmlAttributes}>
       {childrenPosition === 'before' && children}
       {name}
       {childrenPosition === 'after' && children}
     </span>
   );
-}
+});

--- a/packages/react/src/components/controls/ChatToggle.tsx
+++ b/packages/react/src/components/controls/ChatToggle.tsx
@@ -17,8 +17,15 @@ export interface ChatToggleProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * ```
  * @public
  */
-export function ChatToggle(props: ChatToggleProps) {
+export const ChatToggle = React.forwardRef<HTMLButtonElement, ChatToggleProps>(function ChatToggle(
+  props: ChatToggleProps,
+  ref,
+) {
   const { mergedProps } = useChatToggle({ props });
 
-  return <button {...mergedProps}>{props.children}</button>;
-}
+  return (
+    <button ref={ref} {...mergedProps}>
+      {props.children}
+    </button>
+  );
+});

--- a/packages/react/src/components/controls/ChatToggle.tsx
+++ b/packages/react/src/components/controls/ChatToggle.tsx
@@ -17,15 +17,14 @@ export interface ChatToggleProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * ```
  * @public
  */
-export const ChatToggle = React.forwardRef<HTMLButtonElement, ChatToggleProps>(function ChatToggle(
-  props: ChatToggleProps,
-  ref,
-) {
-  const { mergedProps } = useChatToggle({ props });
+export const ChatToggle = /* @__PURE__ */ React.forwardRef<HTMLButtonElement, ChatToggleProps>(
+  function ChatToggle(props: ChatToggleProps, ref) {
+    const { mergedProps } = useChatToggle({ props });
 
-  return (
-    <button ref={ref} {...mergedProps}>
-      {props.children}
-    </button>
-  );
-});
+    return (
+      <button ref={ref} {...mergedProps}>
+        {props.children}
+      </button>
+    );
+  },
+);

--- a/packages/react/src/components/controls/ClearPinButton.tsx
+++ b/packages/react/src/components/controls/ClearPinButton.tsx
@@ -18,13 +18,14 @@ export interface ClearPinButtonProps extends React.ButtonHTMLAttributes<HTMLButt
  * ```
  * @public
  */
-export const ClearPinButton = React.forwardRef<HTMLButtonElement, ClearPinButtonProps>(
-  function ClearPinButton(props: ClearPinButtonProps, ref) {
-    const { buttonProps } = useClearPinButton(props);
-    return (
-      <button ref={ref} {...buttonProps}>
-        {props.children}
-      </button>
-    );
-  },
-);
+export const ClearPinButton = /* @__PURE__ */ React.forwardRef<
+  HTMLButtonElement,
+  ClearPinButtonProps
+>(function ClearPinButton(props: ClearPinButtonProps, ref) {
+  const { buttonProps } = useClearPinButton(props);
+  return (
+    <button ref={ref} {...buttonProps}>
+      {props.children}
+    </button>
+  );
+});

--- a/packages/react/src/components/controls/ClearPinButton.tsx
+++ b/packages/react/src/components/controls/ClearPinButton.tsx
@@ -18,7 +18,13 @@ export interface ClearPinButtonProps extends React.ButtonHTMLAttributes<HTMLButt
  * ```
  * @public
  */
-export function ClearPinButton(props: ClearPinButtonProps) {
-  const { buttonProps } = useClearPinButton(props);
-  return <button {...buttonProps}>{props.children}</button>;
-}
+export const ClearPinButton = React.forwardRef<HTMLButtonElement, ClearPinButtonProps>(
+  function ClearPinButton(props: ClearPinButtonProps, ref) {
+    const { buttonProps } = useClearPinButton(props);
+    return (
+      <button ref={ref} {...buttonProps}>
+        {props.children}
+      </button>
+    );
+  },
+);

--- a/packages/react/src/components/controls/DisconnectButton.tsx
+++ b/packages/react/src/components/controls/DisconnectButton.tsx
@@ -18,7 +18,13 @@ export interface DisconnectButtonProps extends React.ButtonHTMLAttributes<HTMLBu
  * ```
  * @public
  */
-export function DisconnectButton(props: DisconnectButtonProps) {
-  const { buttonProps } = useDisconnectButton(props);
-  return <button {...buttonProps}>{props.children}</button>;
-}
+export const DisconnectButton = React.forwardRef<HTMLButtonElement, DisconnectButtonProps>(
+  function DisconnectButton(props: DisconnectButtonProps, ref) {
+    const { buttonProps } = useDisconnectButton(props);
+    return (
+      <button ref={ref} {...buttonProps}>
+        {props.children}
+      </button>
+    );
+  },
+);

--- a/packages/react/src/components/controls/DisconnectButton.tsx
+++ b/packages/react/src/components/controls/DisconnectButton.tsx
@@ -18,13 +18,14 @@ export interface DisconnectButtonProps extends React.ButtonHTMLAttributes<HTMLBu
  * ```
  * @public
  */
-export const DisconnectButton = React.forwardRef<HTMLButtonElement, DisconnectButtonProps>(
-  function DisconnectButton(props: DisconnectButtonProps, ref) {
-    const { buttonProps } = useDisconnectButton(props);
-    return (
-      <button ref={ref} {...buttonProps}>
-        {props.children}
-      </button>
-    );
-  },
-);
+export const DisconnectButton = /* @__PURE__ */ React.forwardRef<
+  HTMLButtonElement,
+  DisconnectButtonProps
+>(function DisconnectButton(props: DisconnectButtonProps, ref) {
+  const { buttonProps } = useDisconnectButton(props);
+  return (
+    <button ref={ref} {...buttonProps}>
+      {props.children}
+    </button>
+  );
+});

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -22,29 +22,31 @@ export interface FocusToggleProps extends React.ButtonHTMLAttributes<HTMLButtonE
  * ```
  * @public
  */
-export function FocusToggle({ trackRef, ...props }: FocusToggleProps) {
-  const trackRefFromContext = useMaybeTrackRefContext();
+export const FocusToggle = React.forwardRef<HTMLButtonElement, FocusToggleProps>(
+  function FocusToggle({ trackRef, ...props }: FocusToggleProps, ref) {
+    const trackRefFromContext = useMaybeTrackRefContext();
 
-  const { mergedProps, inFocus } = useFocusToggle({
-    trackRef: trackRef ?? trackRefFromContext,
-    props,
-  });
+    const { mergedProps, inFocus } = useFocusToggle({
+      trackRef: trackRef ?? trackRefFromContext,
+      props,
+    });
 
-  return (
-    <LayoutContext.Consumer>
-      {(layoutContext) =>
-        layoutContext !== undefined && (
-          <button {...mergedProps}>
-            {props.children ? (
-              props.children
-            ) : inFocus ? (
-              <UnfocusToggleIcon />
-            ) : (
-              <FocusToggleIcon />
-            )}
-          </button>
-        )
-      }
-    </LayoutContext.Consumer>
-  );
-}
+    return (
+      <LayoutContext.Consumer>
+        {(layoutContext) =>
+          layoutContext !== undefined && (
+            <button ref={ref} {...mergedProps}>
+              {props.children ? (
+                props.children
+              ) : inFocus ? (
+                <UnfocusToggleIcon />
+              ) : (
+                <FocusToggleIcon />
+              )}
+            </button>
+          )
+        }
+      </LayoutContext.Consumer>
+    );
+  },
+);

--- a/packages/react/src/components/controls/FocusToggle.tsx
+++ b/packages/react/src/components/controls/FocusToggle.tsx
@@ -22,7 +22,7 @@ export interface FocusToggleProps extends React.ButtonHTMLAttributes<HTMLButtonE
  * ```
  * @public
  */
-export const FocusToggle = React.forwardRef<HTMLButtonElement, FocusToggleProps>(
+export const FocusToggle = /* @__PURE__ */ React.forwardRef<HTMLButtonElement, FocusToggleProps>(
   function FocusToggle({ trackRef, ...props }: FocusToggleProps, ref) {
     const trackRefFromContext = useMaybeTrackRefContext();
 

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -42,95 +42,96 @@ export interface MediaDeviceSelectProps
  * ```
  * @public
  */
-export const MediaDeviceSelect = React.forwardRef<HTMLUListElement, MediaDeviceSelectProps>(
-  function MediaDeviceSelect(
-    {
-      kind,
-      initialSelection,
-      onActiveDeviceChange,
-      onDeviceListChange,
-      onDeviceSelectError,
-      exactMatch,
-      track,
-      requestPermissions,
-      onError,
-      ...props
-    }: MediaDeviceSelectProps,
-    ref,
-  ) {
-    const room = useMaybeRoomContext();
-    const handleError = React.useCallback(
-      (e: Error) => {
-        if (room) {
-          // awkwardly emit the event from outside of the room, as we don't have other means to raise a MediaDeviceError
-          room.emit(RoomEvent.MediaDevicesError, e);
-        }
-        onError?.(e);
-      },
-      [room, onError],
-    );
-    const { devices, activeDeviceId, setActiveMediaDevice, className } = useMediaDeviceSelect({
-      kind,
-      room,
-      track,
-      requestPermissions,
-      onError: handleError,
-    });
-    React.useEffect(() => {
-      if (initialSelection !== undefined) {
-        setActiveMediaDevice(initialSelection);
+export const MediaDeviceSelect = /* @__PURE__ */ React.forwardRef<
+  HTMLUListElement,
+  MediaDeviceSelectProps
+>(function MediaDeviceSelect(
+  {
+    kind,
+    initialSelection,
+    onActiveDeviceChange,
+    onDeviceListChange,
+    onDeviceSelectError,
+    exactMatch,
+    track,
+    requestPermissions,
+    onError,
+    ...props
+  }: MediaDeviceSelectProps,
+  ref,
+) {
+  const room = useMaybeRoomContext();
+  const handleError = React.useCallback(
+    (e: Error) => {
+      if (room) {
+        // awkwardly emit the event from outside of the room, as we don't have other means to raise a MediaDeviceError
+        room.emit(RoomEvent.MediaDevicesError, e);
       }
-    }, [setActiveMediaDevice]);
-
-    React.useEffect(() => {
-      if (typeof onDeviceListChange === 'function') {
-        onDeviceListChange(devices);
-      }
-    }, [onDeviceListChange, devices]);
-
-    React.useEffect(() => {
-      if (activeDeviceId && activeDeviceId !== '') {
-        onActiveDeviceChange?.(activeDeviceId);
-      }
-    }, [activeDeviceId]);
-
-    const handleActiveDeviceChange = async (deviceId: string) => {
-      try {
-        await setActiveMediaDevice(deviceId, { exact: exactMatch });
-      } catch (e) {
-        if (e instanceof Error) {
-          onDeviceSelectError?.(e);
-        } else {
-          throw e;
-        }
-      }
-    };
-    // Merge Props
-    const mergedProps = React.useMemo(
-      () => mergeProps(props, { className }, { className: 'lk-list' }),
-      [className, props],
-    );
-
-    function isActive(deviceId: string, activeDeviceId: string, index: number) {
-      return deviceId === activeDeviceId || (index === 0 && activeDeviceId === 'default');
+      onError?.(e);
+    },
+    [room, onError],
+  );
+  const { devices, activeDeviceId, setActiveMediaDevice, className } = useMediaDeviceSelect({
+    kind,
+    room,
+    track,
+    requestPermissions,
+    onError: handleError,
+  });
+  React.useEffect(() => {
+    if (initialSelection !== undefined) {
+      setActiveMediaDevice(initialSelection);
     }
+  }, [setActiveMediaDevice]);
 
-    return (
-      <ul ref={ref} {...mergedProps}>
-        {devices.map((device, index) => (
-          <li
-            key={device.deviceId}
-            id={device.deviceId}
-            data-lk-active={isActive(device.deviceId, activeDeviceId, index)}
-            aria-selected={isActive(device.deviceId, activeDeviceId, index)}
-            role="option"
-          >
-            <button className="lk-button" onClick={() => handleActiveDeviceChange(device.deviceId)}>
-              {device.label}
-            </button>
-          </li>
-        ))}
-      </ul>
-    );
-  },
-);
+  React.useEffect(() => {
+    if (typeof onDeviceListChange === 'function') {
+      onDeviceListChange(devices);
+    }
+  }, [onDeviceListChange, devices]);
+
+  React.useEffect(() => {
+    if (activeDeviceId && activeDeviceId !== '') {
+      onActiveDeviceChange?.(activeDeviceId);
+    }
+  }, [activeDeviceId]);
+
+  const handleActiveDeviceChange = async (deviceId: string) => {
+    try {
+      await setActiveMediaDevice(deviceId, { exact: exactMatch });
+    } catch (e) {
+      if (e instanceof Error) {
+        onDeviceSelectError?.(e);
+      } else {
+        throw e;
+      }
+    }
+  };
+  // Merge Props
+  const mergedProps = React.useMemo(
+    () => mergeProps(props, { className }, { className: 'lk-list' }),
+    [className, props],
+  );
+
+  function isActive(deviceId: string, activeDeviceId: string, index: number) {
+    return deviceId === activeDeviceId || (index === 0 && activeDeviceId === 'default');
+  }
+
+  return (
+    <ul ref={ref} {...mergedProps}>
+      {devices.map((device, index) => (
+        <li
+          key={device.deviceId}
+          id={device.deviceId}
+          data-lk-active={isActive(device.deviceId, activeDeviceId, index)}
+          aria-selected={isActive(device.deviceId, activeDeviceId, index)}
+          role="option"
+        >
+          <button className="lk-button" onClick={() => handleActiveDeviceChange(device.deviceId)}>
+            {device.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+});

--- a/packages/react/src/components/controls/MediaDeviceSelect.tsx
+++ b/packages/react/src/components/controls/MediaDeviceSelect.tsx
@@ -42,90 +42,95 @@ export interface MediaDeviceSelectProps
  * ```
  * @public
  */
-export function MediaDeviceSelect({
-  kind,
-  initialSelection,
-  onActiveDeviceChange,
-  onDeviceListChange,
-  onDeviceSelectError,
-  exactMatch,
-  track,
-  requestPermissions,
-  onError,
-  ...props
-}: MediaDeviceSelectProps) {
-  const room = useMaybeRoomContext();
-  const handleError = React.useCallback(
-    (e: Error) => {
-      if (room) {
-        // awkwardly emit the event from outside of the room, as we don't have other means to raise a MediaDeviceError
-        room.emit(RoomEvent.MediaDevicesError, e);
+export const MediaDeviceSelect = React.forwardRef<HTMLUListElement, MediaDeviceSelectProps>(
+  function MediaDeviceSelect(
+    {
+      kind,
+      initialSelection,
+      onActiveDeviceChange,
+      onDeviceListChange,
+      onDeviceSelectError,
+      exactMatch,
+      track,
+      requestPermissions,
+      onError,
+      ...props
+    }: MediaDeviceSelectProps,
+    ref,
+  ) {
+    const room = useMaybeRoomContext();
+    const handleError = React.useCallback(
+      (e: Error) => {
+        if (room) {
+          // awkwardly emit the event from outside of the room, as we don't have other means to raise a MediaDeviceError
+          room.emit(RoomEvent.MediaDevicesError, e);
+        }
+        onError?.(e);
+      },
+      [room, onError],
+    );
+    const { devices, activeDeviceId, setActiveMediaDevice, className } = useMediaDeviceSelect({
+      kind,
+      room,
+      track,
+      requestPermissions,
+      onError: handleError,
+    });
+    React.useEffect(() => {
+      if (initialSelection !== undefined) {
+        setActiveMediaDevice(initialSelection);
       }
-      onError?.(e);
-    },
-    [room, onError],
-  );
-  const { devices, activeDeviceId, setActiveMediaDevice, className } = useMediaDeviceSelect({
-    kind,
-    room,
-    track,
-    requestPermissions,
-    onError: handleError,
-  });
-  React.useEffect(() => {
-    if (initialSelection !== undefined) {
-      setActiveMediaDevice(initialSelection);
-    }
-  }, [setActiveMediaDevice]);
+    }, [setActiveMediaDevice]);
 
-  React.useEffect(() => {
-    if (typeof onDeviceListChange === 'function') {
-      onDeviceListChange(devices);
-    }
-  }, [onDeviceListChange, devices]);
-
-  React.useEffect(() => {
-    if (activeDeviceId && activeDeviceId !== '') {
-      onActiveDeviceChange?.(activeDeviceId);
-    }
-  }, [activeDeviceId]);
-
-  const handleActiveDeviceChange = async (deviceId: string) => {
-    try {
-      await setActiveMediaDevice(deviceId, { exact: exactMatch });
-    } catch (e) {
-      if (e instanceof Error) {
-        onDeviceSelectError?.(e);
-      } else {
-        throw e;
+    React.useEffect(() => {
+      if (typeof onDeviceListChange === 'function') {
+        onDeviceListChange(devices);
       }
+    }, [onDeviceListChange, devices]);
+
+    React.useEffect(() => {
+      if (activeDeviceId && activeDeviceId !== '') {
+        onActiveDeviceChange?.(activeDeviceId);
+      }
+    }, [activeDeviceId]);
+
+    const handleActiveDeviceChange = async (deviceId: string) => {
+      try {
+        await setActiveMediaDevice(deviceId, { exact: exactMatch });
+      } catch (e) {
+        if (e instanceof Error) {
+          onDeviceSelectError?.(e);
+        } else {
+          throw e;
+        }
+      }
+    };
+    // Merge Props
+    const mergedProps = React.useMemo(
+      () => mergeProps(props, { className }, { className: 'lk-list' }),
+      [className, props],
+    );
+
+    function isActive(deviceId: string, activeDeviceId: string, index: number) {
+      return deviceId === activeDeviceId || (index === 0 && activeDeviceId === 'default');
     }
-  };
-  // Merge Props
-  const mergedProps = React.useMemo(
-    () => mergeProps(props, { className }, { className: 'lk-list' }),
-    [className, props],
-  );
 
-  function isActive(deviceId: string, activeDeviceId: string, index: number) {
-    return deviceId === activeDeviceId || (index === 0 && activeDeviceId === 'default');
-  }
-
-  return (
-    <ul {...mergedProps}>
-      {devices.map((device, index) => (
-        <li
-          key={device.deviceId}
-          id={device.deviceId}
-          data-lk-active={isActive(device.deviceId, activeDeviceId, index)}
-          aria-selected={isActive(device.deviceId, activeDeviceId, index)}
-          role="option"
-        >
-          <button className="lk-button" onClick={() => handleActiveDeviceChange(device.deviceId)}>
-            {device.label}
-          </button>
-        </li>
-      ))}
-    </ul>
-  );
-}
+    return (
+      <ul ref={ref} {...mergedProps}>
+        {devices.map((device, index) => (
+          <li
+            key={device.deviceId}
+            id={device.deviceId}
+            data-lk-active={isActive(device.deviceId, activeDeviceId, index)}
+            aria-selected={isActive(device.deviceId, activeDeviceId, index)}
+            role="option"
+          >
+            <button className="lk-button" onClick={() => handleActiveDeviceChange(device.deviceId)}>
+              {device.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    );
+  },
+);

--- a/packages/react/src/components/controls/PaginationIndicator.tsx
+++ b/packages/react/src/components/controls/PaginationIndicator.tsx
@@ -5,20 +5,21 @@ export interface PaginationIndicatorProps {
   currentPage: number;
 }
 
-export const PaginationIndicator = React.forwardRef<HTMLDivElement, PaginationIndicatorProps>(
-  function PaginationIndicator({ totalPageCount, currentPage }: PaginationIndicatorProps, ref) {
-    const bubbles = new Array(totalPageCount).fill('').map((_, index) => {
-      if (index + 1 === currentPage) {
-        return <span data-lk-active key={index} />;
-      } else {
-        return <span key={index} />;
-      }
-    });
+export const PaginationIndicator = /* @__PURE__ */ React.forwardRef<
+  HTMLDivElement,
+  PaginationIndicatorProps
+>(function PaginationIndicator({ totalPageCount, currentPage }: PaginationIndicatorProps, ref) {
+  const bubbles = new Array(totalPageCount).fill('').map((_, index) => {
+    if (index + 1 === currentPage) {
+      return <span data-lk-active key={index} />;
+    } else {
+      return <span key={index} />;
+    }
+  });
 
-    return (
-      <div ref={ref} className="lk-pagination-indicator">
-        {bubbles}
-      </div>
-    );
-  },
-);
+  return (
+    <div ref={ref} className="lk-pagination-indicator">
+      {bubbles}
+    </div>
+  );
+});

--- a/packages/react/src/components/controls/PaginationIndicator.tsx
+++ b/packages/react/src/components/controls/PaginationIndicator.tsx
@@ -5,14 +5,20 @@ export interface PaginationIndicatorProps {
   currentPage: number;
 }
 
-export function PaginationIndicator({ totalPageCount, currentPage }: PaginationIndicatorProps) {
-  const bubbles = new Array(totalPageCount).fill('').map((_, index) => {
-    if (index + 1 === currentPage) {
-      return <span data-lk-active key={index} />;
-    } else {
-      return <span key={index} />;
-    }
-  });
+export const PaginationIndicator = React.forwardRef<HTMLDivElement, PaginationIndicatorProps>(
+  function PaginationIndicator({ totalPageCount, currentPage }: PaginationIndicatorProps, ref) {
+    const bubbles = new Array(totalPageCount).fill('').map((_, index) => {
+      if (index + 1 === currentPage) {
+        return <span data-lk-active key={index} />;
+      } else {
+        return <span key={index} />;
+      }
+    });
 
-  return <div className="lk-pagination-indicator">{bubbles}</div>;
-}
+    return (
+      <div ref={ref} className="lk-pagination-indicator">
+        {bubbles}
+      </div>
+    );
+  },
+);

--- a/packages/react/src/components/controls/SettingsMenuToggle.tsx
+++ b/packages/react/src/components/controls/SettingsMenuToggle.tsx
@@ -11,14 +11,15 @@ export interface SettingsMenuToggleProps extends React.ButtonHTMLAttributes<HTML
  *
  * @alpha
  */
-export const SettingsMenuToggle = React.forwardRef<HTMLButtonElement, SettingsMenuToggleProps>(
-  function SettingsMenuToggle(props: SettingsMenuToggleProps, ref) {
-    const { mergedProps } = useSettingsToggle({ props });
+export const SettingsMenuToggle = /* @__PURE__ */ React.forwardRef<
+  HTMLButtonElement,
+  SettingsMenuToggleProps
+>(function SettingsMenuToggle(props: SettingsMenuToggleProps, ref) {
+  const { mergedProps } = useSettingsToggle({ props });
 
-    return (
-      <button ref={ref} {...mergedProps}>
-        {props.children}
-      </button>
-    );
-  },
-);
+  return (
+    <button ref={ref} {...mergedProps}>
+      {props.children}
+    </button>
+  );
+});

--- a/packages/react/src/components/controls/SettingsMenuToggle.tsx
+++ b/packages/react/src/components/controls/SettingsMenuToggle.tsx
@@ -11,8 +11,14 @@ export interface SettingsMenuToggleProps extends React.ButtonHTMLAttributes<HTML
  *
  * @alpha
  */
-export function SettingsMenuToggle(props: SettingsMenuToggleProps) {
-  const { mergedProps } = useSettingsToggle({ props });
+export const SettingsMenuToggle = React.forwardRef<HTMLButtonElement, SettingsMenuToggleProps>(
+  function SettingsMenuToggle(props: SettingsMenuToggleProps, ref) {
+    const { mergedProps } = useSettingsToggle({ props });
 
-  return <button {...mergedProps}>{props.children}</button>;
-}
+    return (
+      <button ref={ref} {...mergedProps}>
+        {props.children}
+      </button>
+    );
+  },
+);

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -22,15 +22,16 @@ export interface AllowAudioPlaybackProps extends React.ButtonHTMLAttributes<HTML
  * @see Autoplay policy on MDN web docs: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
  * @public
  */
-export const StartAudio = React.forwardRef<HTMLButtonElement, AllowAudioPlaybackProps>(
-  function StartAudio({ label = 'Allow Audio', ...props }: AllowAudioPlaybackProps, ref) {
-    const room = useRoomContext();
-    const { mergedProps } = useStartAudio({ room, props });
+export const StartAudio = /* @__PURE__ */ React.forwardRef<
+  HTMLButtonElement,
+  AllowAudioPlaybackProps
+>(function StartAudio({ label = 'Allow Audio', ...props }: AllowAudioPlaybackProps, ref) {
+  const room = useRoomContext();
+  const { mergedProps } = useStartAudio({ room, props });
 
-    return (
-      <button ref={ref} {...mergedProps}>
-        {label}
-      </button>
-    );
-  },
-);
+  return (
+    <button ref={ref} {...mergedProps}>
+      {label}
+    </button>
+  );
+});

--- a/packages/react/src/components/controls/StartAudio.tsx
+++ b/packages/react/src/components/controls/StartAudio.tsx
@@ -22,9 +22,15 @@ export interface AllowAudioPlaybackProps extends React.ButtonHTMLAttributes<HTML
  * @see Autoplay policy on MDN web docs: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
  * @public
  */
-export function StartAudio({ label = 'Allow Audio', ...props }: AllowAudioPlaybackProps) {
-  const room = useRoomContext();
-  const { mergedProps } = useStartAudio({ room, props });
+export const StartAudio = React.forwardRef<HTMLButtonElement, AllowAudioPlaybackProps>(
+  function StartAudio({ label = 'Allow Audio', ...props }: AllowAudioPlaybackProps, ref) {
+    const room = useRoomContext();
+    const { mergedProps } = useStartAudio({ room, props });
 
-  return <button {...mergedProps}>{label}</button>;
-}
+    return (
+      <button ref={ref} {...mergedProps}>
+        {label}
+      </button>
+    );
+  },
+);

--- a/packages/react/src/components/controls/StartMediaButton.tsx
+++ b/packages/react/src/components/controls/StartMediaButton.tsx
@@ -22,18 +22,19 @@ export interface AllowMediaPlaybackProps extends React.ButtonHTMLAttributes<HTML
  * @see Autoplay policy on MDN web docs: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
  * @public
  */
-export const StartMediaButton = React.forwardRef<HTMLButtonElement, AllowMediaPlaybackProps>(
-  function StartMediaButton({ label, ...props }: AllowMediaPlaybackProps, ref) {
-    const room = useRoomContext();
-    const { mergedProps: audioProps, canPlayAudio } = useStartAudio({ room, props });
-    const { mergedProps, canPlayVideo } = useStartVideo({ room, props: audioProps });
-    const { style, ...restProps } = mergedProps;
-    style.display = canPlayAudio && canPlayVideo ? 'none' : 'block';
+export const StartMediaButton = /* @__PURE__ */ React.forwardRef<
+  HTMLButtonElement,
+  AllowMediaPlaybackProps
+>(function StartMediaButton({ label, ...props }: AllowMediaPlaybackProps, ref) {
+  const room = useRoomContext();
+  const { mergedProps: audioProps, canPlayAudio } = useStartAudio({ room, props });
+  const { mergedProps, canPlayVideo } = useStartVideo({ room, props: audioProps });
+  const { style, ...restProps } = mergedProps;
+  style.display = canPlayAudio && canPlayVideo ? 'none' : 'block';
 
-    return (
-      <button ref={ref} style={style} {...restProps}>
-        {label ?? `Start ${!canPlayAudio ? 'Audio' : 'Video'}`}
-      </button>
-    );
-  },
-);
+  return (
+    <button ref={ref} style={style} {...restProps}>
+      {label ?? `Start ${!canPlayAudio ? 'Audio' : 'Video'}`}
+    </button>
+  );
+});

--- a/packages/react/src/components/controls/StartMediaButton.tsx
+++ b/packages/react/src/components/controls/StartMediaButton.tsx
@@ -22,16 +22,18 @@ export interface AllowMediaPlaybackProps extends React.ButtonHTMLAttributes<HTML
  * @see Autoplay policy on MDN web docs: {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy}
  * @public
  */
-export function StartMediaButton({ label, ...props }: AllowMediaPlaybackProps) {
-  const room = useRoomContext();
-  const { mergedProps: audioProps, canPlayAudio } = useStartAudio({ room, props });
-  const { mergedProps, canPlayVideo } = useStartVideo({ room, props: audioProps });
-  const { style, ...restProps } = mergedProps;
-  style.display = canPlayAudio && canPlayVideo ? 'none' : 'block';
+export const StartMediaButton = React.forwardRef<HTMLButtonElement, AllowMediaPlaybackProps>(
+  function StartMediaButton({ label, ...props }: AllowMediaPlaybackProps, ref) {
+    const room = useRoomContext();
+    const { mergedProps: audioProps, canPlayAudio } = useStartAudio({ room, props });
+    const { mergedProps, canPlayVideo } = useStartVideo({ room, props: audioProps });
+    const { style, ...restProps } = mergedProps;
+    style.display = canPlayAudio && canPlayVideo ? 'none' : 'block';
 
-  return (
-    <button style={style} {...restProps}>
-      {label ?? `Start ${!canPlayAudio ? 'Audio' : 'Video'}`}
-    </button>
-  );
-}
+    return (
+      <button ref={ref} style={style} {...restProps}>
+        {label ?? `Start ${!canPlayAudio ? 'Audio' : 'Video'}`}
+      </button>
+    );
+  },
+);

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -36,10 +36,9 @@ export interface TrackToggleProps<T extends ToggleSource>
  * ```
  * @public
  */
-export const TrackToggle = React.forwardRef(function TrackToggle<T extends ToggleSource>(
-  { showIcon, ...props }: TrackToggleProps<T>,
-  ref: React.ForwardedRef<HTMLButtonElement>,
-) {
+export const TrackToggle = /* @__PURE__ */ React.forwardRef(function TrackToggle<
+  T extends ToggleSource,
+>({ showIcon, ...props }: TrackToggleProps<T>, ref: React.ForwardedRef<HTMLButtonElement>) {
   const { buttonProps, enabled } = useTrackToggle(props);
   return (
     <button ref={ref} {...buttonProps}>

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -3,6 +3,12 @@ import * as React from 'react';
 import { getSourceIcon } from '../../assets/icons/util';
 import { useTrackToggle } from '../../hooks';
 
+declare module 'react' {
+  function forwardRef<T, P = object>(
+    render: (props: P, ref: React.Ref<T>) => React.ReactElement | null,
+  ): (props: P & React.RefAttributes<T>) => React.ReactElement | null;
+}
+
 /** @public */
 export interface TrackToggleProps<T extends ToggleSource>
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
@@ -30,12 +36,15 @@ export interface TrackToggleProps<T extends ToggleSource>
  * ```
  * @public
  */
-export function TrackToggle<T extends ToggleSource>({ showIcon, ...props }: TrackToggleProps<T>) {
+export const TrackToggle = React.forwardRef(function TrackToggle<T extends ToggleSource>(
+  { showIcon, ...props }: TrackToggleProps<T>,
+  ref: React.ForwardedRef<HTMLButtonElement>,
+) {
   const { buttonProps, enabled } = useTrackToggle(props);
   return (
-    <button {...buttonProps}>
+    <button ref={ref} {...buttonProps}>
       {(showIcon ?? true) && getSourceIcon(props.source, enabled)}
       {props.children}
     </button>
   );
-}
+});

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -36,12 +36,10 @@ export interface AudioTrackProps extends React.AudioHTMLAttributes<HTMLAudioElem
  * @see `ParticipantTile` component
  * @public
  */
-export function AudioTrack({
-  trackRef,
-  onSubscriptionStatusChanged,
-  volume,
-  ...props
-}: AudioTrackProps) {
+export const AudioTrack = React.forwardRef<HTMLAudioElement, AudioTrackProps>(function AudioTrack(
+  { trackRef, onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps,
+  ref,
+) {
   const trackReference = useEnsureTrackRef(trackRef);
 
   const mediaEl = React.useRef<HTMLAudioElement>(null);
@@ -82,5 +80,5 @@ export function AudioTrack({
     }
   }, [props.muted, pub, track]);
 
-  return <audio ref={mediaEl} {...elementProps} />;
-}
+  return <audio ref={ref} {...elementProps} />;
+});

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -36,49 +36,51 @@ export interface AudioTrackProps extends React.AudioHTMLAttributes<HTMLAudioElem
  * @see `ParticipantTile` component
  * @public
  */
-export const AudioTrack = React.forwardRef<HTMLAudioElement, AudioTrackProps>(function AudioTrack(
-  { trackRef, onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps,
-  ref,
-) {
-  const trackReference = useEnsureTrackRef(trackRef);
+export const AudioTrack = /* @__PURE__ */ React.forwardRef<HTMLAudioElement, AudioTrackProps>(
+  function AudioTrack(
+    { trackRef, onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps,
+    ref,
+  ) {
+    const trackReference = useEnsureTrackRef(trackRef);
 
-  const mediaEl = React.useRef<HTMLAudioElement>(null);
+    const mediaEl = React.useRef<HTMLAudioElement>(null);
 
-  const {
-    elementProps,
-    isSubscribed,
-    track,
-    publication: pub,
-  } = useMediaTrackBySourceOrName(trackReference, {
-    element: mediaEl,
-    props,
-  });
+    const {
+      elementProps,
+      isSubscribed,
+      track,
+      publication: pub,
+    } = useMediaTrackBySourceOrName(trackReference, {
+      element: mediaEl,
+      props,
+    });
 
-  React.useEffect(() => {
-    onSubscriptionStatusChanged?.(!!isSubscribed);
-  }, [isSubscribed, onSubscriptionStatusChanged]);
+    React.useEffect(() => {
+      onSubscriptionStatusChanged?.(!!isSubscribed);
+    }, [isSubscribed, onSubscriptionStatusChanged]);
 
-  React.useEffect(() => {
-    if (track === undefined || volume === undefined) {
-      return;
-    }
-    if (track instanceof RemoteAudioTrack) {
-      track.setVolume(volume);
-    } else {
-      log.warn('Volume can only be set on remote audio tracks.');
-    }
-  }, [volume, track]);
+    React.useEffect(() => {
+      if (track === undefined || volume === undefined) {
+        return;
+      }
+      if (track instanceof RemoteAudioTrack) {
+        track.setVolume(volume);
+      } else {
+        log.warn('Volume can only be set on remote audio tracks.');
+      }
+    }, [volume, track]);
 
-  React.useEffect(() => {
-    if (pub === undefined || props.muted === undefined) {
-      return;
-    }
-    if (pub instanceof RemoteTrackPublication) {
-      pub.setEnabled(!props.muted);
-    } else {
-      log.warn('Can only call setEnabled on remote track publications.');
-    }
-  }, [props.muted, pub, track]);
+    React.useEffect(() => {
+      if (pub === undefined || props.muted === undefined) {
+        return;
+      }
+      if (pub instanceof RemoteTrackPublication) {
+        pub.setEnabled(!props.muted);
+      } else {
+        log.warn('Can only call setEnabled on remote track publications.');
+      }
+    }, [props.muted, pub, track]);
 
-  return <audio ref={ref} {...elementProps} />;
-});
+    return <audio ref={ref} {...elementProps} />;
+  },
+);

--- a/packages/react/src/components/participant/AudioVisualizer.tsx
+++ b/packages/react/src/components/participant/AudioVisualizer.tsx
@@ -18,44 +18,45 @@ export interface AudioVisualizerProps extends React.HTMLAttributes<SVGElement> {
  * ```
  * @public
  */
-export const AudioVisualizer = React.forwardRef<SVGSVGElement, AudioVisualizerProps>(
-  function AudioVisualizer({ trackRef, ...props }: AudioVisualizerProps, ref) {
-    const svgWidth = 200;
-    const svgHeight = 90;
-    const barWidth = 6;
-    const barSpacing = 4;
-    const volMultiplier = 50;
-    const barCount = 7;
-    const trackReference = useEnsureTrackRef(trackRef);
+export const AudioVisualizer = /* @__PURE__ */ React.forwardRef<
+  SVGSVGElement,
+  AudioVisualizerProps
+>(function AudioVisualizer({ trackRef, ...props }: AudioVisualizerProps, ref) {
+  const svgWidth = 200;
+  const svgHeight = 90;
+  const barWidth = 6;
+  const barSpacing = 4;
+  const volMultiplier = 50;
+  const barCount = 7;
+  const trackReference = useEnsureTrackRef(trackRef);
 
-    const volumes = useMultibandTrackVolume(trackReference, { bands: 7, loPass: 300 });
+  const volumes = useMultibandTrackVolume(trackReference, { bands: 7, loPass: 300 });
 
-    return (
-      <svg
-        ref={ref}
-        width="100%"
-        height="100%"
-        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-        {...props}
-        className="lk-audio-visualizer"
+  return (
+    <svg
+      ref={ref}
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+      {...props}
+      className="lk-audio-visualizer"
+    >
+      <rect x="0" y="0" width="100%" height="100%" />
+      <g
+        style={{
+          transform: `translate(${(svgWidth - barCount * (barWidth + barSpacing)) / 2}px, 0)`,
+        }}
       >
-        <rect x="0" y="0" width="100%" height="100%" />
-        <g
-          style={{
-            transform: `translate(${(svgWidth - barCount * (barWidth + barSpacing)) / 2}px, 0)`,
-          }}
-        >
-          {volumes.map((vol, idx) => (
-            <rect
-              key={idx}
-              x={idx * (barWidth + barSpacing)}
-              y={svgHeight / 2 - (vol * volMultiplier) / 2}
-              width={barWidth}
-              height={vol * volMultiplier}
-            ></rect>
-          ))}
-        </g>
-      </svg>
-    );
-  },
-);
+        {volumes.map((vol, idx) => (
+          <rect
+            key={idx}
+            x={idx * (barWidth + barSpacing)}
+            y={svgHeight / 2 - (vol * volMultiplier) / 2}
+            width={barWidth}
+            height={vol * volMultiplier}
+          ></rect>
+        ))}
+      </g>
+    </svg>
+  );
+});

--- a/packages/react/src/components/participant/AudioVisualizer.tsx
+++ b/packages/react/src/components/participant/AudioVisualizer.tsx
@@ -18,41 +18,44 @@ export interface AudioVisualizerProps extends React.HTMLAttributes<SVGElement> {
  * ```
  * @public
  */
-export function AudioVisualizer({ trackRef, ...props }: AudioVisualizerProps) {
-  const svgWidth = 200;
-  const svgHeight = 90;
-  const barWidth = 6;
-  const barSpacing = 4;
-  const volMultiplier = 50;
-  const barCount = 7;
-  const trackReference = useEnsureTrackRef(trackRef);
+export const AudioVisualizer = React.forwardRef<SVGSVGElement, AudioVisualizerProps>(
+  function AudioVisualizer({ trackRef, ...props }: AudioVisualizerProps, ref) {
+    const svgWidth = 200;
+    const svgHeight = 90;
+    const barWidth = 6;
+    const barSpacing = 4;
+    const volMultiplier = 50;
+    const barCount = 7;
+    const trackReference = useEnsureTrackRef(trackRef);
 
-  const volumes = useMultibandTrackVolume(trackReference, { bands: 7, loPass: 300 });
+    const volumes = useMultibandTrackVolume(trackReference, { bands: 7, loPass: 300 });
 
-  return (
-    <svg
-      width="100%"
-      height="100%"
-      viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-      {...props}
-      className="lk-audio-visualizer"
-    >
-      <rect x="0" y="0" width="100%" height="100%" />
-      <g
-        style={{
-          transform: `translate(${(svgWidth - barCount * (barWidth + barSpacing)) / 2}px, 0)`,
-        }}
+    return (
+      <svg
+        ref={ref}
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        {...props}
+        className="lk-audio-visualizer"
       >
-        {volumes.map((vol, idx) => (
-          <rect
-            key={idx}
-            x={idx * (barWidth + barSpacing)}
-            y={svgHeight / 2 - (vol * volMultiplier) / 2}
-            width={barWidth}
-            height={vol * volMultiplier}
-          ></rect>
-        ))}
-      </g>
-    </svg>
-  );
-}
+        <rect x="0" y="0" width="100%" height="100%" />
+        <g
+          style={{
+            transform: `translate(${(svgWidth - barCount * (barWidth + barSpacing)) / 2}px, 0)`,
+          }}
+        >
+          {volumes.map((vol, idx) => (
+            <rect
+              key={idx}
+              x={idx * (barWidth + barSpacing)}
+              y={svgHeight / 2 - (vol * volMultiplier) / 2}
+              width={barWidth}
+              height={vol * volMultiplier}
+            ></rect>
+          ))}
+        </g>
+      </svg>
+    );
+  },
+);

--- a/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
+++ b/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
@@ -18,10 +18,17 @@ export interface ConnectionQualityIndicatorProps
  * ```
  * @public
  */
-export function ConnectionQualityIndicator(props: ConnectionQualityIndicatorProps) {
+export const ConnectionQualityIndicator = React.forwardRef<
+  HTMLDivElement,
+  ConnectionQualityIndicatorProps
+>(function ConnectionQualityIndicator(props: ConnectionQualityIndicatorProps, ref) {
   const { className, quality } = useConnectionQualityIndicator(props);
   const elementProps = React.useMemo(() => {
     return { ...mergeProps(props, { className: className as string }), 'data-lk-quality': quality };
   }, [quality, props, className]);
-  return <div {...elementProps}>{props.children ?? getConnectionQualityIcon(quality)}</div>;
-}
+  return (
+    <div ref={ref} {...elementProps}>
+      {props.children ?? getConnectionQualityIcon(quality)}
+    </div>
+  );
+});

--- a/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
+++ b/packages/react/src/components/participant/ConnectionQualityIndicator.tsx
@@ -18,7 +18,7 @@ export interface ConnectionQualityIndicatorProps
  * ```
  * @public
  */
-export const ConnectionQualityIndicator = React.forwardRef<
+export const ConnectionQualityIndicator = /* @__PURE__ */ React.forwardRef<
   HTMLDivElement,
   ConnectionQualityIndicatorProps
 >(function ConnectionQualityIndicator(props: ConnectionQualityIndicatorProps, ref) {

--- a/packages/react/src/components/participant/ParticipantAudioTile.tsx
+++ b/packages/react/src/components/participant/ParticipantAudioTile.tsx
@@ -21,42 +21,43 @@ import { isTrackReference } from '@livekit/components-core';
  * ```
  * @public
  */
-export const ParticipantAudioTile = React.forwardRef<HTMLDivElement, ParticipantTileProps>(
-  function ParticipantAudioTile({
-    children,
+export const ParticipantAudioTile = /* @__PURE__ */ React.forwardRef<
+  HTMLDivElement,
+  ParticipantTileProps
+>(function ParticipantAudioTile({
+  children,
+  disableSpeakingIndicator,
+  onParticipantClick,
+  trackRef,
+  ...htmlProps
+}: ParticipantTileProps) {
+  const trackReference = useEnsureTrackRef(trackRef);
+  const { elementProps } = useParticipantTile({
+    trackRef: trackReference,
+    htmlProps,
     disableSpeakingIndicator,
     onParticipantClick,
-    trackRef,
-    ...htmlProps
-  }: ParticipantTileProps) {
-    const trackReference = useEnsureTrackRef(trackRef);
-    const { elementProps } = useParticipantTile({
-      trackRef: trackReference,
-      htmlProps,
-      disableSpeakingIndicator,
-      onParticipantClick,
-    });
+  });
 
-    return (
-      <div style={{ position: 'relative' }} {...elementProps}>
-        <TrackRefContext.Provider value={trackReference}>
-          {children ?? (
-            <>
-              {isTrackReference(trackReference) && (
-                <AudioTrack trackRef={trackReference}></AudioTrack>
-              )}
-              <AudioVisualizer />
-              <div className="lk-participant-metadata">
-                <div className="lk-participant-metadata-item">
-                  <TrackMutedIndicator trackRef={trackReference}></TrackMutedIndicator>
-                  <ParticipantName />
-                </div>
-                <ConnectionQualityIndicator className="lk-participant-metadata-item" />
+  return (
+    <div style={{ position: 'relative' }} {...elementProps}>
+      <TrackRefContext.Provider value={trackReference}>
+        {children ?? (
+          <>
+            {isTrackReference(trackReference) && (
+              <AudioTrack trackRef={trackReference}></AudioTrack>
+            )}
+            <AudioVisualizer />
+            <div className="lk-participant-metadata">
+              <div className="lk-participant-metadata-item">
+                <TrackMutedIndicator trackRef={trackReference}></TrackMutedIndicator>
+                <ParticipantName />
               </div>
-            </>
-          )}
-        </TrackRefContext.Provider>
-      </div>
-    );
-  },
-);
+              <ConnectionQualityIndicator className="lk-participant-metadata-item" />
+            </div>
+          </>
+        )}
+      </TrackRefContext.Provider>
+    </div>
+  );
+});

--- a/packages/react/src/components/participant/ParticipantAudioTile.tsx
+++ b/packages/react/src/components/participant/ParticipantAudioTile.tsx
@@ -24,13 +24,16 @@ import { isTrackReference } from '@livekit/components-core';
 export const ParticipantAudioTile = /* @__PURE__ */ React.forwardRef<
   HTMLDivElement,
   ParticipantTileProps
->(function ParticipantAudioTile({
-  children,
-  disableSpeakingIndicator,
-  onParticipantClick,
-  trackRef,
-  ...htmlProps
-}: ParticipantTileProps) {
+>(function ParticipantAudioTile(
+  {
+    children,
+    disableSpeakingIndicator,
+    onParticipantClick,
+    trackRef,
+    ...htmlProps
+  }: ParticipantTileProps,
+  ref,
+) {
   const trackReference = useEnsureTrackRef(trackRef);
   const { elementProps } = useParticipantTile({
     trackRef: trackReference,
@@ -40,7 +43,7 @@ export const ParticipantAudioTile = /* @__PURE__ */ React.forwardRef<
   });
 
   return (
-    <div style={{ position: 'relative' }} {...elementProps}>
+    <div ref={ref} style={{ position: 'relative' }} {...elementProps}>
       <TrackRefContext.Provider value={trackReference}>
         {children ?? (
           <>

--- a/packages/react/src/components/participant/ParticipantAudioTile.tsx
+++ b/packages/react/src/components/participant/ParticipantAudioTile.tsx
@@ -21,40 +21,42 @@ import { isTrackReference } from '@livekit/components-core';
  * ```
  * @public
  */
-export function ParticipantAudioTile({
-  children,
-  disableSpeakingIndicator,
-  onParticipantClick,
-  trackRef,
-  ...htmlProps
-}: ParticipantTileProps) {
-  const trackReference = useEnsureTrackRef(trackRef);
-  const { elementProps } = useParticipantTile({
-    trackRef: trackReference,
-    htmlProps,
+export const ParticipantAudioTile = React.forwardRef<HTMLDivElement, ParticipantTileProps>(
+  function ParticipantAudioTile({
+    children,
     disableSpeakingIndicator,
     onParticipantClick,
-  });
+    trackRef,
+    ...htmlProps
+  }: ParticipantTileProps) {
+    const trackReference = useEnsureTrackRef(trackRef);
+    const { elementProps } = useParticipantTile({
+      trackRef: trackReference,
+      htmlProps,
+      disableSpeakingIndicator,
+      onParticipantClick,
+    });
 
-  return (
-    <div style={{ position: 'relative' }} {...elementProps}>
-      <TrackRefContext.Provider value={trackReference}>
-        {children ?? (
-          <>
-            {isTrackReference(trackReference) && (
-              <AudioTrack trackRef={trackReference}></AudioTrack>
-            )}
-            <AudioVisualizer />
-            <div className="lk-participant-metadata">
-              <div className="lk-participant-metadata-item">
-                <TrackMutedIndicator trackRef={trackReference}></TrackMutedIndicator>
-                <ParticipantName />
+    return (
+      <div style={{ position: 'relative' }} {...elementProps}>
+        <TrackRefContext.Provider value={trackReference}>
+          {children ?? (
+            <>
+              {isTrackReference(trackReference) && (
+                <AudioTrack trackRef={trackReference}></AudioTrack>
+              )}
+              <AudioVisualizer />
+              <div className="lk-participant-metadata">
+                <div className="lk-participant-metadata-item">
+                  <TrackMutedIndicator trackRef={trackReference}></TrackMutedIndicator>
+                  <ParticipantName />
+                </div>
+                <ConnectionQualityIndicator className="lk-participant-metadata-item" />
               </div>
-              <ConnectionQualityIndicator className="lk-participant-metadata-item" />
-            </div>
-          </>
-        )}
-      </TrackRefContext.Provider>
-    </div>
-  );
-}
+            </>
+          )}
+        </TrackRefContext.Provider>
+      </div>
+    );
+  },
+);

--- a/packages/react/src/components/participant/ParticipantName.tsx
+++ b/packages/react/src/components/participant/ParticipantName.tsx
@@ -20,29 +20,30 @@ export interface ParticipantNameProps
  * ```
  * @public
  */
-export const ParticipantName = React.forwardRef<HTMLSpanElement, ParticipantNameProps>(
-  function ParticipantName({ participant, ...props }: ParticipantNameProps, ref) {
-    const p = useEnsureParticipant(participant);
+export const ParticipantName = /* @__PURE__ */ React.forwardRef<
+  HTMLSpanElement,
+  ParticipantNameProps
+>(function ParticipantName({ participant, ...props }: ParticipantNameProps, ref) {
+  const p = useEnsureParticipant(participant);
 
-    const { className, infoObserver } = React.useMemo(() => {
-      return setupParticipantName(p);
-    }, [p]);
+  const { className, infoObserver } = React.useMemo(() => {
+    return setupParticipantName(p);
+  }, [p]);
 
-    const { identity, name } = useObservableState(infoObserver, {
-      name: p.name,
-      identity: p.identity,
-      metadata: p.metadata,
-    });
+  const { identity, name } = useObservableState(infoObserver, {
+    name: p.name,
+    identity: p.identity,
+    metadata: p.metadata,
+  });
 
-    const mergedProps = React.useMemo(() => {
-      return mergeProps(props, { className, 'data-lk-participant-name': name });
-    }, [props, className, name]);
+  const mergedProps = React.useMemo(() => {
+    return mergeProps(props, { className, 'data-lk-participant-name': name });
+  }, [props, className, name]);
 
-    return (
-      <span ref={ref} {...mergedProps}>
-        {name !== '' ? name : identity}
-        {props.children}
-      </span>
-    );
-  },
-);
+  return (
+    <span ref={ref} {...mergedProps}>
+      {name !== '' ? name : identity}
+      {props.children}
+    </span>
+  );
+});

--- a/packages/react/src/components/participant/ParticipantName.tsx
+++ b/packages/react/src/components/participant/ParticipantName.tsx
@@ -20,27 +20,29 @@ export interface ParticipantNameProps
  * ```
  * @public
  */
-export function ParticipantName({ participant, ...props }: ParticipantNameProps) {
-  const p = useEnsureParticipant(participant);
+export const ParticipantName = React.forwardRef<HTMLSpanElement, ParticipantNameProps>(
+  function ParticipantName({ participant, ...props }: ParticipantNameProps, ref) {
+    const p = useEnsureParticipant(participant);
 
-  const { className, infoObserver } = React.useMemo(() => {
-    return setupParticipantName(p);
-  }, [p]);
+    const { className, infoObserver } = React.useMemo(() => {
+      return setupParticipantName(p);
+    }, [p]);
 
-  const { identity, name } = useObservableState(infoObserver, {
-    name: p.name,
-    identity: p.identity,
-    metadata: p.metadata,
-  });
+    const { identity, name } = useObservableState(infoObserver, {
+      name: p.name,
+      identity: p.identity,
+      metadata: p.metadata,
+    });
 
-  const mergedProps = React.useMemo(() => {
-    return mergeProps(props, { className, 'data-lk-participant-name': name });
-  }, [props, className, name]);
+    const mergedProps = React.useMemo(() => {
+      return mergeProps(props, { className, 'data-lk-participant-name': name });
+    }, [props, className, name]);
 
-  return (
-    <span {...mergedProps}>
-      {name !== '' ? name : identity}
-      {props.children}
-    </span>
-  );
-}
+    return (
+      <span ref={ref} {...mergedProps}>
+        {name !== '' ? name : identity}
+        {props.children}
+      </span>
+    );
+  },
+);

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -90,100 +90,101 @@ export interface ParticipantTileProps extends React.HTMLAttributes<HTMLDivElemen
  * ```
  * @public
  */
-export const ParticipantTile = React.forwardRef<HTMLDivElement, ParticipantTileProps>(
-  function ParticipantTile(
-    {
-      trackRef,
-      children,
-      onParticipantClick,
-      disableSpeakingIndicator,
-      ...htmlProps
-    }: ParticipantTileProps,
-    ref,
-  ) {
-    const trackReference = useEnsureTrackRef(trackRef);
+export const ParticipantTile = /* @__PURE__ */ React.forwardRef<
+  HTMLDivElement,
+  ParticipantTileProps
+>(function ParticipantTile(
+  {
+    trackRef,
+    children,
+    onParticipantClick,
+    disableSpeakingIndicator,
+    ...htmlProps
+  }: ParticipantTileProps,
+  ref,
+) {
+  const trackReference = useEnsureTrackRef(trackRef);
 
-    const { elementProps } = useParticipantTile<HTMLDivElement>({
-      htmlProps,
-      disableSpeakingIndicator,
-      onParticipantClick,
-      trackRef: trackReference,
-    });
-    const isEncrypted = useIsEncrypted(trackReference.participant);
-    const layoutContext = useMaybeLayoutContext();
+  const { elementProps } = useParticipantTile<HTMLDivElement>({
+    htmlProps,
+    disableSpeakingIndicator,
+    onParticipantClick,
+    trackRef: trackReference,
+  });
+  const isEncrypted = useIsEncrypted(trackReference.participant);
+  const layoutContext = useMaybeLayoutContext();
 
-    const autoManageSubscription = useFeatureContext()?.autoSubscription;
+  const autoManageSubscription = useFeatureContext()?.autoSubscription;
 
-    const handleSubscribe = React.useCallback(
-      (subscribed: boolean) => {
-        if (
-          trackReference.source &&
-          !subscribed &&
-          layoutContext &&
-          layoutContext.pin.dispatch &&
-          isTrackReferencePinned(trackReference, layoutContext.pin.state)
-        ) {
-          layoutContext.pin.dispatch({ msg: 'clear_pin' });
-        }
-      },
-      [trackReference, layoutContext],
-    );
+  const handleSubscribe = React.useCallback(
+    (subscribed: boolean) => {
+      if (
+        trackReference.source &&
+        !subscribed &&
+        layoutContext &&
+        layoutContext.pin.dispatch &&
+        isTrackReferencePinned(trackReference, layoutContext.pin.state)
+      ) {
+        layoutContext.pin.dispatch({ msg: 'clear_pin' });
+      }
+    },
+    [trackReference, layoutContext],
+  );
 
-    return (
-      <div ref={ref} style={{ position: 'relative' }} {...elementProps}>
-        <TrackRefContextIfNeeded trackRef={trackReference}>
-          <ParticipantContextIfNeeded participant={trackReference.participant}>
-            {children ?? (
-              <>
-                {isTrackReference(trackReference) &&
-                (trackReference.publication?.kind === 'video' ||
-                  trackReference.source === Track.Source.Camera ||
-                  trackReference.source === Track.Source.ScreenShare) ? (
-                  <VideoTrack
+  return (
+    <div ref={ref} style={{ position: 'relative' }} {...elementProps}>
+      <TrackRefContextIfNeeded trackRef={trackReference}>
+        <ParticipantContextIfNeeded participant={trackReference.participant}>
+          {children ?? (
+            <>
+              {isTrackReference(trackReference) &&
+              (trackReference.publication?.kind === 'video' ||
+                trackReference.source === Track.Source.Camera ||
+                trackReference.source === Track.Source.ScreenShare) ? (
+                <VideoTrack
+                  trackRef={trackReference}
+                  onSubscriptionStatusChanged={handleSubscribe}
+                  manageSubscription={autoManageSubscription}
+                />
+              ) : (
+                isTrackReference(trackReference) && (
+                  <AudioTrack
                     trackRef={trackReference}
                     onSubscriptionStatusChanged={handleSubscribe}
-                    manageSubscription={autoManageSubscription}
                   />
-                ) : (
-                  isTrackReference(trackReference) && (
-                    <AudioTrack
-                      trackRef={trackReference}
-                      onSubscriptionStatusChanged={handleSubscribe}
-                    />
-                  )
-                )}
-                <div className="lk-participant-placeholder">
-                  <ParticipantPlaceholder />
+                )
+              )}
+              <div className="lk-participant-placeholder">
+                <ParticipantPlaceholder />
+              </div>
+              <div className="lk-participant-metadata">
+                <div className="lk-participant-metadata-item">
+                  {trackReference.source === Track.Source.Camera ? (
+                    <>
+                      {isEncrypted && <LockLockedIcon style={{ marginRight: '0.25rem' }} />}
+                      <TrackMutedIndicator
+                        trackRef={{
+                          participant: trackReference.participant,
+                          source: Track.Source.Microphone,
+                        }}
+                        show={'muted'}
+                      ></TrackMutedIndicator>
+                      <ParticipantName />
+                    </>
+                  ) : (
+                    <>
+                      <ScreenShareIcon style={{ marginRight: '0.25rem' }} />
+                      <ParticipantName>&apos;s screen</ParticipantName>
+                    </>
+                  )}
                 </div>
-                <div className="lk-participant-metadata">
-                  <div className="lk-participant-metadata-item">
-                    {trackReference.source === Track.Source.Camera ? (
-                      <>
-                        {isEncrypted && <LockLockedIcon style={{ marginRight: '0.25rem' }} />}
-                        <TrackMutedIndicator
-                          trackRef={{
-                            participant: trackReference.participant,
-                            source: Track.Source.Microphone,
-                          }}
-                          show={'muted'}
-                        ></TrackMutedIndicator>
-                        <ParticipantName />
-                      </>
-                    ) : (
-                      <>
-                        <ScreenShareIcon style={{ marginRight: '0.25rem' }} />
-                        <ParticipantName>&apos;s screen</ParticipantName>
-                      </>
-                    )}
-                  </div>
-                  <ConnectionQualityIndicator className="lk-participant-metadata-item" />
-                </div>
-              </>
-            )}
-            <FocusToggle trackRef={trackReference} />
-          </ParticipantContextIfNeeded>
-        </TrackRefContextIfNeeded>
-      </div>
-    );
-  },
-);
+                <ConnectionQualityIndicator className="lk-participant-metadata-item" />
+              </div>
+            </>
+          )}
+          <FocusToggle trackRef={trackReference} />
+        </ParticipantContextIfNeeded>
+      </TrackRefContextIfNeeded>
+    </div>
+  );
+});

--- a/packages/react/src/components/participant/ParticipantTile.tsx
+++ b/packages/react/src/components/participant/ParticipantTile.tsx
@@ -90,95 +90,100 @@ export interface ParticipantTileProps extends React.HTMLAttributes<HTMLDivElemen
  * ```
  * @public
  */
-export function ParticipantTile({
-  trackRef,
-  children,
-  onParticipantClick,
-  disableSpeakingIndicator,
-  ...htmlProps
-}: ParticipantTileProps) {
-  const trackReference = useEnsureTrackRef(trackRef);
+export const ParticipantTile = React.forwardRef<HTMLDivElement, ParticipantTileProps>(
+  function ParticipantTile(
+    {
+      trackRef,
+      children,
+      onParticipantClick,
+      disableSpeakingIndicator,
+      ...htmlProps
+    }: ParticipantTileProps,
+    ref,
+  ) {
+    const trackReference = useEnsureTrackRef(trackRef);
 
-  const { elementProps } = useParticipantTile<HTMLDivElement>({
-    htmlProps,
-    disableSpeakingIndicator,
-    onParticipantClick,
-    trackRef: trackReference,
-  });
-  const isEncrypted = useIsEncrypted(trackReference.participant);
-  const layoutContext = useMaybeLayoutContext();
+    const { elementProps } = useParticipantTile<HTMLDivElement>({
+      htmlProps,
+      disableSpeakingIndicator,
+      onParticipantClick,
+      trackRef: trackReference,
+    });
+    const isEncrypted = useIsEncrypted(trackReference.participant);
+    const layoutContext = useMaybeLayoutContext();
 
-  const autoManageSubscription = useFeatureContext()?.autoSubscription;
+    const autoManageSubscription = useFeatureContext()?.autoSubscription;
 
-  const handleSubscribe = React.useCallback(
-    (subscribed: boolean) => {
-      if (
-        trackReference.source &&
-        !subscribed &&
-        layoutContext &&
-        layoutContext.pin.dispatch &&
-        isTrackReferencePinned(trackReference, layoutContext.pin.state)
-      ) {
-        layoutContext.pin.dispatch({ msg: 'clear_pin' });
-      }
-    },
-    [trackReference, layoutContext],
-  );
+    const handleSubscribe = React.useCallback(
+      (subscribed: boolean) => {
+        if (
+          trackReference.source &&
+          !subscribed &&
+          layoutContext &&
+          layoutContext.pin.dispatch &&
+          isTrackReferencePinned(trackReference, layoutContext.pin.state)
+        ) {
+          layoutContext.pin.dispatch({ msg: 'clear_pin' });
+        }
+      },
+      [trackReference, layoutContext],
+    );
 
-  return (
-    <div style={{ position: 'relative' }} {...elementProps}>
-      <TrackRefContextIfNeeded trackRef={trackReference}>
-        <ParticipantContextIfNeeded participant={trackReference.participant}>
-          {children ?? (
-            <>
-              {isTrackReference(trackReference) &&
-              (trackReference.publication?.kind === 'video' ||
-                trackReference.source === Track.Source.Camera ||
-                trackReference.source === Track.Source.ScreenShare) ? (
-                <VideoTrack
-                  trackRef={trackReference}
-                  onSubscriptionStatusChanged={handleSubscribe}
-                  manageSubscription={autoManageSubscription}
-                />
-              ) : (
-                isTrackReference(trackReference) && (
-                  <AudioTrack
+    return (
+      <div ref={ref} style={{ position: 'relative' }} {...elementProps}>
+        <TrackRefContextIfNeeded trackRef={trackReference}>
+          <ParticipantContextIfNeeded participant={trackReference.participant}>
+            {children ?? (
+              <>
+                {isTrackReference(trackReference) &&
+                (trackReference.publication?.kind === 'video' ||
+                  trackReference.source === Track.Source.Camera ||
+                  trackReference.source === Track.Source.ScreenShare) ? (
+                  <VideoTrack
                     trackRef={trackReference}
                     onSubscriptionStatusChanged={handleSubscribe}
+                    manageSubscription={autoManageSubscription}
                   />
-                )
-              )}
-              <div className="lk-participant-placeholder">
-                <ParticipantPlaceholder />
-              </div>
-              <div className="lk-participant-metadata">
-                <div className="lk-participant-metadata-item">
-                  {trackReference.source === Track.Source.Camera ? (
-                    <>
-                      {isEncrypted && <LockLockedIcon style={{ marginRight: '0.25rem' }} />}
-                      <TrackMutedIndicator
-                        trackRef={{
-                          participant: trackReference.participant,
-                          source: Track.Source.Microphone,
-                        }}
-                        show={'muted'}
-                      ></TrackMutedIndicator>
-                      <ParticipantName />
-                    </>
-                  ) : (
-                    <>
-                      <ScreenShareIcon style={{ marginRight: '0.25rem' }} />
-                      <ParticipantName>&apos;s screen</ParticipantName>
-                    </>
-                  )}
+                ) : (
+                  isTrackReference(trackReference) && (
+                    <AudioTrack
+                      trackRef={trackReference}
+                      onSubscriptionStatusChanged={handleSubscribe}
+                    />
+                  )
+                )}
+                <div className="lk-participant-placeholder">
+                  <ParticipantPlaceholder />
                 </div>
-                <ConnectionQualityIndicator className="lk-participant-metadata-item" />
-              </div>
-            </>
-          )}
-          <FocusToggle trackRef={trackReference} />
-        </ParticipantContextIfNeeded>
-      </TrackRefContextIfNeeded>
-    </div>
-  );
-}
+                <div className="lk-participant-metadata">
+                  <div className="lk-participant-metadata-item">
+                    {trackReference.source === Track.Source.Camera ? (
+                      <>
+                        {isEncrypted && <LockLockedIcon style={{ marginRight: '0.25rem' }} />}
+                        <TrackMutedIndicator
+                          trackRef={{
+                            participant: trackReference.participant,
+                            source: Track.Source.Microphone,
+                          }}
+                          show={'muted'}
+                        ></TrackMutedIndicator>
+                        <ParticipantName />
+                      </>
+                    ) : (
+                      <>
+                        <ScreenShareIcon style={{ marginRight: '0.25rem' }} />
+                        <ParticipantName>&apos;s screen</ParticipantName>
+                      </>
+                    )}
+                  </div>
+                  <ConnectionQualityIndicator className="lk-participant-metadata-item" />
+                </div>
+              </>
+            )}
+            <FocusToggle trackRef={trackReference} />
+          </ParticipantContextIfNeeded>
+        </TrackRefContextIfNeeded>
+      </div>
+    );
+  },
+);

--- a/packages/react/src/components/participant/TrackMutedIndicator.tsx
+++ b/packages/react/src/components/participant/TrackMutedIndicator.tsx
@@ -21,32 +21,33 @@ export interface TrackMutedIndicatorProps extends React.HTMLAttributes<HTMLDivEl
  * ```
  * @public
  */
-export const TrackMutedIndicator = React.forwardRef<HTMLDivElement, TrackMutedIndicatorProps>(
-  function TrackMutedIndicator(
-    { trackRef, show = 'always', ...props }: TrackMutedIndicatorProps,
-    ref,
-  ) {
-    const { className, isMuted } = useTrackMutedIndicator(trackRef);
+export const TrackMutedIndicator = /* @__PURE__ */ React.forwardRef<
+  HTMLDivElement,
+  TrackMutedIndicatorProps
+>(function TrackMutedIndicator(
+  { trackRef, show = 'always', ...props }: TrackMutedIndicatorProps,
+  ref,
+) {
+  const { className, isMuted } = useTrackMutedIndicator(trackRef);
 
-    const showIndicator =
-      show === 'always' || (show === 'muted' && isMuted) || (show === 'unmuted' && !isMuted);
+  const showIndicator =
+    show === 'always' || (show === 'muted' && isMuted) || (show === 'unmuted' && !isMuted);
 
-    const htmlProps = React.useMemo(
-      () =>
-        mergeProps(props, {
-          className,
-        }),
-      [className, props],
-    );
+  const htmlProps = React.useMemo(
+    () =>
+      mergeProps(props, {
+        className,
+      }),
+    [className, props],
+  );
 
-    if (!showIndicator) {
-      return null;
-    }
+  if (!showIndicator) {
+    return null;
+  }
 
-    return (
-      <div ref={ref} {...htmlProps} data-lk-muted={isMuted}>
-        {props.children ?? getSourceIcon(trackRef.source, !isMuted)}
-      </div>
-    );
-  },
-);
+  return (
+    <div ref={ref} {...htmlProps} data-lk-muted={isMuted}>
+      {props.children ?? getSourceIcon(trackRef.source, !isMuted)}
+    </div>
+  );
+});

--- a/packages/react/src/components/participant/TrackMutedIndicator.tsx
+++ b/packages/react/src/components/participant/TrackMutedIndicator.tsx
@@ -21,31 +21,32 @@ export interface TrackMutedIndicatorProps extends React.HTMLAttributes<HTMLDivEl
  * ```
  * @public
  */
-export function TrackMutedIndicator({
-  trackRef,
-  show = 'always',
-  ...props
-}: TrackMutedIndicatorProps) {
-  const { className, isMuted } = useTrackMutedIndicator(trackRef);
+export const TrackMutedIndicator = React.forwardRef<HTMLDivElement, TrackMutedIndicatorProps>(
+  function TrackMutedIndicator(
+    { trackRef, show = 'always', ...props }: TrackMutedIndicatorProps,
+    ref,
+  ) {
+    const { className, isMuted } = useTrackMutedIndicator(trackRef);
 
-  const showIndicator =
-    show === 'always' || (show === 'muted' && isMuted) || (show === 'unmuted' && !isMuted);
+    const showIndicator =
+      show === 'always' || (show === 'muted' && isMuted) || (show === 'unmuted' && !isMuted);
 
-  const htmlProps = React.useMemo(
-    () =>
-      mergeProps(props, {
-        className,
-      }),
-    [className, props],
-  );
+    const htmlProps = React.useMemo(
+      () =>
+        mergeProps(props, {
+          className,
+        }),
+      [className, props],
+    );
 
-  if (!showIndicator) {
-    return null;
-  }
+    if (!showIndicator) {
+      return null;
+    }
 
-  return (
-    <div {...htmlProps} data-lk-muted={isMuted}>
-      {props.children ?? getSourceIcon(trackRef.source, !isMuted)}
-    </div>
-  );
-}
+    return (
+      <div ref={ref} {...htmlProps} data-lk-muted={isMuted}>
+        {props.children ?? getSourceIcon(trackRef.source, !isMuted)}
+      </div>
+    );
+  },
+);

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -4,6 +4,7 @@ import { useMediaTrackBySourceOrName } from '../../hooks/useMediaTrackBySourceOr
 import type { ParticipantClickEvent, TrackReference } from '@livekit/components-core';
 import { useEnsureTrackRef } from '../../context';
 import * as useHooks from 'usehooks-ts';
+import { useForwardedRef } from '../../utils';
 
 /** @public */
 export interface VideoTrackProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
@@ -25,14 +26,17 @@ export interface VideoTrackProps extends React.VideoHTMLAttributes<HTMLVideoElem
  * @see {@link @livekit/components-react#ParticipantTile | ParticipantTile}
  * @public
  */
-export function VideoTrack({
-  onTrackClick,
-  onClick,
-  onSubscriptionStatusChanged,
-  trackRef,
-  manageSubscription,
-  ...props
-}: VideoTrackProps) {
+export const VideoTrack = React.forwardRef<HTMLVideoElement, VideoTrackProps>(function VideoTrack(
+  {
+    onTrackClick,
+    onClick,
+    onSubscriptionStatusChanged,
+    trackRef,
+    manageSubscription,
+    ...props
+  }: VideoTrackProps,
+  ref,
+) {
   const trackReference = useEnsureTrackRef(trackRef);
 
   const mediaEl = React.useRef<HTMLVideoElement>(null);
@@ -62,12 +66,14 @@ export function VideoTrack({
     }
   }, [intersectionEntry, trackReference, manageSubscription]);
 
+  const mediaElRef = useForwardedRef(ref);
+
   const {
     elementProps,
     publication: pub,
     isSubscribed,
   } = useMediaTrackBySourceOrName(trackReference, {
-    element: mediaEl,
+    element: mediaElRef,
     props,
   });
 
@@ -80,5 +86,5 @@ export function VideoTrack({
     onTrackClick?.({ participant: trackReference?.participant, track: pub });
   };
 
-  return <video ref={mediaEl} {...elementProps} muted={true} onClick={clickHandler}></video>;
-}
+  return <video ref={ref} {...elementProps} muted={true} onClick={clickHandler}></video>;
+});

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -26,65 +26,67 @@ export interface VideoTrackProps extends React.VideoHTMLAttributes<HTMLVideoElem
  * @see {@link @livekit/components-react#ParticipantTile | ParticipantTile}
  * @public
  */
-export const VideoTrack = React.forwardRef<HTMLVideoElement, VideoTrackProps>(function VideoTrack(
-  {
-    onTrackClick,
-    onClick,
-    onSubscriptionStatusChanged,
-    trackRef,
-    manageSubscription,
-    ...props
-  }: VideoTrackProps,
-  ref,
-) {
-  const trackReference = useEnsureTrackRef(trackRef);
+export const VideoTrack = /* @__PURE__ */ React.forwardRef<HTMLVideoElement, VideoTrackProps>(
+  function VideoTrack(
+    {
+      onTrackClick,
+      onClick,
+      onSubscriptionStatusChanged,
+      trackRef,
+      manageSubscription,
+      ...props
+    }: VideoTrackProps,
+    ref,
+  ) {
+    const trackReference = useEnsureTrackRef(trackRef);
 
-  const mediaEl = React.useRef<HTMLVideoElement>(null);
+    const mediaEl = React.useRef<HTMLVideoElement>(null);
 
-  const intersectionEntry = useHooks.useIntersectionObserver(mediaEl, {});
+    const intersectionEntry = useHooks.useIntersectionObserver(mediaEl, {});
 
-  const debouncedIntersectionEntry = useHooks.useDebounce(intersectionEntry, 3000);
+    const debouncedIntersectionEntry = useHooks.useDebounce(intersectionEntry, 3000);
 
-  React.useEffect(() => {
-    if (
-      manageSubscription &&
-      trackReference.publication instanceof RemoteTrackPublication &&
-      debouncedIntersectionEntry?.isIntersecting === false &&
-      intersectionEntry?.isIntersecting === false
-    ) {
-      trackReference.publication.setSubscribed(false);
-    }
-  }, [debouncedIntersectionEntry, trackReference, manageSubscription]);
+    React.useEffect(() => {
+      if (
+        manageSubscription &&
+        trackReference.publication instanceof RemoteTrackPublication &&
+        debouncedIntersectionEntry?.isIntersecting === false &&
+        intersectionEntry?.isIntersecting === false
+      ) {
+        trackReference.publication.setSubscribed(false);
+      }
+    }, [debouncedIntersectionEntry, trackReference, manageSubscription]);
 
-  React.useEffect(() => {
-    if (
-      manageSubscription &&
-      trackReference.publication instanceof RemoteTrackPublication &&
-      intersectionEntry?.isIntersecting === true
-    ) {
-      trackReference.publication.setSubscribed(true);
-    }
-  }, [intersectionEntry, trackReference, manageSubscription]);
+    React.useEffect(() => {
+      if (
+        manageSubscription &&
+        trackReference.publication instanceof RemoteTrackPublication &&
+        intersectionEntry?.isIntersecting === true
+      ) {
+        trackReference.publication.setSubscribed(true);
+      }
+    }, [intersectionEntry, trackReference, manageSubscription]);
 
-  const mediaElRef = useForwardedRef(ref);
+    const mediaElRef = useForwardedRef(ref);
 
-  const {
-    elementProps,
-    publication: pub,
-    isSubscribed,
-  } = useMediaTrackBySourceOrName(trackReference, {
-    element: mediaElRef,
-    props,
-  });
+    const {
+      elementProps,
+      publication: pub,
+      isSubscribed,
+    } = useMediaTrackBySourceOrName(trackReference, {
+      element: mediaElRef,
+      props,
+    });
 
-  React.useEffect(() => {
-    onSubscriptionStatusChanged?.(!!isSubscribed);
-  }, [isSubscribed, onSubscriptionStatusChanged]);
+    React.useEffect(() => {
+      onSubscriptionStatusChanged?.(!!isSubscribed);
+    }, [isSubscribed, onSubscriptionStatusChanged]);
 
-  const clickHandler = (evt: React.MouseEvent<HTMLVideoElement, MouseEvent>) => {
-    onClick?.(evt);
-    onTrackClick?.({ participant: trackReference?.participant, track: pub });
-  };
+    const clickHandler = (evt: React.MouseEvent<HTMLVideoElement, MouseEvent>) => {
+      onClick?.(evt);
+      onTrackClick?.({ participant: trackReference?.participant, track: pub });
+    };
 
-  return <video ref={ref} {...elementProps} muted={true} onClick={clickHandler}></video>;
-});
+    return <video ref={ref} {...elementProps} muted={true} onClick={clickHandler}></video>;
+  },
+);

--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -6,7 +6,7 @@ import { mergeProps } from '../utils';
 
 /** @public */
 export interface UseMediaTrackOptions {
-  element?: React.RefObject<HTMLMediaElement>;
+  element?: React.RefObject<HTMLMediaElement> | null;
   props?: React.HTMLAttributes<HTMLVideoElement | HTMLAudioElement>;
 }
 

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -53,3 +53,21 @@ export function warnAboutMissingStyles(el?: HTMLElement) {
     }
   }
 }
+
+/**
+ * @internal
+ */
+export function useForwardedRef<T extends HTMLElement>(ref: React.ForwardedRef<T>) {
+  const innerRef = React.useRef<T>(null);
+
+  React.useEffect(() => {
+    if (!ref) return;
+    if (typeof ref === 'function') {
+      ref(innerRef.current);
+    } else {
+      ref.current = innerRef.current;
+    }
+  });
+
+  return innerRef;
+}


### PR DESCRIPTION
not being able to reference the underlying elements has been a long standing caveat with the react components.
This PR adds the ability to reference e.g. the underlying HTMLVideoElement of the `VideoTrack` component via

```ts
const videoEl = React.createRef(null);

return <VideoTrack ref={videoEl} ... />
```