### PR TITLE
Include useKrispNoiseFilter in generated docs, + related improvements

### DIFF
--- a/.changeset/brown-taxis-appear.md
+++ b/.changeset/brown-taxis-appear.md
@@ -1,0 +1,7 @@
+---
+"@livekit/components-core": patch
+"@livekit/components-react": patch
+"@livekit/api-documenter": patch
+---
+
+Include useKrispNoiseFilter in generated docs

--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -221,7 +221,7 @@ export type GridLayoutInfo = {
 export function isEqualTrackRef(a?: TrackReferenceOrPlaceholder, b?: TrackReferenceOrPlaceholder): boolean;
 
 // @public (undocumented)
-export function isLocal(p: Participant): p is LocalParticipant;
+export function isLocal(p: Participant): boolean;
 
 // @public
 export function isMobileBrowser(): boolean;
@@ -235,7 +235,7 @@ export function isParticipantTrackReferencePinned(trackRef: TrackReference, pinS
 export function isPlaceholderReplacement(currentTrackRef: TrackReferenceOrPlaceholder, nextTrackRef: TrackReferenceOrPlaceholder): boolean;
 
 // @public (undocumented)
-export function isRemote(p: Participant): p is RemoteParticipant;
+export function isRemote(p: Participant): boolean;
 
 // @public (undocumented)
 export function isSourcesWithOptions(sources: SourcesArray): sources is TrackSourceWithOptions[];

--- a/packages/core/tsdoc.json
+++ b/packages/core/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": [ "../../tsdoc.json" ]
+}

--- a/packages/react/api-extractor.json
+++ b/packages/react/api-extractor.json
@@ -16,5 +16,5 @@
    * DEFAULT VALUE: ""
    */
   "extends": "../../api-extractor-shared.json",
-  "mainEntryPointFilePath": "./dist/index.d.ts"
+  "mainEntryPointFilePath": "./dist/index.docs.d.ts"
 }

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -889,8 +889,6 @@ export function useIsRecording(room?: Room): boolean;
 // @public
 export function useIsSpeaking(participant?: Participant): boolean;
 
