### PR TITLE
Fix `useRemoteParticipant` re-rendering on participant events

### DIFF
--- a/.changeset/quiet-rocks-grab.md
+++ b/.changeset/quiet-rocks-grab.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix `useRemoteParticipant` re-rendering on participant events

--- a/packages/react/src/hooks/useRemoteParticipant.ts
+++ b/packages/react/src/hooks/useRemoteParticipant.ts
@@ -2,7 +2,6 @@ import { connectedParticipantObserver } from '@livekit/components-core';
 import type { ParticipantEvent, RemoteParticipant } from 'livekit-client';
 import * as React from 'react';
 import { useRoomContext } from '../context';
-// import { useObservableState } from './internal';
 
 /** @public */
 export interface UseRemoteParticipantOptions {
@@ -36,6 +35,8 @@ export function useRemoteParticipant(
     [room, identity, updateOnlyOn],
   );
 
+  // Using `wrapperParticipant` to ensure a new object reference,
+  // triggering a re-render when the participant events fire.
   const [participantWrapper, setParticipantWrapper] = React.useState({
     p: room.getParticipantByIdentity(identity) as RemoteParticipant | undefined,
   });

--- a/packages/react/src/hooks/useRemoteParticipant.ts
+++ b/packages/react/src/hooks/useRemoteParticipant.ts
@@ -2,7 +2,7 @@ import { connectedParticipantObserver } from '@livekit/components-core';
 import type { ParticipantEvent, RemoteParticipant } from 'livekit-client';
 import * as React from 'react';
 import { useRoomContext } from '../context';
-import { useObservableState } from './internal';
+// import { useObservableState } from './internal';
 
 /** @public */
 export interface UseRemoteParticipantOptions {
@@ -35,9 +35,14 @@ export function useRemoteParticipant(
     () => connectedParticipantObserver(room, identity, { additionalEvents: updateOnlyOn }),
     [room, identity, updateOnlyOn],
   );
-  const participant = useObservableState(
-    observable,
-    room.getParticipantByIdentity(identity) as RemoteParticipant | undefined,
-  );
-  return participant;
+
+  const [participantWrapper, setParticipantWrapper] = React.useState({
+    p: room.getParticipantByIdentity(identity) as RemoteParticipant | undefined,
+  });
+  React.useEffect(() => {
+    const listener = observable.subscribe((p) => setParticipantWrapper({ p }));
+    return () => listener.unsubscribe();
+  }, [observable]);
+
+  return participantWrapper.p;
 }


### PR DESCRIPTION
Hi,
This PR fixes the problem of not re-rendering in `useRemoteParticipant` for triggered participant events.

Currently, this hook uses `useObservableState`, which itself uses a `useState` to execute a re-render after each emit value in the `observable`. But we know that the reference of participant object does not change when new events are fired, and thus re-rendering does not occur. So, to solve this problem, we need to put the participant in a wrapper object to use `useState`.

P.S:
Maybe a cleaner coding to solve this problem:
(although it requires the 'map' operator from rxjs)
``` typescript
const observable = React.useMemo(
  () =>
    connectedParticipantObserver(room, identity, { additionalEvents: updateOnlyOn }).pipe(
      map((p) => ({ p })),
    ),
  [room, identity, updateOnlyOn],
);
const { p: participant } = useObservableState(observable, {
  p: room.getParticipantByIdentity(identity) as RemoteParticipant | undefined,
});
```

