### PR TITLE
Fix state update on participant attributes hook

### DIFF
--- a/.changeset/lovely-rocks-share.md
+++ b/.changeset/lovely-rocks-share.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix state update on participant attributes hook

--- a/packages/react/src/hooks/useParticipantAttributes.ts
+++ b/packages/react/src/hooks/useParticipantAttributes.ts
@@ -27,11 +27,11 @@ export function useParticipantAttributes(props: UseParticipantAttributesOptions 
     () => (p ? participantAttributesObserver(p) : participantAttributesObserver(p)),
     [p],
   );
-  const { attributes } = useObservableState(attributeObserver, {
+  const attributeState = useObservableState(attributeObserver, {
     attributes: p?.attributes,
   });
 
-  return { attributes };
+  return attributeState;
 }
 
 /**


### PR DESCRIPTION
previously the state update was triggered on every re-render due to the hook recreating an object each time.