### PR TITLE
Fix releasing of local tracks in prejoin

### DIFF
--- a/.changeset/shaggy-actors-perform.md
+++ b/.changeset/shaggy-actors-perform.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix releasing of local tracks in prejoin

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -66,9 +66,6 @@ export function usePreviewTracks(
     let localTracks: Array<LocalTrack> = [];
     trackLock.lock().then(async (unlock) => {
       try {
-        // tracks?.forEach((track) => {
-        //   track.stop();
-        // });
         if (options.audio || options.video) {
           localTracks = await createLocalTracks(options);
 

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -63,13 +63,14 @@ export function usePreviewTracks(
 
   React.useEffect(() => {
     let needsCleanup = false;
+    let localTracks: Array<LocalTrack> = [];
     trackLock.lock().then(async (unlock) => {
       try {
-        tracks?.forEach((track) => {
-          track.stop();
-        });
+        // tracks?.forEach((track) => {
+        //   track.stop();
+        // });
         if (options.audio || options.video) {
-          const localTracks = await createLocalTracks(options);
+          localTracks = await createLocalTracks(options);
 
           if (needsCleanup) {
             localTracks.forEach((tr) => tr.stop());
@@ -90,11 +91,11 @@ export function usePreviewTracks(
 
     return () => {
       needsCleanup = true;
-      tracks?.forEach((track) => {
+      localTracks.forEach((track) => {
         track.stop();
       });
     };
-  }, [JSON.stringify(options)]);
+  }, [JSON.stringify(options), onError, trackLock]);
 
   return tracks;
 }


### PR DESCRIPTION
more subtleties when navigating away from prejoin. These changes make sure that the locally scoped variable is used to stop previously created tracks within the useEffect. 
Tested both against meet and the example and seems to consistently work now