### PR TITLE
Fix Chat usage without layoutcontext

### DIFF
--- a/.changeset/empty-tables-agree.md
+++ b/.changeset/empty-tables-agree.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix Chat usage without layoutcontext

--- a/packages/react/src/prefabs/Chat.tsx
+++ b/packages/react/src/prefabs/Chat.tsx
@@ -89,9 +89,11 @@ export function Chat({
     <div {...props} className="lk-chat">
       <div className="lk-chat-header">
         Messages
-        <ChatToggle className="lk-close-button">
-          <ChatCloseIcon />
-        </ChatToggle>
+        {layoutContext && (
+          <ChatToggle className="lk-close-button">
+            <ChatCloseIcon />
+          </ChatToggle>
+        )}
       </div>
 
       <ul className="lk-list lk-chat-messages" ref={ulRef}>


### PR DESCRIPTION
The functionality of the `<Chat />` component should not depend on the presence of `LayoutContext`. 
There was a regression when we introduced a close button for chat as the `ChatToggle` button requires the `LayoutContext`. This PR fixes that by only rendering the ChatToggle if a LayoutContext is actually present.