### PR TITLE
preserve casing in generated docs page slugs

### DIFF
--- a/.changeset/wicked-masks-serve.md
+++ b/.changeset/wicked-masks-serve.md
@@ -1,0 +1,5 @@
+---
+"@livekit/api-documenter": patch
+---
+
+preserve casing in generated docs page slugs

--- a/tooling/api-documenter/src/utils/Utilities.ts
+++ b/tooling/api-documenter/src/utils/Utilities.ts
@@ -21,6 +21,6 @@ export class Utilities {
   public static getSafeFilenameForName(name: string): string {
     // TODO: This can introduce naming collisions.
     // We will fix that as part of https://github.com/microsoft/rushstack/issues/1308
-    return name.replace(Utilities._badFilenameCharsRegExp, '_').toLowerCase();
+    return name.replace(Utilities._badFilenameCharsRegExp, '_');
   }
 }


### PR DESCRIPTION
right now these get lowercased which makes the links less readable