### PR TITLE
Expose StartMediaButton for External Use

### DIFF
--- a/.changeset/modern-tips-eat.md
+++ b/.changeset/modern-tips-eat.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Add StartMediaButton to public API

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -43,6 +43,12 @@ export interface AllowAudioPlaybackProps extends React_2.ButtonHTMLAttributes<HT
     label: string;
 }
 
+// @public (undocumented)
+export interface AllowMediaPlaybackProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement> {
+    // (undocumented)
+    label?: string;
+}
+
 // @public
 export function AudioConference({ ...props }: AudioConferenceProps): React_2.JSX.Element;
 
@@ -640,6 +646,9 @@ export const SpinnerIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Elemen
 
 // @public
 export const StartAudio: (props: AllowAudioPlaybackProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactNode;
+
+// @public
+export const StartMediaButton: (props: AllowMediaPlaybackProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactNode;
 
 // @public
 export function Toast(props: React_2.HTMLAttributes<HTMLDivElement>): React_2.JSX.Element;

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -5,6 +5,7 @@ export * from './controls/DisconnectButton';
 export * from './controls/FocusToggle';
 export * from './controls/MediaDeviceSelect';
 export * from './controls/StartAudio';
+export * from './controls/StartMediaButton';
 export * from './controls/TrackToggle';
 export * from './layout';
 export * from './layout/LayoutContextProvider';


### PR DESCRIPTION
Hello, LiveKit developers,

I noticed that the [`StartMediaButton`](https://github.com/livekit/components-js/blob/main/packages/react/src/components/controls/StartMediaButton.tsx#L23) component is marked as `@public`, but it’s currently not accessible from outside the package. It would be greatly appreciated if you could add it to the exported components list to make it available for external use. (I am currently customizing the control bar.)

Thank you for considering this request!