### PR TITLE
Correct LiveKit Cloud hyperlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </h1>
 
 <!--BEGIN_DESCRIPTION-->
-Use this SDK to add realtime video, audio and data features to your React app. By connecting to <a href="https://livekit.io/">LiveKit</a> Cloud or a self-hosted server, you can quickly build applications such as multi-modal AI, live streaming, or video calls with just a few lines of code.
+Use this SDK to add realtime video, audio and data features to your React app. By connecting to <a href="https://cloud.livekit.io/">LiveKit Cloud</a> or a self-hosted server, you can quickly build applications such as multi-modal AI, live streaming, or video calls with just a few lines of code.
 <!--END_DESCRIPTION-->
 
 <br/>


### PR DESCRIPTION
https://livekit.io/cloud hyperlinked here redirects to the main page, proposing updating the link to https://cloud.livekit.io/