### PR TITLE
Replace instanceof LocalParticipant checks

### DIFF
--- a/packages/core/src/observables/room.ts
+++ b/packages/core/src/observables/room.ts
@@ -261,8 +261,8 @@ export function encryptionStatusObservable(room: Room, participant: Participant 
     ),
     map(([encrypted]) => encrypted),
     startWith(
-      participant instanceof LocalParticipant
-        ? participant.isE2EEEnabled
+      participant?.isLocal
+        ? (participant as LocalParticipant).isE2EEEnabled
         : !!participant?.isEncrypted,
     ),
   );

--- a/packages/core/src/sorting/sort-participants.ts
+++ b/packages/core/src/sorting/sort-participants.ts
@@ -47,7 +47,7 @@ export function sortParticipants(participants: Participant[]): Participant[] {
     // joinedAt
     return sortParticipantsByJoinedAt(a, b);
   });
-  const localParticipant = sortedParticipants.find((p) => p instanceof LocalParticipant);
+  const localParticipant = sortedParticipants.find((p) => p.isLocal) as LocalParticipant;
   if (localParticipant) {
     const localIdx = sortedParticipants.indexOf(localParticipant);
     if (localIdx >= 0) {

--- a/packages/react/src/hooks/useIsEncrypted.ts
+++ b/packages/react/src/hooks/useIsEncrypted.ts
@@ -23,7 +23,7 @@ export function useIsEncrypted(participant?: Participant, options: UseIsEncrypte
   const observer = React.useMemo(() => encryptionStatusObservable(room, p), [room, p]);
   const isEncrypted = useObservableState(
     observer,
-    p instanceof LocalParticipant ? p.isE2EEEnabled : !!p?.isEncrypted,
+    p.isLocal ? (p as LocalParticipant).isE2EEEnabled : !!p?.isEncrypted,
   );
   return isEncrypted;
 }


### PR DESCRIPTION
follow up to #1050. 

There are still additional places where we perform `instanceof` checks for tracks and track publications. To remove those we'll first need an update to the client sdk exposing something like `participant.isLocal` on tracks and publications.