-// Warning: (ae-incompatible-release-tags) The symbol "useKrispNoiseFilter" is marked as @beta, but its signature references "useKrispNoiseFilterOptions" which is marked as @alpha
-//
 // @beta
 export function useKrispNoiseFilter(options?: useKrispNoiseFilterOptions): {
     setNoiseFilterEnabled: (enable: boolean) => Promise<void>;
@@ -899,7 +897,7 @@ export function useKrispNoiseFilter(options?: useKrispNoiseFilterOptions): {
     processor: KrispNoiseFilterProcessor | undefined;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface useKrispNoiseFilterOptions {
     // @internal (undocumented)
     filterOptions?: NoiseFilterOptions;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -13,12 +13,14 @@ import { CreateLocalTracksOptions } from 'livekit-client';
 import { DataPublishOptions } from 'livekit-client';
 import { DisconnectReason } from 'livekit-client';
 import { HTMLAttributes } from 'react';
+import { KrispNoiseFilterProcessor } from '@livekit/krisp-noise-filter';
 import { LocalAudioTrack } from 'livekit-client';
 import { LocalParticipant } from 'livekit-client';
 import { LocalTrack } from 'livekit-client';
 import { LocalTrackPublication } from 'livekit-client';
 import { LocalVideoTrack } from 'livekit-client';
 import { MediaDeviceFailure } from 'livekit-client';
+import { NoiseFilterOptions } from '@livekit/krisp-noise-filter';
 import { Participant } from 'livekit-client';
 import { ParticipantEvent } from 'livekit-client';
 import type { ParticipantKind } from 'livekit-client';
@@ -162,7 +164,7 @@ export const ChatIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
 export { ChatMessage }
 
-// Warning: (ae-forgotten-export) The symbol "ChatOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ChatOptions" needs to be exported by the entry point index.docs.d.ts
 //
 // @public (undocumented)
 export interface ChatProps extends React_2.HTMLAttributes<HTMLDivElement>, ChatOptions {
@@ -445,12 +447,12 @@ export interface MediaDeviceSelectProps extends Omit<React_2.HTMLAttributes<HTML
     track?: LocalAudioTrack | LocalVideoTrack;
 }
 
-// Warning: (ae-forgotten-export) The symbol "LegacyReceivedChatMessage" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "LegacyReceivedChatMessage" needs to be exported by the entry point index.docs.d.ts
 //
 // @public @deprecated (undocumented)
 export type MessageDecoder = (message: Uint8Array) => LegacyReceivedChatMessage;
 
-// Warning: (ae-forgotten-export) The symbol "LegacyChatMessage" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "LegacyChatMessage" needs to be exported by the entry point index.docs.d.ts
 //
 // @public @deprecated (undocumented)
 export type MessageEncoder = (message: LegacyChatMessage) => Uint8Array;
@@ -500,7 +502,7 @@ export function ParticipantContextIfNeeded(props: React_2.PropsWithChildren<{
     participant?: Participant;
 }>): React_2.JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "RequireAtLeastOne" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "RequireAtLeastOne" needs to be exported by the entry point index.docs.d.ts
 //
 // @beta (undocumented)
 export type ParticipantIdentifier = RequireAtLeastOne<{
@@ -629,14 +631,14 @@ export const ScreenShareIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.El
 // @internal (undocumented)
 export const ScreenShareStopIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "LogExtension" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "SetLogExtensionOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "LogExtension" needs to be exported by the entry point index.docs.d.ts
+// Warning: (ae-forgotten-export) The symbol "SetLogExtensionOptions" needs to be exported by the entry point index.docs.d.ts
 //
 // @public
 export function setLogExtension(extension: LogExtension, options?: SetLogExtensionOptions): void;
 
-// Warning: (ae-forgotten-export) The symbol "LogLevel" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "SetLogLevelOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "LogLevel" needs to be exported by the entry point index.docs.d.ts
+// Warning: (ae-forgotten-export) The symbol "SetLogLevelOptions" needs to be exported by the entry point index.docs.d.ts
 //
 // @public
 export function setLogLevel(level: LogLevel, options?: SetLogLevelOptions): void;
@@ -692,19 +694,19 @@ export type TrackReference = {
     source: Track.Source;
 };
 
-// Warning: (ae-forgotten-export) The symbol "TrackReferencePlaceholder" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TrackReferencePlaceholder" needs to be exported by the entry point index.docs.d.ts
 //
 // @public (undocumented)
 export type TrackReferenceOrPlaceholder = TrackReference | TrackReferencePlaceholder;
 
-// Warning: (ae-forgotten-export) The symbol "ToggleSource" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ToggleSource" needs to be exported by the entry point index.docs.d.ts
 //
 // @public
 export const TrackToggle: <T extends ToggleSource>(props: TrackToggleProps<T> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactNode;
 
 // @public (undocumented)
 export interface TrackToggleProps<T extends ToggleSource> extends Omit<React_2.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
-    // Warning: (ae-forgotten-export) The symbol "CaptureOptionsBySource" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CaptureOptionsBySource" needs to be exported by the entry point index.docs.d.ts
     //
     // (undocumented)
     captureOptions?: CaptureOptionsBySource<T>;
@@ -793,8 +795,8 @@ export function useConnectionState(room?: Room): ConnectionState_2;
 // @public (undocumented)
 export function useCreateLayoutContext(): LayoutContextType;
 
-// Warning: (ae-forgotten-export) The symbol "ReceivedDataMessage" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "UseDataChannelReturnType" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ReceivedDataMessage" needs to be exported by the entry point index.docs.d.ts
+// Warning: (ae-forgotten-export) The symbol "UseDataChannelReturnType" needs to be exported by the entry point index.docs.d.ts
 //
 // @public
 export function useDataChannel<T extends string>(topic: T, onMessage?: (msg: ReceivedDataMessage<T>) => void): UseDataChannelReturnType<T>;
@@ -829,7 +831,7 @@ export function useEnsureTrackRef(trackRef?: TrackReferenceOrPlaceholder): Track
 // @alpha
 export function useFacingMode(trackReference: TrackReferenceOrPlaceholder): 'user' | 'environment' | 'left' | 'right' | 'undefined';
 
-// Warning: (ae-forgotten-export) The symbol "FeatureContext" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "FeatureContext" needs to be exported by the entry point index.docs.d.ts
 // Warning: (ae-internal-missing-underscore) The name "useFeatureContext" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -886,6 +888,21 @@ export function useIsRecording(room?: Room): boolean;
 
 // @public
 export function useIsSpeaking(participant?: Participant): boolean;
+
+// @alpha
+export function useKrispNoiseFilter(options?: useKrispNoiseFilterOptions): {
+    setNoiseFilterEnabled: (enable: boolean) => Promise<void>;
+    isNoiseFilterEnabled: boolean;
+    isNoiseFilterPending: boolean;
+    processor: KrispNoiseFilterProcessor | undefined;
+};
+
+// @alpha (undocumented)
+export interface useKrispNoiseFilterOptions {
+    // (undocumented)
+    filterOptions?: NoiseFilterOptions;
+    trackRef?: TrackReferenceOrPlaceholder;
+}
 
 // @public
 export function useLayoutContext(): LayoutContextType;
@@ -1183,7 +1200,7 @@ export interface UseTokenOptions {
 // @public
 export function useTrackByName(name: string, participant?: Participant): TrackReferenceOrPlaceholder;
 
-// Warning: (ae-forgotten-export) The symbol "TrackMutedIndicatorReturnType" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TrackMutedIndicatorReturnType" needs to be exported by the entry point index.docs.d.ts
 //
 // @public
 export function useTrackMutedIndicator(trackRef?: TrackReferenceOrPlaceholder): TrackMutedIndicatorReturnType;
@@ -1191,12 +1208,12 @@ export function useTrackMutedIndicator(trackRef?: TrackReferenceOrPlaceholder): 
 // @public
 export function useTrackRefContext(): TrackReferenceOrPlaceholder;
 
-// Warning: (ae-forgotten-export) The symbol "SourcesArray" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SourcesArray" needs to be exported by the entry point index.docs.d.ts
 //
 // @public
 export function useTracks<T extends SourcesArray = Track.Source[]>(sources?: T, options?: UseTracksOptions): UseTracksHookReturnType<T>;
 
-// Warning: (ae-forgotten-export) The symbol "TrackSourceWithOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TrackSourceWithOptions" needs to be exported by the entry point index.docs.d.ts
 //
 // @public (undocumented)
 export type UseTracksHookReturnType<T> = T extends Track.Source[] ? TrackReference[] : T extends TrackSourceWithOptions[] ? TrackReferenceOrPlaceholder[] : never;
@@ -1316,11 +1333,11 @@ export type WidgetState = {
 
 // Warnings were encountered during analysis:
 //
-// src/context/layout-context.ts:10:3 - (ae-forgotten-export) The symbol "PinContextType" needs to be exported by the entry point index.d.ts
-// src/context/layout-context.ts:11:3 - (ae-forgotten-export) The symbol "WidgetContextType" needs to be exported by the entry point index.d.ts
-// src/hooks/useGridLayout.ts:27:6 - (ae-forgotten-export) The symbol "GridLayoutInfo" needs to be exported by the entry point index.d.ts
-// src/hooks/useMediaDeviceSelect.ts:47:29 - (ae-forgotten-export) The symbol "SetMediaDeviceOptions" needs to be exported by the entry point index.d.ts
-// src/hooks/useTrackTranscription.ts:43:38 - (ae-forgotten-export) The symbol "ReceivedTranscriptionSegment" needs to be exported by the entry point index.d.ts
+// src/context/layout-context.ts:10:3 - (ae-forgotten-export) The symbol "PinContextType" needs to be exported by the entry point index.docs.d.ts
+// src/context/layout-context.ts:11:3 - (ae-forgotten-export) The symbol "WidgetContextType" needs to be exported by the entry point index.docs.d.ts
+// src/hooks/useGridLayout.ts:27:6 - (ae-forgotten-export) The symbol "GridLayoutInfo" needs to be exported by the entry point index.docs.d.ts
+// src/hooks/useMediaDeviceSelect.ts:47:29 - (ae-forgotten-export) The symbol "SetMediaDeviceOptions" needs to be exported by the entry point index.docs.d.ts
+// src/hooks/useTrackTranscription.ts:43:38 - (ae-forgotten-export) The symbol "ReceivedTranscriptionSegment" needs to be exported by the entry point index.docs.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -901,7 +901,7 @@ export function useKrispNoiseFilter(options?: useKrispNoiseFilterOptions): {
 
 // @alpha (undocumented)
 export interface useKrispNoiseFilterOptions {
-    // (undocumented)
+    // @internal (undocumented)
     filterOptions?: NoiseFilterOptions;
     trackRef?: TrackReferenceOrPlaceholder;
 }

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -889,7 +889,9 @@ export function useIsRecording(room?: Room): boolean;
 // @public
 export function useIsSpeaking(participant?: Participant): boolean;
 
-// @alpha
+// Warning: (ae-incompatible-release-tags) The symbol "useKrispNoiseFilter" is marked as @beta, but its signature references "useKrispNoiseFilterOptions" which is marked as @alpha
+//
+// @beta
 export function useKrispNoiseFilter(options?: useKrispNoiseFilterOptions): {
     setNoiseFilterEnabled: (enable: boolean) => Promise<void>;
     isNoiseFilterEnabled: boolean;

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -10,18 +10,22 @@ import { useLocalParticipant } from '../../..';
  */
 export interface useKrispNoiseFilterOptions {
   /**
-   * by default the hook will use the localParticipant's microphone track publication.
-   * You can override this behavior by passing in a target TrackReference here
+   * The track reference to use for the noise filter (defaults: local microphone track)
    */
   trackRef?: TrackReferenceOrPlaceholder;
+  /**
+   * @internal
+   */
   filterOptions?: NoiseFilterOptions;
 }
 
 /**
  * Enable the Krisp enhanced noise cancellation feature for local audio tracks.
  *
+ * Defaults to the localParticipant's microphone track publication, but you can override this behavior by passing in a different track reference.
+ *
  * @package @livekit/components-react/krisp
- * @remarks This filter requires that you installthe `@livekit/krisp-noise-filter` package and is supported only on [LiveKit Cloud](https://cloud.livekit.io).
+ * @remarks This filter requires that you install the `@livekit/krisp-noise-filter` package and is supported only on [LiveKit Cloud](https://cloud.livekit.io).
  * @beta
  * @example
  * ```tsx

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -6,7 +6,7 @@ import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
 import { useLocalParticipant } from '../../..';
 
 /**
- * @alpha
+ * @beta
  */
 export interface useKrispNoiseFilterOptions {
   /**

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -24,7 +24,7 @@ export interface useKrispNoiseFilterOptions {
  *
  * Defaults to the localParticipant's microphone track publication, but you can override this behavior by passing in a different track reference.
  *
- * @package @livekit/components-react/krisp
+ * @package \@livekit/components-react/krisp
  * @remarks This filter requires that you install the `@livekit/krisp-noise-filter` package and is supported only on [LiveKit Cloud](https://cloud.livekit.io).
  * @beta
  * @example

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -21,6 +21,7 @@ export interface useKrispNoiseFilterOptions {
  * This hook is a convenience helper for enabling Krisp Enhanced Audio Noise Cancellation on LiveKit audio tracks.
  * It returns a `setNoiseFilterEnabled` method to conveniently toggle between enabled and disabled states.
  *
+ * @package @livekit/components-react/krisp
  * @remarks Krisp noise filter is a feature that's only supported on LiveKit cloud plans
  * @alpha
  * @example

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -25,7 +25,7 @@ export interface useKrispNoiseFilterOptions {
  * Defaults to the localParticipant's microphone track publication, but you can override this behavior by passing in a different track reference.
  *
  * @package \@livekit/components-react/krisp
- * @remarks This filter requires that you install the `@livekit/krisp-noise-filter` package and is supported only on [LiveKit Cloud](https://cloud.livekit.io).
+ * @remarks This filter requires that you install the `@livekit/krisp-noise-filter` package and is supported only on {@link https://cloud.livekit.io | LiveKit Cloud}.
  * @beta
  * @example
  * ```tsx

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -29,14 +29,15 @@ export interface useKrispNoiseFilterOptions {
  * @beta
  * @example
  * ```tsx
- *   const krisp = useKrispNoiseFilter();
- *   return <input
-        type="checkbox"
-        onChange={(ev) => krisp.setNoiseFilterEnabled(ev.target.checked)}
-        checked={krisp.isNoiseFilterEnabled}
-        disabled={krisp.isNoiseFilterPending}
-      />
+ * const krisp = useKrispNoiseFilter();
+ * return <input
+ *   type="checkbox"
+ *   onChange={(ev) => krisp.setNoiseFilterEnabled(ev.target.checked)}
+ *   checked={krisp.isNoiseFilterEnabled}
+ *   disabled={krisp.isNoiseFilterPending}
+ * />
  * ```
+ * @returns Use `setIsNoiseFilterEnabled` to enable/disable the noise filter.
  */
 export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
   const [shouldEnable, setShouldEnable] = React.useState(false);

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -18,12 +18,11 @@ export interface useKrispNoiseFilterOptions {
 }
 
 /**
- * This hook is a convenience helper for enabling Krisp Enhanced Audio Noise Cancellation on LiveKit audio tracks.
- * It returns a `setNoiseFilterEnabled` method to conveniently toggle between enabled and disabled states.
+ * Enable the Krisp enhanced noise cancellation feature for local audio tracks.
  *
  * @package @livekit/components-react/krisp
- * @remarks Krisp noise filter is a feature that's only supported on LiveKit cloud plans
- * @alpha
+ * @remarks This filter requires that you installthe `@livekit/krisp-noise-filter` package and is supported only on [LiveKit Cloud](https://cloud.livekit.io).
+ * @beta
  * @example
  * ```tsx
  *   const krisp = useKrispNoiseFilter();

--- a/packages/react/src/hooks/useIsMuted.ts
+++ b/packages/react/src/hooks/useIsMuted.ts
@@ -26,9 +26,8 @@ export interface UseIsMutedOptions {
  * const isMuted = useIsMuted('camera', { participant });
  * ```
  *
- * @param trackRef - A track reference object
- * @param sourceOrTrackRef - Either a `TrackRef` or a track source
- * @param options - Additional options when using with track source
+ * @param sourceOrTrackRef - Either a `TrackReference` or a `Track.Source` (see usage examples)
+ * @param options - Additional options when using a `Track.Source`
  * @returns boolean indicating if the track is muted
  *
  * @public

--- a/packages/react/src/hooks/useIsMuted.ts
+++ b/packages/react/src/hooks/useIsMuted.ts
@@ -27,7 +27,7 @@ export interface UseIsMutedOptions {
  * ```
  *
  * @param trackRef - A track reference object
- * @param sourceOrTrackRef - Either a track reference or a track source
+ * @param sourceOrTrackRef - Either a `TrackRef` or a track source
  * @param options - Additional options when using with track source
  * @returns boolean indicating if the track is muted
  *

--- a/packages/react/src/hooks/useIsMuted.ts
+++ b/packages/react/src/hooks/useIsMuted.ts
@@ -16,18 +16,18 @@ export interface UseIsMutedOptions {
  * The `useIsMuted` hook is used to implement the `TrackMutedIndicator` or your custom implementation of it.
  * It returns a `boolean` that indicates if the track is muted or not.
  *
- * @example Using with a track reference
+ * @example With a track reference
  * ```tsx
  * const isMuted = useIsMuted(track);
  * ```
  *
- * @example Using with a track source
+ * @example With a track source / participant
  * ```tsx
  * const isMuted = useIsMuted('camera', { participant });
  * ```
  *
  * @param trackRef - A track reference object
- * @param sourceOrTrackRef - Either a track reference or a track source string
+ * @param sourceOrTrackRef - Either a track reference or a track source
  * @param options - Additional options when using with track source
  * @returns boolean indicating if the track is muted
  *

--- a/packages/react/src/hooks/useIsMuted.ts
+++ b/packages/react/src/hooks/useIsMuted.ts
@@ -16,10 +16,21 @@ export interface UseIsMutedOptions {
  * The `useIsMuted` hook is used to implement the `TrackMutedIndicator` or your custom implementation of it.
  * It returns a `boolean` that indicates if the track is muted or not.
  *
- * @example
+ * @example Using with a track reference
  * ```tsx
  * const isMuted = useIsMuted(track);
  * ```
+ *
+ * @example Using with a track source
+ * ```tsx
+ * const isMuted = useIsMuted('camera', { participant });
+ * ```
+ *
+ * @param trackRef - A track reference object
+ * @param sourceOrTrackRef - Either a track reference or a track source string
+ * @param options - Additional options when using with track source
+ * @returns boolean indicating if the track is muted
+ *
  * @public
  */
 export function useIsMuted(trackRef: TrackReferenceOrPlaceholder): boolean;

--- a/packages/react/src/index.docs.ts
+++ b/packages/react/src/index.docs.ts
@@ -1,6 +1,5 @@
 /**
- * API Docs index. This is used by api-extractor given our package.json exports.
- * Monitoring: https://github.com/microsoft/rushstack/issues/3557
+ * Used to merge the exports from the main index.ts file with the exports from the cloud/krisp/useKrispNoiseFilter.ts file for docs generation.
  */
 
 // Regular exports

--- a/packages/react/src/index.docs.ts
+++ b/packages/react/src/index.docs.ts
@@ -1,0 +1,13 @@
+/**
+ * API Docs index. This is used by api-extractor given our package.json exports.
+ * Monitoring: https://github.com/microsoft/rushstack/issues/3557
+ */
+
+// Regular exports
+export * from './index';
+
+// Cloud/Krisp exports
+export {
+  useKrispNoiseFilter,
+  type useKrispNoiseFilterOptions,
+} from './hooks/cloud/krisp/useKrispNoiseFilter';

--- a/packages/react/tsdoc.json
+++ b/packages/react/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": [ "../../tsdoc.json" ]
+}

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -261,7 +261,7 @@ export class MarkdownDocumenter {
           );
         }
 
-        this._appendSection(output, tsdocComment.summarySection);
+        this._appendSection(output, this._processMarkdownContent(tsdocComment.summarySection));
       }
     }
 
@@ -500,7 +500,9 @@ export class MarkdownDocumenter {
         // Write the @remarks block
         if (tsdocComment.remarksBlock) {
           output.appendNode(new DocHeading({ configuration, title: 'Remarks', level: 2 }));
-          this._appendSection(output, tsdocComment.remarksBlock.content);
+          // Process the content to handle markdown links before appending
+          const processedContent = this._processMarkdownContent(tsdocComment.remarksBlock.content);
+          this._appendSection(output, processedContent);
         }
 
         // Write the @example blocks
@@ -514,8 +516,9 @@ export class MarkdownDocumenter {
             exampleBlocks.length > 1 ? `Usage Example ${exampleNumber}` : 'Usage';
 
           output.appendNode(new DocHeading({ configuration, title: heading, level: 2 }));
-
-          this._appendSection(output, exampleBlock.content);
+          // Process the content to handle markdown links before appending
+          const processedContent = this._processMarkdownContent(exampleBlock.content);
+          this._appendSection(output, processedContent);
 
           ++exampleNumber;
         }
@@ -536,6 +539,72 @@ export class MarkdownDocumenter {
     }
   }
 
+  private _processMarkdownContent(content: DocSection): DocSection {
+    const configuration: TSDocConfiguration = this._tsdocConfiguration;
+    const processedSection = new DocSection({ configuration });
+
+    // Process each node in the content
+    for (const node of content.nodes) {
+      if (node.kind === DocNodeKind.Paragraph) {
+        const paragraph = node as DocParagraph;
+        const processedParagraph = new DocParagraph({ configuration });
+
+        // Process each child node in the paragraph
+        for (const child of paragraph.getChildNodes()) {
+          if (child.kind === DocNodeKind.PlainText) {
+            const text = (child as DocPlainText).text;
+            // Look for markdown links [text](url)
+            const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+            let lastIndex = 0;
+            let match;
+
+            while ((match = linkRegex.exec(text)) !== null) {
+              // Add any text before the link
+              if (match.index > lastIndex) {
+                processedParagraph.appendNode(
+                  new DocPlainText({
+                    configuration,
+                    text: text.substring(lastIndex, match.index),
+                  })
+                );
+              }
+
+              // Add the link
+              processedParagraph.appendNode(
+                new DocLinkTag({
+                  configuration,
+                  tagName: '@link',
+                  linkText: match[1],
+                  urlDestination: match[2],
+                })
+              );
+
+              lastIndex = match.index + match[0].length;
+            }
+
+            // Add any remaining text
+            if (lastIndex < text.length) {
+              processedParagraph.appendNode(
+                new DocPlainText({
+                  configuration,
+                  text: text.substring(lastIndex),
+                })
+              );
+            }
+          } else {
+            processedParagraph.appendNode(child);
+          }
+        }
+
+        processedSection.appendNode(processedParagraph);
+      } else {
+        processedSection.appendNode(node);
+      }
+    }
+
+    return processedSection;
+  }
+
   private _writeThrowsSection(output: DocSection, apiItem: ApiItem): void {
     const configuration: TSDocConfiguration = this._tsdocConfiguration;
 
@@ -553,7 +622,9 @@ export class MarkdownDocumenter {
           output.appendNode(new DocHeading({ configuration, title: heading }));
 
           for (const throwsBlock of throwsBlocks) {
-            this._appendSection(output, throwsBlock.content);
+            // Process throws blocks for markdown links
+            const processedContent = this._processMarkdownContent(throwsBlock.content);
+            this._appendSection(output, processedContent);
           }
         }
       }
@@ -1073,7 +1144,9 @@ export class MarkdownDocumenter {
 
       if (apiParameterListMixin instanceof ApiDocumentedItem) {
         if (apiParameterListMixin.tsdocComment && apiParameterListMixin.tsdocComment.returnsBlock) {
-          this._appendSection(output, apiParameterListMixin.tsdocComment.returnsBlock.content);
+          // Process returns block for markdown links
+          const processedReturns = this._processMarkdownContent(apiParameterListMixin.tsdocComment.returnsBlock.content);
+          this._appendSection(output, processedReturns);
         }
       }
     }
@@ -1361,7 +1434,9 @@ export class MarkdownDocumenter {
 
     if (apiItem instanceof ApiDocumentedItem) {
       if (apiItem.tsdocComment !== undefined) {
-        this._appendAndMergeSection(section, apiItem.tsdocComment.summarySection);
+        // Process summary section for markdown links
+        const processedSummary = this._processMarkdownContent(apiItem.tsdocComment.summarySection);
+        this._appendAndMergeSection(section, processedSummary);
       }
     }
 
@@ -1535,7 +1610,9 @@ export class MarkdownDocumenter {
     for (const node of docSection.nodes) {
       if (firstNode) {
         if (node.kind === DocNodeKind.Paragraph) {
-          output.appendNodesInParagraph(node.getChildNodes());
+          // Process paragraph nodes for markdown links
+          const processedParagraph = this._processMarkdownContent(new DocSection({ configuration: this._tsdocConfiguration }, [node]));
+          output.appendNodesInParagraph(processedParagraph.nodes[0].getChildNodes());
           firstNode = false;
           continue;
         }

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -500,9 +500,7 @@ export class MarkdownDocumenter {
         // Write the @remarks block
         if (tsdocComment.remarksBlock) {
           output.appendNode(new DocHeading({ configuration, title: 'Remarks', level: 2 }));
-          // Process the content to handle markdown links before appending
-          const processedContent = this._processMarkdownContent(tsdocComment.remarksBlock.content);
-          this._appendSection(output, processedContent);
+          this._appendSection(output, this._processMarkdownContent(tsdocComment.remarksBlock.content));
         }
 
         // Write the @example blocks
@@ -510,31 +508,16 @@ export class MarkdownDocumenter {
           (x) => x.blockTag.tagNameWithUpperCase === StandardTags.example.tagNameWithUpperCase,
         );
 
-        let exampleNumber: number = 1;
-        for (const exampleBlock of exampleBlocks) {
-          const heading: string =
-            exampleBlocks.length > 1 ? `Usage Example ${exampleNumber}` : 'Usage';
-
-          output.appendNode(new DocHeading({ configuration, title: heading, level: 2 }));
-          // Process the content to handle markdown links before appending
-          const processedContent = this._processMarkdownContent(exampleBlock.content);
-          this._appendSection(output, processedContent);
-
-          ++exampleNumber;
+        if (exampleBlocks.length > 0) {
+          output.appendNode(new DocHeading({ configuration, title: 'Usage', level: 2 }));
         }
 
-        output.appendNode(
-          new MarkDocTag({
-            configuration,
-            name: 'partial',
-            attributes: {
-              file: 'p_usage.md',
-            },
-            variables: {
-              exampleCount: exampleNumber - 1,
-            },
-          }),
-        );
+        for (const [index, exampleBlock] of exampleBlocks.entries()) {
+          if (exampleBlocks.length > 1) {
+            output.appendNode(new DocHeading({ configuration, title: `Example ${index + 1}`, level: 3 }));
+          }
+          this._appendSection(output, this._processMarkdownContent(exampleBlock.content));
+        }
       }
     }
   }

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -1191,7 +1191,7 @@ export class MarkdownDocumenter {
                 new ParameterItem({
                   configuration,
                   attributes: {
-                    name: member.displayName,
+                    name: `${apiParameter.name}.${member.displayName}`,
                     type: member.propertyTypeExcerpt.text,
                     optional: member.isOptional,
                     description: member.tsdocComment?.summarySection?.nodes ?? [],

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -524,22 +524,22 @@ export class MarkdownDocumenter {
 
   private _processMarkdownContent(content: DocSection): DocSection {
     const configuration: TSDocConfiguration = this._tsdocConfiguration;
-    const processedSection = new DocSection({ configuration });
+    const processedSection: DocSection = new DocSection({ configuration });
 
     // Process each node in the content
     for (const node of content.nodes) {
       if (node.kind === DocNodeKind.Paragraph) {
-        const paragraph = node as DocParagraph;
-        const processedParagraph = new DocParagraph({ configuration });
+        const paragraph: DocParagraph = node as DocParagraph;
+        const processedParagraph: DocParagraph = new DocParagraph({ configuration });
 
         // Process each child node in the paragraph
         for (const child of paragraph.getChildNodes()) {
           if (child.kind === DocNodeKind.PlainText) {
-            const text = (child as DocPlainText).text;
+            const text: string = (child as DocPlainText).text;
             // Look for markdown links [text](url)
-            const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-            let lastIndex = 0;
-            let match;
+            const linkRegex: RegExp = /\[([^\]]+)\]\(([^)]+)\)/g;
+            let lastIndex: number = 0;
+            let match: RegExpExecArray | null;
 
             while ((match = linkRegex.exec(text)) !== null) {
               // Add any text before the link

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -1177,7 +1177,7 @@ export class MarkdownDocumenter {
         //@ts-ignore
         // apiParameter?._parent?.displayName === 'useParticipantTile' &&
         firstParameter.kind === ExcerptTokenKind.Reference &&
-        firstParameter.text.endsWith('Props') &&
+        (firstParameter.text.endsWith('Props') || firstParameter.text.endsWith('Options')) &&
         firstParameter.canonicalReference
       ) {
         // First parameter is a props object.

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -262,7 +262,7 @@ export class MarkdownDocumenter {
           );
         }
 
-        this._appendSection(output, this._processMarkdownContent(tsdocComment.summarySection));
+        this._appendSection(output, tsdocComment.summarySection);
       }
     }
 
@@ -501,10 +501,7 @@ export class MarkdownDocumenter {
         // Write the @remarks block
         if (tsdocComment.remarksBlock) {
           output.appendNode(new DocHeading({ configuration, title: 'Remarks', level: 2 }));
-          this._appendSection(
-            output,
-            this._processMarkdownContent(tsdocComment.remarksBlock.content),
-          );
+          this._appendSection(output, tsdocComment.remarksBlock.content);
         }
 
         // Write the @example blocks
@@ -583,83 +580,13 @@ export class MarkdownDocumenter {
               newContent.appendNode(exampleBlock.content.nodes[i]);
             }
 
-            this._appendSection(output, this._processMarkdownContent(newContent));
+            this._appendSection(output, newContent);
           } else {
-            this._appendSection(output, this._processMarkdownContent(exampleBlock.content));
+            this._appendSection(output, exampleBlock.content);
           }
         }
       }
     }
-  }
-
-  private _processMarkdownContent(content: DocSection): DocSection {
-    const configuration: TSDocConfiguration = this._tsdocConfiguration;
-    const processedSection: DocSection = new DocSection({ configuration });
-
-    // Process each node in the content
-    for (const node of content.nodes) {
-      if (node.kind === DocNodeKind.Paragraph) {
-        const paragraph: DocParagraph = node as DocParagraph;
-        const processedParagraph: DocParagraph = new DocParagraph({ configuration });
-
-        // Process each child node in the paragraph
-        for (const child of paragraph.getChildNodes()) {
-          if (child.kind === DocNodeKind.PlainText || child.kind === DocNodeKind.EscapedText) {
-            const text: string =
-              child.kind === DocNodeKind.PlainText
-                ? (child as DocPlainText).text
-                : (child as DocEscapedText).decodedText;
-
-            // Look for markdown links [text](url)
-            const linkRegex: RegExp = /\[([^\]]+)\]\(([^)]+)\)/g;
-            let lastIndex: number = 0;
-            let match: RegExpExecArray | null;
-
-            while ((match = linkRegex.exec(text)) !== null) {
-              // Add any text before the link
-              if (match.index > lastIndex) {
-                processedParagraph.appendNode(
-                  new DocPlainText({
-                    configuration,
-                    text: text.substring(lastIndex, match.index),
-                  }),
-                );
-              }
-
-              // Add the link
-              processedParagraph.appendNode(
-                new DocLinkTag({
-                  configuration,
-                  tagName: '@link',
-                  linkText: match[1],
-                  urlDestination: match[2],
-                }),
-              );
-
-              lastIndex = match.index + match[0].length;
-            }
-
-            // Add any remaining text
-            if (lastIndex < text.length) {
-              processedParagraph.appendNode(
-                new DocPlainText({
-                  configuration,
-                  text: text.substring(lastIndex),
-                }),
-              );
-            }
-          } else {
-            processedParagraph.appendNode(child);
-          }
-        }
-
-        processedSection.appendNode(processedParagraph);
-      } else {
-        processedSection.appendNode(node);
-      }
-    }
-
-    return processedSection;
   }
 
   private _writeThrowsSection(output: DocSection, apiItem: ApiItem): void {
@@ -679,9 +606,7 @@ export class MarkdownDocumenter {
           output.appendNode(new DocHeading({ configuration, title: heading }));
 
           for (const throwsBlock of throwsBlocks) {
-            // Process throws blocks for markdown links
-            const processedContent = this._processMarkdownContent(throwsBlock.content);
-            this._appendSection(output, processedContent);
+            this._appendSection(output, throwsBlock.content);
           }
         }
       }
@@ -1283,10 +1208,7 @@ export class MarkdownDocumenter {
 
       if (apiParameterListMixin instanceof ApiDocumentedItem) {
         if (apiParameterListMixin.tsdocComment?.returnsBlock) {
-          this._appendSection(
-            output,
-            this._processMarkdownContent(apiParameterListMixin.tsdocComment.returnsBlock.content),
-          );
+          this._appendSection(output, apiParameterListMixin.tsdocComment.returnsBlock.content);
         }
       }
 
@@ -1498,9 +1420,7 @@ export class MarkdownDocumenter {
 
     if (apiItem instanceof ApiDocumentedItem) {
       if (apiItem.tsdocComment !== undefined) {
-        // Process summary section for markdown links
-        const processedSummary = this._processMarkdownContent(apiItem.tsdocComment.summarySection);
-        this._appendAndMergeSection(section, processedSummary);
+        this._appendAndMergeSection(section, apiItem.tsdocComment.summarySection);
       }
     }
 
@@ -1674,11 +1594,7 @@ export class MarkdownDocumenter {
     for (const node of docSection.nodes) {
       if (firstNode) {
         if (node.kind === DocNodeKind.Paragraph) {
-          // Process paragraph nodes for markdown links
-          const processedParagraph = this._processMarkdownContent(
-            new DocSection({ configuration: this._tsdocConfiguration }, [node]),
-          );
-          output.appendNodesInParagraph(processedParagraph.nodes[0].getChildNodes());
+          output.appendNodesInParagraph(node.getChildNodes());
           firstNode = false;
           continue;
         }

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -562,13 +562,11 @@ export class MarkdownDocumenter {
             
             output.appendNode(new DocHeading({ configuration, title, level: 3 }));
 
-            // Create new content with modified first node
-            const newContent = new DocSection({ configuration });
+            const newContent: DocSection = new DocSection({ configuration });
             if (firstNode && firstNode.getChildNodes().length > 0) {
               newContent.appendNode(firstNode);
             }
-            // Add all other nodes after the first one
-            for (let i = 1; i < exampleBlock.content.nodes.length; i++) {
+            for (let i: number = 1; i < exampleBlock.content.nodes.length; i++) {
               newContent.appendNode(exampleBlock.content.nodes[i]);
             }
 

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -18,6 +18,7 @@ import {
   DocComment,
   DocNodeContainer,
   DocNode,
+  DocEscapedText,
 } from '@microsoft/tsdoc';
 import {
   ApiModel,
@@ -1783,6 +1784,8 @@ export class MarkdownDocumenter {
                 .map((child) => {
                   if (child.kind === DocNodeKind.PlainText) {
                     return (child as DocPlainText).text;
+                  } else if (child.kind === DocNodeKind.EscapedText) {
+                    return (child as DocEscapedText).decodedText;
                   }
                   return '';
                 })

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -1630,40 +1630,35 @@ export class MarkdownDocumenter {
   }
 
   private _getImportPath(apiItem: ApiDeclaredItem): string {
-    try {
-      // Check for custom import path from TSDoc first
-      if (apiItem instanceof ApiDocumentedItem && apiItem.tsdocComment) {
-        const packageTag: DocBlock | undefined = apiItem.tsdocComment.customBlocks.find(
-          (block) => block.blockTag.tagName === '@package',
-        );
+    // Check for custom import path from TSDoc first
+    if (apiItem instanceof ApiDocumentedItem && apiItem.tsdocComment) {
+      const packageTag: DocBlock | undefined = apiItem.tsdocComment.customBlocks.find(
+        (block) => block.blockTag.tagName === '@package',
+      );
 
-        if (packageTag) {
-          return packageTag.content.nodes
-            .map((node) => {
-              if (node.kind === DocNodeKind.Paragraph) {
-                return node
-                  .getChildNodes()
-                  .map((child) => {
-                    if (child.kind === DocNodeKind.PlainText) {
-                      return (child as DocPlainText).text;
-                    }
-                    return '';
-                  })
-                  .join('');
-              }
-              return '';
-            })
-            .join('')
-            .trim();
-        }
+      if (packageTag) {
+        return packageTag.content.nodes
+          .map((node) => {
+            if (node.kind === DocNodeKind.Paragraph) {
+              return node
+                .getChildNodes()
+                .map((child) => {
+                  if (child.kind === DocNodeKind.PlainText) {
+                    return (child as DocPlainText).text;
+                  }
+                  return '';
+                })
+                .join('');
+            }
+            return '';
+          })
+          .join('')
+          .trim();
       }
-
-      // Fallback to canonical reference
-      // @ts-ignore
-      return apiItem.canonicalReference.source.escapedPath;
-    } catch (error) {
-      console.error(error);
-      return '';
     }
+
+    // Fallback to canonical reference
+    // @ts-ignore
+    return apiItem.canonicalReference.source.escapedPath;
   }
 }

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -1144,9 +1144,7 @@ export class MarkdownDocumenter {
 
       if (apiParameterListMixin instanceof ApiDocumentedItem) {
         if (apiParameterListMixin.tsdocComment && apiParameterListMixin.tsdocComment.returnsBlock) {
-          // Process returns block for markdown links
-          const processedReturns = this._processMarkdownContent(apiParameterListMixin.tsdocComment.returnsBlock.content);
-          this._appendSection(output, processedReturns);
+          this._appendSection(output, apiParameterListMixin.tsdocComment.returnsBlock.content);
         }
       }
     }
@@ -1225,6 +1223,14 @@ export class MarkdownDocumenter {
     if (ApiReturnTypeMixin.isBaseClassOf(apiParameterListMixin)) {
       const returnTypeExcerpt: Excerpt = apiParameterListMixin.returnTypeExcerpt;
       output.appendNode(new DocHeading({ configuration, title: 'Returns', level: 2 }));
+
+      if (apiParameterListMixin instanceof ApiDocumentedItem) {
+        if (apiParameterListMixin.tsdocComment?.returnsBlock) {
+          this._appendSection(output, this._processMarkdownContent(
+            apiParameterListMixin.tsdocComment.returnsBlock.content
+          ));
+        }
+      }
 
       const fencedCode: DocFencedCode = new DocFencedCode({
         configuration,

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -500,7 +500,10 @@ export class MarkdownDocumenter {
         // Write the @remarks block
         if (tsdocComment.remarksBlock) {
           output.appendNode(new DocHeading({ configuration, title: 'Remarks', level: 2 }));
-          this._appendSection(output, this._processMarkdownContent(tsdocComment.remarksBlock.content));
+          this._appendSection(
+            output,
+            this._processMarkdownContent(tsdocComment.remarksBlock.content),
+          );
         }
 
         // Write the @example blocks
@@ -512,15 +515,17 @@ export class MarkdownDocumenter {
           output.appendNode(new DocHeading({ configuration, title: 'Usage', level: 2 }));
         }
 
-        const findFirstPlainText = (node: DocNode): { text: string | undefined, node: DocPlainText | undefined } => {
+        const findFirstPlainText = (
+          node: DocNode,
+        ): { text: string | undefined; node: DocPlainText | undefined } => {
           if (node.kind === DocNodeKind.PlainText) {
             const plainTextNode = node as DocPlainText;
-            return { 
+            return {
               text: plainTextNode.text.split('\n')[0].trim(),
-              node: plainTextNode
+              node: plainTextNode,
             };
           }
-          
+
           if (node instanceof DocNodeContainer) {
             for (const childNode of node.getChildNodes()) {
               const result = findFirstPlainText(childNode);
@@ -529,7 +534,7 @@ export class MarkdownDocumenter {
               }
             }
           }
-          
+
           return { text: undefined, node: undefined };
         };
 
@@ -537,29 +542,36 @@ export class MarkdownDocumenter {
           if (exampleBlocks.length > 1) {
             let firstNode: DocNode | undefined = exampleBlock.content.nodes[0];
             let title: string = `Example ${index + 1}`;
-            
+
             if (firstNode) {
               const { text, node: plainTextNode } = findFirstPlainText(firstNode);
               if (text) {
                 title = text;
                 if (plainTextNode) {
-                  const remainingText: string | undefined = plainTextNode.text.split('\n').slice(1).join('\n').trim();
+                  const remainingText: string | undefined = plainTextNode.text
+                    .split('\n')
+                    .slice(1)
+                    .join('\n')
+                    .trim();
                   const parent: DocNodeContainer = firstNode as DocNodeContainer;
-                  
-                  const newChildNodes: DocNode[] = parent.getChildNodes().map(childNode => {
-                    if (childNode === plainTextNode) {
-                      return remainingText ? 
-                        new DocPlainText({ configuration, text: remainingText }) :
-                        undefined;
-                    }
-                    return childNode;
-                  }).filter((node): node is DocNode => node !== undefined);
+
+                  const newChildNodes: DocNode[] = parent
+                    .getChildNodes()
+                    .map((childNode) => {
+                      if (childNode === plainTextNode) {
+                        return remainingText
+                          ? new DocPlainText({ configuration, text: remainingText })
+                          : undefined;
+                      }
+                      return childNode;
+                    })
+                    .filter((node): node is DocNode => node !== undefined);
 
                   firstNode = new DocParagraph({ configuration }, newChildNodes);
                 }
               }
             }
-            
+
             output.appendNode(new DocHeading({ configuration, title, level: 3 }));
 
             const newContent: DocSection = new DocSection({ configuration });
@@ -605,7 +617,7 @@ export class MarkdownDocumenter {
                   new DocPlainText({
                     configuration,
                     text: text.substring(lastIndex, match.index),
-                  })
+                  }),
                 );
               }
 
@@ -616,7 +628,7 @@ export class MarkdownDocumenter {
                   tagName: '@link',
                   linkText: match[1],
                   urlDestination: match[2],
-                })
+                }),
               );
 
               lastIndex = match.index + match[0].length;
@@ -628,7 +640,7 @@ export class MarkdownDocumenter {
                 new DocPlainText({
                   configuration,
                   text: text.substring(lastIndex),
-                })
+                }),
               );
             }
           } else {
@@ -1266,9 +1278,10 @@ export class MarkdownDocumenter {
 
       if (apiParameterListMixin instanceof ApiDocumentedItem) {
         if (apiParameterListMixin.tsdocComment?.returnsBlock) {
-          this._appendSection(output, this._processMarkdownContent(
-            apiParameterListMixin.tsdocComment.returnsBlock.content
-          ));
+          this._appendSection(
+            output,
+            this._processMarkdownContent(apiParameterListMixin.tsdocComment.returnsBlock.content),
+          );
         }
       }
 
@@ -1657,7 +1670,9 @@ export class MarkdownDocumenter {
       if (firstNode) {
         if (node.kind === DocNodeKind.Paragraph) {
           // Process paragraph nodes for markdown links
-          const processedParagraph = this._processMarkdownContent(new DocSection({ configuration: this._tsdocConfiguration }, [node]));
+          const processedParagraph = this._processMarkdownContent(
+            new DocSection({ configuration: this._tsdocConfiguration }, [node]),
+          );
           output.appendNodesInParagraph(processedParagraph.nodes[0].getChildNodes());
           firstNode = false;
           continue;

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -748,6 +748,7 @@ export class MarkdownDocumenter {
     // if (classesTable.rows.length > 0) {
     //   output.appendNode(new DocHeading({ configuration, title: 'Classes' }));
     //   output.appendNode(classesTable);
+    // }
 
     // if (abstractClassesTable.rows.length > 0) {
     //   output.appendNode(new DocHeading({ configuration, title: 'Abstract Classes' }));

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -209,6 +209,9 @@ export class MarkdownDocumenter {
       if (apiItem.releaseTag === ReleaseTag.Beta) {
         this._writeBetaWarning(output);
       }
+      if (apiItem.releaseTag === ReleaseTag.Alpha) {
+        this._writeAlphaWarning(output);
+      }
     }
 
     const decoratorBlocks: DocBlock[] = [];
@@ -1501,12 +1504,24 @@ export class MarkdownDocumenter {
   private _writeBetaWarning(output: DocSection): void {
     const configuration: TSDocConfiguration = this._tsdocConfiguration;
     const betaWarning: string =
-      'This API is provided as a preview for developers and may change' +
-      ' based on feedback that we receive.  Do not use this API in a production environment.';
+      "This feature is under active development and may change based on developer feedback and real-world usage."
     output.appendNode(
-      new DocNoteBox({ configuration }, [
+      new Callout({ configuration }, [
         new DocParagraph({ configuration }, [
           new DocPlainText({ configuration, text: betaWarning }),
+        ]),
+      ]),
+    );
+  }
+
+  private _writeAlphaWarning(output: DocSection): void {
+    const configuration: TSDocConfiguration = this._tsdocConfiguration;
+    const alphaWarning: string =
+      "This feature is experimental and may change or be removed based on developer feedback and real-world usage."
+    output.appendNode(
+      new Callout({ configuration }, [
+        new DocParagraph({ configuration }, [
+          new DocPlainText({ configuration, text: alphaWarning }),
         ]),
       ]),
     );

--- a/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
+++ b/tooling/api-documenter/src/documenters/MarkdownDocumenter.ts
@@ -604,8 +604,12 @@ export class MarkdownDocumenter {
 
         // Process each child node in the paragraph
         for (const child of paragraph.getChildNodes()) {
-          if (child.kind === DocNodeKind.PlainText) {
-            const text: string = (child as DocPlainText).text;
+          if (child.kind === DocNodeKind.PlainText || child.kind === DocNodeKind.EscapedText) {
+            const text: string =
+              child.kind === DocNodeKind.PlainText
+                ? (child as DocPlainText).text
+                : (child as DocEscapedText).decodedText;
+
             // Look for markdown links [text](url)
             const linkRegex: RegExp = /\[([^\]]+)\]\(([^)]+)\)/g;
             let lastIndex: number = 0;

--- a/tooling/api-documenter/src/nodes/Callout.ts
+++ b/tooling/api-documenter/src/nodes/Callout.ts
@@ -4,7 +4,7 @@
 import { IDocNodeParameters, DocNode, DocSection } from '@microsoft/tsdoc';
 import { CustomDocNodeKind } from './CustomDocNodeKind';
 
-type CalloutType = 'info' | 'tip' | 'important' | 'caution' | 'warning';
+type CalloutType = 'note' | 'tip' | 'important' | 'caution' | 'warning';
 type CalloutVariant = 'normal' | 'compact';
 
 /**
@@ -26,7 +26,7 @@ export class Callout extends DocNode {
   public constructor(parameters: ICalloutParameters, sectionChildNodes?: ReadonlyArray<DocNode>) {
     super(parameters);
     this.content = new DocSection({ configuration: this.configuration }, sectionChildNodes);
-    this.type = parameters.type ?? 'info';
+    this.type = parameters.type ?? 'note';
     this.variant = parameters.variant ?? 'normal';
   }
 

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@package",
+      "syntaxKind": "block"
+    }
+  ]
+} 


### PR DESCRIPTION
The main issue here is the krisp hook was excluded from generated docs because it's not actually in the react package index.d.ts. I decided the most straightforward thing to do is include it in generated docs anyways alongside everything else. I improved its docs a bit and upgraded it from alpha to beta.

While working on this I found and fixed the following additional issues:

- Added a custom `@package` tag for tsdoc so we can override the import path for the krisp hook
- Turn the `@beta` tag into a callout instead of a paragraph (and some text edits)
- Add a callout for the `@alpha` tag just like the `@beta` tag has
- We automatically unrolled parameters with type names ending in "Props" but we also sometimes use "Options" instead, including for useKrispNoiseFilter, so I added that.
- Unrolled parameters are confusing when there are other parameters in the list as well so I also added a prefix to them indicating where they should be included (e.g. `options.abc`). this still has room for improvement
- The `@return` directive is currently ignored entirely in favor of a generated signature. To improve docs, I've added the return description, if supplied, alongside the generated code.
- Multi-example docs were kinda unnatural with totally separate sections labeled "Usage Example 1", "Usage Example 2", etc. I changed it to be one section called Usage, with sub-headers for individual examples. They now use their first line as the title, falling back to numbered examples. I added extra examples to useIsMuted with this change.

<img width="683" alt="image" src="https://github.com/user-attachments/assets/a40d50e6-9dce-44de-b664-c722ab4eec57" />

<img width="671" alt="image" src="https://github.com/user-attachments/assets/e3270a53-e66b-419b-a52a-a30a0ede591e" />

