### PR TITLE
Fix typo in useSpeakingParticipants autogen doc

### DIFF
--- a/packages/react/src/hooks/useSpeakingParticipants.ts
+++ b/packages/react/src/hooks/useSpeakingParticipants.ts
@@ -4,7 +4,7 @@ import { useRoomContext } from '../context';
 import { useObservableState } from './internal';
 
 /**
- * The `useSpeakingParticipants` hook returns the only the active speakers of all participants.
+ * The `useSpeakingParticipants` hook returns only the active speakers of all participants.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
Fixes typo in the autogen docs for useSpeakingParticipants hook:

> The useSpeakingParticipants hook returns ~~the~~ only the active speakers of all participants.