### PR TITLE
Add `gridLayoutOptions` as optional parameter for `useGridLayout` hook

### DIFF
--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -8,7 +8,6 @@ import type { AudioCaptureOptions } from 'livekit-client';
 import { BehaviorSubject } from 'rxjs';
 import { ConnectionQuality } from 'livekit-client';
 import { ConnectionState } from 'livekit-client';
-import createEmailRegExp from 'email-regex';
 import { DataPacket_Kind } from 'livekit-client';
 import type { DataPublishOptions } from 'livekit-client';
 import { LocalAudioTrack } from 'livekit-client';
@@ -128,7 +127,10 @@ export const createDefaultGrammar: () => {
     url: RegExp;
 };
 
-export { createEmailRegExp }
+// @public (undocumented)
+export function createEmailRegExp({ exact }?: {
+    exact?: boolean;
+}): RegExp;
 
 // Warning: (ae-internal-missing-underscore) The name "createInteractingObservable" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -784,7 +784,9 @@ export interface UseFocusToggleProps {
 // @public
 export function useGridLayout(
 gridElement: React_2.RefObject<HTMLDivElement>,
-trackCount: number): {
+trackCount: number, options?: {
+    gridLayouts?: GridLayoutDefinition[];
+}): {
     layout: GridLayoutDefinition;
 };
 
@@ -1188,7 +1190,7 @@ export type WidgetState = {
 //
 // src/context/layout-context.ts:10:3 - (ae-forgotten-export) The symbol "PinContextType" needs to be exported by the entry point index.d.ts
 // src/context/layout-context.ts:11:3 - (ae-forgotten-export) The symbol "WidgetContextType" needs to be exported by the entry point index.d.ts
-// src/hooks/useGridLayout.ts:24:6 - (ae-forgotten-export) The symbol "GridLayoutDefinition" needs to be exported by the entry point index.d.ts
+// src/hooks/useGridLayout.ts:25:5 - (ae-forgotten-export) The symbol "GridLayoutDefinition" needs to be exported by the entry point index.d.ts
 // src/hooks/useMediaDeviceSelect.ts:47:29 - (ae-forgotten-export) The symbol "SetMediaDeviceOptions" needs to be exported by the entry point index.d.ts
 // src/hooks/useTrackTranscription.ts:39:38 - (ae-forgotten-export) The symbol "ReceivedTranscriptionSegment" needs to be exported by the entry point index.d.ts
 

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -788,6 +788,8 @@ trackCount: number, options?: {
     gridLayouts?: GridLayoutDefinition[];
 }): {
     layout: GridLayoutDefinition;
+    width: number;
+    height: number;
 };
 
 // @alpha (undocumented)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livekit/components-react",
-  "version": "2.3.3",
+  "version": "2.4.3",
   "license": "Apache-2.0",
   "author": "LiveKit",
   "repository": {

--- a/packages/react/src/hooks/useGridLayout.ts
+++ b/packages/react/src/hooks/useGridLayout.ts
@@ -42,5 +42,7 @@ export function useGridLayout(
 
   return {
     layout,
+    width,
+    height,
   };
 }

--- a/packages/react/src/hooks/useGridLayout.ts
+++ b/packages/react/src/hooks/useGridLayout.ts
@@ -21,12 +21,16 @@ export function useGridLayout(
   gridElement: React.RefObject<HTMLDivElement>,
   /** Count of tracks that should get layed out */
   trackCount: number,
-): { layout: GridLayoutDefinition } {
+  options: {
+    gridLayouts?: GridLayoutDefinition[];
+  } = {},
+): { layout: GridLayoutDefinition, width: number, height: number } {
+  const { gridLayouts } = options;
   const { width, height } = useSize(gridElement);
 
   const layout =
     width > 0 && height > 0
-      ? selectGridLayout(GRID_LAYOUTS, trackCount, width, height)
+      ? selectGridLayout(gridLayouts || GRID_LAYOUTS, trackCount, width, height)
       : GRID_LAYOUTS[0];
 
   React.useEffect(() => {

--- a/packages/react/src/hooks/useGridLayout.ts
+++ b/packages/react/src/hooks/useGridLayout.ts
@@ -24,7 +24,7 @@ export function useGridLayout(
   options: {
     gridLayouts?: GridLayoutDefinition[];
   } = {},
-): { layout: GridLayoutDefinition, width: number, height: number } {
+): { layout: GridLayoutDefinition; width: number; height: number } {
   const { gridLayouts } = options;
   const { width, height } = useSize(gridElement);
 


### PR DESCRIPTION
## Situation

The `useGridLayout` hook is very handy and provides grid configurations based on the grid container width. However it's limited to a fixed set of grid configurations and if a screen is larger it will always fallback to the `5x5` grid which is the largest available today

## Proposal

This PR adds an optional `option.gridLayouts` parameters so when using the hook, we can **optionally** pass our own custom grid configurations, either by extending the existing one (already being exported [here](https://github.com/Nilomiranda/livekit-components-js/blob/1a9851b9ecdd48e22ef3c4e17a3795086f06e979/packages/core/src/helper/grid-layouts.ts#L23)) or writing your own set.

## Second "optional" proposal

Return `width` and `height` from the hook as it could be useful to have access to the width and height determined by the logic inside the hook to run, if needed, some additional logic within the component using the `useGridLayout` hook. I'm marking this as optional because if the team thinks this shouldn't exist, I can happily exclude it.