### PR TITLE
Logarithmic binning of multiband track volumes

### DIFF
--- a/.changeset/lemon-dancers-work.md
+++ b/.changeset/lemon-dancers-work.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Logarithmic binning of multiband track volumes

--- a/packages/react/src/components/participant/AudioVisualizer.tsx
+++ b/packages/react/src/components/participant/AudioVisualizer.tsx
@@ -30,7 +30,15 @@ export const AudioVisualizer: (
     const barCount = 7;
     const trackReference = useEnsureTrackRef(trackRef);
 
-    const volumes = useMultibandTrackVolume(trackReference, { bands: 7, loPass: 300 });
+    const volumes = useMultibandTrackVolume(trackReference, {
+      bands: 7,
+      loPass: 60,
+      hiPass: 1800,
+      analyserOptions: {
+        minDecibels: -60,
+        maxDecibels: -20,
+      },
+    });
 
     return (
       <svg

--- a/packages/react/src/hooks/useTrackVolume.ts
+++ b/packages/react/src/hooks/useTrackVolume.ts
@@ -119,6 +119,7 @@ export function useMultibandTrackVolume(
     if (!track || !track?.mediaStream) {
       return;
     }
+
     const { analyser, cleanup } = createAudioAnalyser(track, opts.analyserOptions);
 
     const bufferLength = analyser.frequencyBinCount;


### PR DESCRIPTION
for audio visualisation tasks it's more appropriate to use logarithmic binning of the linear frequency values in order to have a visual representation of frequency bands that more closely reflects human hearing.