### PR TITLE
Fix toggle hydration error

### DIFF
--- a/.changeset/chatty-cups-turn.md
+++ b/.changeset/chatty-cups-turn.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix toggle hydration error

--- a/packages/react/src/components/controls/TrackToggle.tsx
+++ b/packages/react/src/components/controls/TrackToggle.tsx
@@ -39,10 +39,16 @@ export const TrackToggle: <T extends ToggleSource>(
   T extends ToggleSource,
 >({ showIcon, ...props }: TrackToggleProps<T>, ref: React.ForwardedRef<HTMLButtonElement>) {
   const { buttonProps, enabled } = useTrackToggle(props);
+  const [isClient, setIsClient] = React.useState(false);
+  React.useEffect(() => {
+    setIsClient(true);
+  }, []);
   return (
-    <button ref={ref} {...buttonProps}>
-      {(showIcon ?? true) && getSourceIcon(props.source, enabled)}
-      {props.children}
-    </button>
+    isClient && (
+      <button ref={ref} {...buttonProps}>
+        {(showIcon ?? true) && getSourceIcon(props.source, enabled)}
+        {props.children}
+      </button>
+    )
   );
 });

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -232,12 +232,12 @@ export function PreJoin({
   ...htmlProps
 }: PreJoinProps) {
   // TODO: Remove and pipe `defaults` object directly into `usePersistentUserChoices` once we fully switch from type `LocalUserChoices` to `UserChoices`.
-  const partialDefaults: Partial<LocalUserChoices> = {
-    ...(defaults.audioDeviceId !== undefined && { audioDeviceId: defaults.audioDeviceId }),
-    ...(defaults.videoDeviceId !== undefined && { videoDeviceId: defaults.videoDeviceId }),
-    ...(defaults.audioEnabled !== undefined && { audioEnabled: defaults.audioEnabled }),
-    ...(defaults.videoEnabled !== undefined && { videoEnabled: defaults.videoEnabled }),
-    ...(defaults.username !== undefined && { username: defaults.username }),
+  const mergedDefaults: LocalUserChoices = {
+    username: defaults.username ?? defaultUserChoices.username,
+    audioEnabled: defaults.audioEnabled ?? defaultUserChoices.audioEnabled,
+    videoEnabled: defaults.videoEnabled ?? defaultUserChoices.videoEnabled,
+    audioDeviceId: defaults.audioDeviceId ?? defaultUserChoices.audioDeviceId,
+    videoDeviceId: defaults.videoDeviceId ?? defaultUserChoices.videoDeviceId,
   };
 
   const {
@@ -248,7 +248,7 @@ export function PreJoin({
     saveVideoInputEnabled,
     saveUsername,
   } = usePersistentUserChoices({
-    defaults: partialDefaults,
+    defaults: mergedDefaults,
     preventSave: !persistUserChoices,
     preventLoad: !persistUserChoices,
   });

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -231,8 +231,6 @@ export function PreJoin({
   videoProcessor,
   ...htmlProps
 }: PreJoinProps) {
-  const [userChoices, setUserChoices] = React.useState(defaultUserChoices);
-
   // TODO: Remove and pipe `defaults` object directly into `usePersistentUserChoices` once we fully switch from type `LocalUserChoices` to `UserChoices`.
   const partialDefaults: Partial<LocalUserChoices> = {
     ...(defaults.audioDeviceId !== undefined && { audioDeviceId: defaults.audioDeviceId }),
@@ -255,16 +253,14 @@ export function PreJoin({
     preventLoad: !persistUserChoices,
   });
 
+  const [userChoices, setUserChoices] = React.useState(initialUserChoices);
+
   // Initialize device settings
-  const [audioEnabled, setAudioEnabled] = React.useState<boolean>(initialUserChoices.audioEnabled);
-  const [videoEnabled, setVideoEnabled] = React.useState<boolean>(initialUserChoices.videoEnabled);
-  const [audioDeviceId, setAudioDeviceId] = React.useState<string>(
-    initialUserChoices.audioDeviceId,
-  );
-  const [videoDeviceId, setVideoDeviceId] = React.useState<string>(
-    initialUserChoices.videoDeviceId,
-  );
-  const [username, setUsername] = React.useState(initialUserChoices.username);
+  const [audioEnabled, setAudioEnabled] = React.useState<boolean>(userChoices.audioEnabled);
+  const [videoEnabled, setVideoEnabled] = React.useState<boolean>(userChoices.videoEnabled);
+  const [audioDeviceId, setAudioDeviceId] = React.useState<string>(userChoices.audioDeviceId);
+  const [videoDeviceId, setVideoDeviceId] = React.useState<string>(userChoices.videoDeviceId);
+  const [username, setUsername] = React.useState(userChoices.username);
 
   // Save user choices to persistent storage.
   React.useEffect(() => {

--- a/packages/react/src/prefabs/PreJoin.tsx
+++ b/packages/react/src/prefabs/PreJoin.tsx
@@ -22,7 +22,6 @@ import { log } from '@livekit/components-core';
 import { ParticipantPlaceholder } from '../assets/images';
 import { useMediaDevices, usePersistentUserChoices } from '../hooks';
 import { useWarnAboutMissingStyles } from '../hooks/useWarnAboutMissingStyles';
-import { defaultUserChoices } from '@livekit/components-core';
 import { roomOptionsStringifyReplacer } from '../utils';
 
 /**
@@ -231,15 +230,6 @@ export function PreJoin({
   videoProcessor,
   ...htmlProps
 }: PreJoinProps) {
-  // TODO: Remove and pipe `defaults` object directly into `usePersistentUserChoices` once we fully switch from type `LocalUserChoices` to `UserChoices`.
-  const mergedDefaults: LocalUserChoices = {
-    username: defaults.username ?? defaultUserChoices.username,
-    audioEnabled: defaults.audioEnabled ?? defaultUserChoices.audioEnabled,
-    videoEnabled: defaults.videoEnabled ?? defaultUserChoices.videoEnabled,
-    audioDeviceId: defaults.audioDeviceId ?? defaultUserChoices.audioDeviceId,
-    videoDeviceId: defaults.videoDeviceId ?? defaultUserChoices.videoDeviceId,
-  };
-
   const {
     userChoices: initialUserChoices,
     saveAudioInputDeviceId,
@@ -248,7 +238,7 @@ export function PreJoin({
     saveVideoInputEnabled,
     saveUsername,
   } = usePersistentUserChoices({
-    defaults: mergedDefaults,
+    defaults,
     preventSave: !persistUserChoices,
     preventLoad: !persistUserChoices,
   });


### PR DESCRIPTION
track toggle would be server rendered and not updated some times leading to wrong UI state. 

This PR ensures the TrackToggle is only rendered on client side as recommended by react docs 🫠 
 https://nextjs.org/docs/messages/react-hydration-error#solution-1-using-useeffect-to-run-on-the-client-only