### PR TITLE
use JS SDK's isLocal check

### DIFF
--- a/.changeset/wise-ghosts-talk.md
+++ b/.changeset/wise-ghosts-talk.md
@@ -1,0 +1,6 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+---
+
+use JS SDK's isLocal check

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,16 +1,15 @@
 import type { Participant, TrackPublication } from 'livekit-client';
-import { LocalParticipant, RemoteParticipant } from 'livekit-client';
 
-import type { PinState } from './types';
 import type { TrackReference } from './track-reference';
 import { isEqualTrackRef } from './track-reference';
+import type { PinState } from './types';
 
 export function isLocal(p: Participant) {
-  return p instanceof LocalParticipant;
+  return p.isLocal;
 }
 
 export function isRemote(p: Participant) {
-  return p instanceof RemoteParticipant;
+  return !p.isLocal;
 }
 
 export const attachIfSubscribed = (

--- a/packages/react/src/components/RoomAudioRenderer.tsx
+++ b/packages/react/src/components/RoomAudioRenderer.tsx
@@ -1,4 +1,4 @@
-import { getTrackReferenceId, isLocal } from '@livekit/components-core';
+import { getTrackReferenceId } from '@livekit/components-core';
 import { Track } from 'livekit-client';
 import * as React from 'react';
 import { useTracks } from '../hooks';
@@ -36,7 +36,7 @@ export function RoomAudioRenderer({ volume, muted }: RoomAudioRendererProps) {
       updateOnlyOn: [],
       onlySubscribed: true,
     },
-  ).filter((ref) => !isLocal(ref.participant) && ref.publication.kind === Track.Kind.Audio);
+  ).filter((ref) => !ref.participant.isLocal && ref.publication.kind === Track.Kind.Audio);
 
   return (
     <div style={{ display: 'none' }}>

--- a/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
+++ b/packages/react/src/hooks/useMediaTrackBySourceOrName.ts
@@ -1,6 +1,10 @@
 import type { TrackIdentifier } from '@livekit/components-core';
-import { isTrackReference } from '@livekit/components-core';
-import { setupMediaTrack, log, isLocal, getTrackByIdentifier } from '@livekit/components-core';
+import {
+  getTrackByIdentifier,
+  isTrackReference,
+  log,
+  setupMediaTrack,
+} from '@livekit/components-core';
 import * as React from 'react';
 import { mergeProps } from '../utils';
 
@@ -52,7 +56,7 @@ export function useMediaTrackBySourceOrName(
       }
       if (
         options.element?.current &&
-        !(isLocal(observerOptions.participant) && track?.kind === 'audio')
+        !(observerOptions.participant.isLocal && track?.kind === 'audio')
       ) {
         track.attach(options.element.current);
       }


### PR DESCRIPTION
closes #1037

while it's not totally clear why instance type check failed in this example. it seems like a good practice to us the JS SDK's isLocal check.