### PR TITLE
Fix duplicated incoming audio when using AudioTrack renderer and its muted property

### DIFF
--- a/.changeset/olive-zebras-shop.md
+++ b/.changeset/olive-zebras-shop.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix duplicated incoming audio when using AudioTrack renderer and its muted property

--- a/packages/react/src/components/participant/AudioTrack.tsx
+++ b/packages/react/src/components/participant/AudioTrack.tsx
@@ -38,7 +38,7 @@ export interface AudioTrackProps extends React.AudioHTMLAttributes<HTMLAudioElem
  */
 export const AudioTrack = /* @__PURE__ */ React.forwardRef<HTMLAudioElement, AudioTrackProps>(
   function AudioTrack(
-    { trackRef, onSubscriptionStatusChanged, volume, ...props }: AudioTrackProps,
+    { trackRef, onSubscriptionStatusChanged, volume, muted, ...props }: AudioTrackProps,
     ref,
   ) {
     const trackReference = useEnsureTrackRef(trackRef);
@@ -72,15 +72,15 @@ export const AudioTrack = /* @__PURE__ */ React.forwardRef<HTMLAudioElement, Aud
     }, [volume, track]);
 
     React.useEffect(() => {
-      if (pub === undefined || props.muted === undefined) {
+      if (pub === undefined || muted === undefined) {
         return;
       }
       if (pub instanceof RemoteTrackPublication) {
-        pub.setEnabled(!props.muted);
+        pub.setEnabled(!muted);
       } else {
         log.warn('Can only call setEnabled on remote track publications.');
       }
-    }, [props.muted, pub, track]);
+    }, [muted, pub, track]);
 
     return <audio ref={mediaEl} {...elementProps} />;
   },


### PR DESCRIPTION
closes https://github.com/livekit/components-js/issues/845

With `webAudioMix` enabled by default, we're relying on the fact that the HTMLAudioElement stays `muted` in the DOM as the audio playback itself will be happening through the WebAudio API. 

However, we didn't extract the `muted` property from the AudioTrackProps before re-assigning them to the `<AudioTrack />` component. This could lead to the audio being played back both through the HTMLAudioElement *and* the WebAudio API. 

