### PR TITLE
React requires the class property to be called 'className'

### DIFF
--- a/.changeset/fresh-fans-deliver.md
+++ b/.changeset/fresh-fans-deliver.md
@@ -2,4 +2,4 @@
 "@livekit/components-react": patch
 ---
 
-React requires the class property to be called 'className'
+Fix className property on BarVisualizer

--- a/.changeset/fresh-fans-deliver.md
+++ b/.changeset/fresh-fans-deliver.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+React requires the class property to be called 'className'

--- a/packages/react/src/components/participant/BarVisualizer.tsx
+++ b/packages/react/src/components/participant/BarVisualizer.tsx
@@ -110,7 +110,7 @@ export const BarVisualizer = /* @__PURE__ */ React.forwardRef<HTMLDivElement, Ba
             cloneSingleChild(children, {
               'data-lk-highlighted': highlightedIndices.includes(idx),
               'data-lk-bar-index': idx,
-              class: 'lk-audio-bar',
+              className: 'lk-audio-bar',
               style: { height: `${Math.min(maxHeight, Math.max(minHeight, volume * 100 + 5))}%` },
             })
           ) : (


### PR DESCRIPTION
Reproduce errors as 

```
<BarVisualizer
  trackRef={{participant, publication, source: publication?.source || Track.Source.Microphone}}
  barCount={3}>
  <span>
    <span style={{backgroundColor: "black"}}/>
  </span>
</BarVisualizer>
```

Adding `<span>'s` as children like this is required to override the theming for this component