### PR TITLE
Fix useDataChannel's send return type

### DIFF
--- a/.changeset/short-dingos-jump.md
+++ b/.changeset/short-dingos-jump.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix useDataChannel's send return type

--- a/packages/react/src/hooks/useDataChannel.ts
+++ b/packages/react/src/hooks/useDataChannel.ts
@@ -7,7 +7,7 @@ import { useObservableState } from './internal';
 
 type UseDataChannelReturnType<T extends string | undefined = undefined> = {
   isSending: boolean;
-  send: (payload: Uint8Array, options: DataPublishOptions) => void;
+  send: (payload: Uint8Array, options: DataPublishOptions) => Promise<void>;
   message: ReceivedDataMessage<T> | undefined;
 };
 


### PR DESCRIPTION
Adjusting `useDataChannel` TypeScript definition to match the `send` function returned by 'setupDataMessageHandler`.