### PR TITLE
Improves bar visualizer animations and adds initializing state

### DIFF
--- a/.changeset/ninety-cheetahs-tickle.md
+++ b/.changeset/ninety-cheetahs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Improve bar visualizer animations and add initializing state

--- a/packages/react/src/components/participant/BarVisualizer.tsx
+++ b/packages/react/src/components/participant/BarVisualizer.tsx
@@ -30,7 +30,8 @@ export interface BarVisualizerProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 const sequencerIntervals = new Map<AgentState, number>([
-  ['connecting', 25 * 15],
+  ['connecting', 2000],
+  ['initializing', 2000],
   ['listening', 500],
   ['thinking', 150],
 ]);

--- a/packages/react/src/components/participant/animationSequences/connectingSequence.ts
+++ b/packages/react/src/components/participant/animationSequences/connectingSequence.ts
@@ -1,7 +1,7 @@
 export const generateConnectingSequenceBar = (columns: number): number[][] => {
   const seq = [];
 
-  for (let x = 0; x <= columns; x++) {
+  for (let x = 0; x < columns; x++) {
     seq.push([x, columns - 1 - x]);
   }
 


### PR DESCRIPTION
```
['connecting', 2000],
['initializing', 2000],
```

- Updated connecting interval to smooth out animation. These intervals shouldn't really be intervals as they are divided by `barCount`.  What we actually want is to define the overall length of the animation, in this case 2s, and divide that by `barCount`. This code works, but feels a bit indirect to call it 'intervals' with this update.

- Added an entry for 'initializing' as this wasn't supported and produced animation glitching. 

- Updated the connection sequence as to not repeat first/last when animation repeats. 