### PR TITLE
Run pnpm dedupe on renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base"],
   "rangeStrategy": "auto",
+  "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
       "schedule": "before 6am on the first day of the month",


### PR DESCRIPTION
in some recent renovate PRs not all instances of a library were updated correctly in pnpm-lock.yaml. 
Running `pnpm dedupe` manually fixes the issue. 
This PR adds that command automatically before renovate commits the changes.