### PR TITLE
Update useParticipants to listen for any Participant's info changes

### DIFF
--- a/.changeset/calm-rivers-behave.md
+++ b/.changeset/calm-rivers-behave.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-core': patch
+---
+
+update useParticipants to listen for any Participant's info changes

--- a/packages/core/src/helper/eventGroups.ts
+++ b/packages/core/src/helper/eventGroups.ts
@@ -11,6 +11,8 @@ export const allRemoteParticipantRoomEvents = [
   RoomEvent.ParticipantDisconnected,
   RoomEvent.ParticipantPermissionsChanged,
   RoomEvent.ParticipantMetadataChanged,
+  RoomEvent.ParticipantNameChanged,
+  RoomEvent.ParticipantAttributesChanged,
 
   RoomEvent.TrackMuted,
   RoomEvent.TrackUnmuted,

--- a/packages/react/src/prefabs/ControlBar.tsx
+++ b/packages/react/src/prefabs/ControlBar.tsx
@@ -30,7 +30,7 @@ export interface ControlBarProps extends React.HTMLAttributes<HTMLDivElement> {
   controls?: ControlBarControls;
   /**
    * If `true`, the user's device choices will be persisted.
-   * This will enables the user to have the same device choices when they rejoin the room.
+   * This will enable the user to have the same device choices when they rejoin the room.
    * @defaultValue true
    * @alpha
    */

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -203,7 +203,7 @@ export function usePreviewDevice<T extends LocalVideoTrack | LocalAudioTrack>(
  *
  * @remarks
  * This component is independent of the `LiveKitRoom` component and should not be nested within it.
- * Because it only access the local media tracks this component is self contained and works without connection to the LiveKit server.
+ * Because it only accesses the local media tracks this component is self-contained and works without connection to the LiveKit server.
  *
  * @example
  * ```tsx

--- a/packages/react/src/prefabs/VideoConference.tsx
+++ b/packages/react/src/prefabs/VideoConference.tsx
@@ -43,7 +43,7 @@ export interface VideoConferenceProps extends React.HTMLAttributes<HTMLDivElemen
  * @remarks
  * The component is implemented with other LiveKit components like `FocusContextProvider`,
  * `GridLayout`, `ControlBar`, `FocusLayoutContainer` and `FocusLayout`.
- * You can use this components as a starting point for your own custom video conferencing application.
+ * You can use these components as a starting point for your own custom video conferencing application.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
### Issue
This is my first contribution! I’d love any advice on how to contribute to the repo. While working with the `useParticipants` hook, I expected it to keep the participants list updated with their names. However, I found that `useParticipants` only listens to metadata changes by default and does not react to updates in names or attributes.

To ensure the participants list updates correctly, I called the hook as follows:

```javascript
const participants = useParticipants({
  updateOnlyOn: [
    RoomEvent.ParticipantNameChanged,
    ...allParticipantRoomEvents,
  ],
});
```

Additionally, I noticed that the term `updateOnlyOn` could be misleading, as it always includes three events. While the documentation clarifies this, it may cause confusion when reading the code.

### Solution

I found the previous implementation a bit convoluted. I propose that `useParticipants` should update on all room events that trigger state changes for a participant, as originally intended by @Ocupe. Additionally, please note that a few events related to end-to-end encryption and permissions are still missing from the current setup.