### PR TITLE
Improve track acquiring and handling in usePreviewTracks

### DIFF
--- a/.changeset/many-geese-jump.md
+++ b/.changeset/many-geese-jump.md
@@ -1,6 +1,6 @@
 ---
-"@livekit/components-core": patch
-"@livekit/components-react": patch
+"@livekit/components-core": minor
+"@livekit/components-react": minor
 ---
 
 Require livekit-client ^2.1.0 peer dependency

--- a/.changeset/many-geese-jump.md
+++ b/.changeset/many-geese-jump.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+Require livekit-client ^2.1.0 peer dependency

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@livekit/components-react": "workspace:*",
     "@livekit/components-styles": "workspace:*",
-    "livekit-client": "^2.0.10",
+    "livekit-client": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@livekit/components-react": "workspace:*",
     "@livekit/components-styles": "workspace:*",
-    "livekit-client": "^2.0.10",
+    "livekit-client": "^2.1.0",
     "livekit-server-sdk": "^1.2.7",
     "next": "^12.3.4",
     "react": "^18.2.0",

--- a/examples/nextjs/pages/prejoin.tsx
+++ b/examples/nextjs/pages/prejoin.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import { PreJoin, setLogLevel } from '@livekit/components-react';
 import type { NextPage } from 'next';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "rxjs": "7.8.1"
   },
   "peerDependencies": {
-    "livekit-client": "^2.0.10",
+    "livekit-client": "^2.1.0",
     "@livekit/protocol": "^1.12.0",
     "tslib": "^2.6.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,7 @@
     "usehooks-ts": "2.16.0"
   },
   "peerDependencies": {
-    "livekit-client": "^2.0.10",
+    "livekit-client": "^2.1.0",
     "@livekit/protocol": "^1.12.0",
     "react": ">=18",
     "react-dom": ">=18",

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -11,6 +11,7 @@ import {
   facingModeFromLocalTrack,
   Track,
   VideoPresets,
+  Mutex,
 } from 'livekit-client';
 import * as React from 'react';
 import { MediaDeviceMenu } from './MediaDeviceMenu';
@@ -21,7 +22,6 @@ import { ParticipantPlaceholder } from '../assets/images';
 import { useMediaDevices, usePersistentUserChoices } from '../hooks';
 import { useWarnAboutMissingStyles } from '../hooks/useWarnAboutMissingStyles';
 import { defaultUserChoices } from '@livekit/components-core';
-import { Mutex } from '../utils';
 
 /**
  * Props for the PreJoin component.

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -62,12 +62,13 @@ export function usePreviewTracks(
   const trackLock = new Mutex();
 
   React.useEffect(() => {
-    let trackPromise: Promise<LocalTrack[]> | undefined = undefined;
     let needsCleanup = false;
     trackLock.lock().then((unlock) => {
+      tracks?.forEach((track) => {
+        track.stop();
+      });
       if (options.audio || options.video) {
-        trackPromise = createLocalTracks(options);
-        trackPromise
+        createLocalTracks(options)
           .then((tracks) => {
             if (needsCleanup) {
               tracks.forEach((tr) => tr.stop());

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -59,7 +59,7 @@ export function usePreviewTracks(
 ) {
   const [tracks, setTracks] = React.useState<LocalTrack[]>();
 
-  const trackLock = new Mutex();
+  const trackLock = React.useMemo(() => new Mutex(), []);
 
   React.useEffect(() => {
     let needsCleanup = false;

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -71,3 +71,38 @@ export function useForwardedRef<T extends HTMLElement>(ref: React.ForwardedRef<T
 
   return innerRef;
 }
+
+export class Mutex {
+  private _locking: Promise<void>;
+
+  private _locks: number;
+
+  constructor() {
+    this._locking = Promise.resolve();
+    this._locks = 0;
+  }
+
+  isLocked() {
+    return this._locks > 0;
+  }
+
+  lock() {
+    this._locks += 1;
+
+    let unlockNext: () => void;
+
+    const willLock = new Promise<void>(
+      (resolve) =>
+        (unlockNext = () => {
+          this._locks -= 1;
+          resolve();
+        }),
+    );
+
+    const willUnlock = this._locking.then(() => unlockNext);
+
+    this._locking = this._locking.then(() => willLock);
+
+    return willUnlock;
+  }
+}

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -71,38 +71,3 @@ export function useForwardedRef<T extends HTMLElement>(ref: React.ForwardedRef<T
 
   return innerRef;
 }
-
-export class Mutex {
-  private _locking: Promise<void>;
-
-  private _locks: number;
-
-  constructor() {
-    this._locking = Promise.resolve();
-    this._locks = 0;
-  }
-
-  isLocked() {
-    return this._locks > 0;
-  }
-
-  lock() {
-    this._locks += 1;
-
-    let unlockNext: () => void;
-
-    const willLock = new Promise<void>(
-      (resolve) =>
-        (unlockNext = () => {
-          this._locks -= 1;
-          resolve();
-        }),
-    );
-
-    const willUnlock = this._locking.then(() => unlockNext);
-
-    this._locking = this._locking.then(() => willLock);
-
-    return willUnlock;
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/styles
       livekit-client:
-        specifier: ^2.0.10
-        version: 2.0.10
+        specifier: ^2.1.0
+        version: 2.1.0
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -115,8 +115,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/styles
       livekit-client:
-        specifier: ^2.0.10
-        version: 2.0.10
+        specifier: ^2.1.0
+        version: 2.1.0
       livekit-server-sdk:
         specifier: ^1.2.7
         version: 1.2.7
@@ -161,8 +161,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0
       livekit-client:
-        specifier: ^2.0.10
-        version: 2.0.10
+        specifier: ^2.1.0
+        version: 2.1.0
       loglevel:
         specifier: 1.9.1
         version: 1.9.1
@@ -216,8 +216,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       livekit-client:
-        specifier: ^2.0.10
-        version: 2.0.10
+        specifier: ^2.1.0
+        version: 2.1.0
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -3037,14 +3037,14 @@ packages:
       - encoding
     dev: true
 
-  /@livekit/protocol@1.10.4:
-    resolution: {integrity: sha512-7Occ6l5VqjsKsUjpLeVJXJkip4ce22iG9QR/haOkrDXYwGSY+TwCA4ubbJ81aQBt2z0kHVZuaQWdzJSDLI+Kag==}
+  /@livekit/protocol@1.12.0:
+    resolution: {integrity: sha512-AMUWxna4AO/biPaKiu45JYYVHi7sc+sK6pkeNNpqkzL85+eeHkNhkFfENn9YbQKQsVWABkOmcL8p4ZbUjxZkeQ==}
     dependencies:
       '@bufbuild/protobuf': 1.7.2
     dev: false
 
-  /@livekit/protocol@1.12.0:
-    resolution: {integrity: sha512-AMUWxna4AO/biPaKiu45JYYVHi7sc+sK6pkeNNpqkzL85+eeHkNhkFfENn9YbQKQsVWABkOmcL8p4ZbUjxZkeQ==}
+  /@livekit/protocol@1.13.0:
+    resolution: {integrity: sha512-M3U36VgRfb0VutWG6pnozXusL+mkYstbCctTLUyCIyye36Ztv1wA9zYpyYvz7VnsgmCn+g/g0eB2rnAkTVwcnA==}
     dependencies:
       '@bufbuild/protobuf': 1.7.2
     dev: false
@@ -10891,10 +10891,10 @@ packages:
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  /livekit-client@2.0.10:
-    resolution: {integrity: sha512-V+EyTEd3kM1Vl9/TsE3nc7PEnJI2t21ZV0/nkqhGThszym1SJzmc61hKjmCJBnR199pskUxSjrwzMl9HrPQ85A==}
+  /livekit-client@2.1.0:
+    resolution: {integrity: sha512-nJwfRKw1Pafd2napk66l30dlBjsv1VZ+na3mzNezcAFAYT2lQ4Gch57TdbMBDYo+QfrZ98s+kuZzsFhBwM5rqw==}
     dependencies:
-      '@livekit/protocol': 1.10.4
+      '@livekit/protocol': 1.13.0
       events: 3.3.0
       loglevel: 1.9.1
       sdp-transform: 2.14.2


### PR DESCRIPTION
This PR tries to mitigate `NotReadableErrors` by making sure we only ever perform one `createLocalTracks` request at a time. 
Users reported seeing errors on Windows when trying to acquire specific cameras, so this is an attempt to fix that. 

depends on https://github.com/livekit/client-sdk-js/pull/1110 being released