### PR TITLE
Support passing room to useIsEncrypted

### DIFF
--- a/.changeset/metal-jobs-argue.md
+++ b/.changeset/metal-jobs-argue.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Support passing room to useIsEncrypted hook

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -780,7 +780,13 @@ trackCount: number): {
 };
 
 // @alpha (undocumented)
-export function useIsEncrypted(participant?: Participant): boolean;
+export function useIsEncrypted(participant?: Participant, options?: UseIsEncryptedOptions): boolean;
+
+// @alpha (undocumented)
+export interface UseIsEncryptedOptions {
+    // (undocumented)
+    room?: Room;
+}
 
 // @public
 export function useIsMuted(trackRef: TrackReferenceOrPlaceholder): boolean;

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -47,7 +47,7 @@ export {
   usePersistentUserChoices,
   type UsePersistentUserChoicesOptions,
 } from './usePersistentUserChoices';
-export { useIsEncrypted } from './useIsEncrypted';
+export { UseIsEncryptedOptions, useIsEncrypted } from './useIsEncrypted';
 export * from './useTrackVolume';
 export * from './useParticipantTracks';
 export * from './useTrackTranscription';

--- a/packages/react/src/hooks/useIsEncrypted.ts
+++ b/packages/react/src/hooks/useIsEncrypted.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { LocalParticipant, Participant } from 'livekit-client';
+import { LocalParticipant, Participant, Room } from 'livekit-client';
 import { encryptionStatusObservable } from '@livekit/components-core';
 import { useEnsureParticipant, useEnsureRoom } from '../context';
 import { useObservableState } from './internal';
@@ -7,9 +7,16 @@ import { useObservableState } from './internal';
 /**
  * @alpha
  */
-export function useIsEncrypted(participant?: Participant) {
+export interface UseIsEncryptedOptions {
+  room?: Room;
+}
+
+/**
+ * @alpha
+ */
+export function useIsEncrypted(participant?: Participant, options: UseIsEncryptedOptions = {}) {
   const p = useEnsureParticipant(participant);
-  const room = useEnsureRoom();
+  const room = useEnsureRoom(options.room);
 
   const observer = React.useMemo(() => encryptionStatusObservable(room, p), [room, p]);
   const isEncrypted = useObservableState(


### PR DESCRIPTION
I am aware this is alpha, so I am not sure how much support this gets. 

I would find it useful if the hook could also get the room passed directly as other hooks so it can be used in a place where `Room` is manually created, where the room context is not available. :pray: 

I was not sure whether the hook should only get `options` where both `participant` and `room` could be. I can rewrite it to that if that makes more sense. :pray: 