### PR TITLE
Fix size-limit action in CI

### DIFF
--- a/.github/workflows/size-limit.yaml
+++ b/.github/workflows/size-limit.yaml
@@ -24,6 +24,6 @@ jobs:
       - uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          script: pnpm --filter @livekit/components-react exec size-limit --json
+          script: pnpm --filter @livekit/components-react --reporter-hide-prefix exec size-limit --json
           package_manager: pnpm
           build_script: build:react


### PR DESCRIPTION
works around a breaking change introduced in pnpm `v9.2.0`. 
see https://github.com/pnpm/pnpm/issues/8174