### PR TITLE
Fix audio playing issue

### DIFF
--- a/.changeset/lemon-snakes-pull.md
+++ b/.changeset/lemon-snakes-pull.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix audio playing issue by using imperative handle

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -44,6 +44,7 @@ export const AudioTrack = /* @__PURE__ */ React.forwardRef<HTMLAudioElement, Aud
     const trackReference = useEnsureTrackRef(trackRef);
 
     const mediaEl = React.useRef<HTMLAudioElement>(null);
+    React.useImperativeHandle(ref, () => mediaEl.current as HTMLAudioElement);
 
     const {
       elementProps,
@@ -81,6 +82,6 @@ export const AudioTrack = /* @__PURE__ */ React.forwardRef<HTMLAudioElement, Aud
       }
     }, [props.muted, pub, track]);
 
-    return <audio ref={ref} {...elementProps} />;
+    return <audio ref={mediaEl} {...elementProps} />;
   },
 );


### PR DESCRIPTION
It appears that there is a bug where the audio from `<AudioTrack>` is not playing during `<VideoConference>` in v2.1.0 and v2.1.1.
This likely involves the same issue as with the `<VideoTrack>` described in https://github.com/livekit/components-js/pull/831, where the refs aren't being passed correctly.
I have made the necessary corrections on the AudioTrack side.

Related slack threads: https://livekit-users.slack.com/archives/C01KVTJH6BX/p1713514083336509