### PR TITLE
Don't auto subscribe to all audio tracks automatically in RoomAudioRenderer

### DIFF
--- a/.changeset/heavy-moose-cross.md
+++ b/.changeset/heavy-moose-cross.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": minor
+---
+
+Don't auto subscribe to all audio tracks automatically in RoomAudioRenderer

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -1,5 +1,4 @@
 import { getTrackReferenceId, isLocal } from '@livekit/components-core';
-import type { RemoteTrackPublication } from 'livekit-client';
 import { Track } from 'livekit-client';
 import * as React from 'react';
 import { useTracks } from '../hooks';
@@ -35,15 +34,9 @@ export function RoomAudioRenderer({ volume, muted }: RoomAudioRendererProps) {
     [Track.Source.Microphone, Track.Source.ScreenShareAudio, Track.Source.Unknown],
     {
       updateOnlyOn: [],
-      onlySubscribed: false,
+      onlySubscribed: true,
     },
   ).filter((ref) => !isLocal(ref.participant) && ref.publication.kind === Track.Kind.Audio);
-
-  React.useEffect(() => {
-    for (const track of tracks) {
-      (track.publication as RemoteTrackPublication).setSubscribed(true);
-    }
-  }, [tracks]);
 
   return (
     <div style={{ display: 'none' }}>

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -74,7 +74,12 @@ export function useTracks<T extends SourcesArray = Track.Source[]>(
       setParticipants(participants);
     });
     return () => subscription.unsubscribe();
-  }, [room, JSON.stringify(options), JSON.stringify(sources)]);
+  }, [
+    room,
+    JSON.stringify(options.onlySubscribed),
+    JSON.stringify(options.updateOnlyOn),
+    JSON.stringify(sources),
+  ]);
 
   const maybeTrackReferences = React.useMemo(() => {
     if (isSourcesWithOptions(sources)) {

--- a/packages/react/src/hooks/useTracks.ts
+++ b/packages/react/src/hooks/useTracks.ts
@@ -74,7 +74,7 @@ export function useTracks<T extends SourcesArray = Track.Source[]>(
       setParticipants(participants);
     });
     return () => subscription.unsubscribe();
-  }, [room, JSON.stringify(options.updateOnlyOn), JSON.stringify(sources)]);
+  }, [room, JSON.stringify(options), JSON.stringify(sources)]);
 
   const maybeTrackReferences = React.useMemo(() => {
     if (isSourcesWithOptions(sources)) {


### PR DESCRIPTION
for users with `autoSubscribe: false` automatically subscribing to all audio publications is rather unexpected