### PR TITLE
Update agent component compatibility comments

### DIFF
--- a/packages/react/src/components/participant/BarVisualizer.tsx
+++ b/packages/react/src/components/participant/BarVisualizer.tsx
@@ -61,7 +61,7 @@ const getSequencerInterval = (
  * If the `state` prop is set, it automatically transitions between VoiceAssistant states.
  * @beta
  *
- * @remarks For VoiceAssistant state transitions this component requires a voice assistant agent running with livekit-agents \>= 0.8.11
+ * @remarks For VoiceAssistant state transitions this component requires a voice assistant agent running with livekit-agents \>= 0.9.0
  *
  * @example
  * ```tsx

--- a/packages/react/src/hooks/useVoiceAssistant.ts
+++ b/packages/react/src/hooks/useVoiceAssistant.ts
@@ -34,7 +34,7 @@ const state_attribute = 'lk.agent.state';
 
 /**
  * This hook looks for the first agent-participant in the room.
- * @remarks This hook requires an agent running with livekit-agents \>= 0.8.11
+ * @remarks This hook requires an agent running with livekit-agents \>= 0.9.0
  * @example
  * ```tsx
  * const { state, audioTrack, agentTranscriptions, agentAttributes } = useVoiceAssistant();


### PR DESCRIPTION
I noticed that these comments are now outdated, since the state param changed names in 0.9.0.