### PR TITLE
chore: Update locale handling in ChatEntry component

### DIFF
--- a/packages/react/src/components/ChatEntry.tsx
+++ b/packages/react/src/components/ChatEntry.tsx
@@ -45,7 +45,7 @@ export const ChatEntry: (
     }, [entry.message, messageFormatter]);
     const hasBeenEdited = !!entry.editTimestamp;
     const time = new Date(entry.timestamp);
-    const locale = navigator ? navigator.language : 'en-US';
+    const locale = undefined; // If undefined, uses the browser's default locale.
 
     return (
       <li


### PR DESCRIPTION
Currently all timestamps are displayed in the US format AM/PM.

This PR fixes that.
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/3088722c-fff4-4421-928c-b4123c0d0203">
