### PR TITLE
useTextStream encounters TypeError('A text stream handler for topic...') upon browser refresh

### DIFF
--- a/.changeset/itchy-rocks-tan.md
+++ b/.changeset/itchy-rocks-tan.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+fix: avoid text stream re-register on disconnect

--- a/packages/react/src/hooks/useTextStream.ts
+++ b/packages/react/src/hooks/useTextStream.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { ConnectionState } from 'livekit-client';
 import { setupTextStream, type TextStreamData } from '@livekit/components-core';
 import { useRoomContext } from '../context';
@@ -19,17 +19,10 @@ export function useTextStream(topic: string) {
   const room = useRoomContext();
 
   const connectionState = useConnectionState(room);
-  const isDisconnected = React.useMemo(
-    () => connectionState === ConnectionState.Disconnected,
-    [connectionState],
-  );
+  const isDisconnected = connectionState === ConnectionState.Disconnected;
 
-  const textStreamObservable = React.useMemo(() => {
-    if (!isDisconnected) {
-      return setupTextStream(room, topic);
-    }
-    return undefined;
-  }, [room, topic, isDisconnected]);
+  const textStreamData = useMemo(() => setupTextStream(room, topic), [room, topic]);
+  const textStreamObservable = isDisconnected ? undefined : textStreamData;
 
   const textStreams = useObservableState<TextStreamData[]>(textStreamObservable, []);
 

--- a/packages/react/src/hooks/useTextStream.ts
+++ b/packages/react/src/hooks/useTextStream.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import * as React from 'react';
 import { ConnectionState } from 'livekit-client';
 import { setupTextStream, type TextStreamData } from '@livekit/components-core';
 import { useRoomContext } from '../context';
@@ -21,7 +21,7 @@ export function useTextStream(topic: string) {
   const connectionState = useConnectionState(room);
   const isDisconnected = connectionState === ConnectionState.Disconnected;
 
-  const textStreamData = useMemo(() => setupTextStream(room, topic), [room, topic]);
+  const textStreamData = React.useMemo(() => setupTextStream(room, topic), [room, topic]);
   const textStreamObservable = isDisconnected ? undefined : textStreamData;
 
   const textStreams = useObservableState<TextStreamData[]>(textStreamObservable, []);

--- a/packages/react/src/hooks/useTextStream.ts
+++ b/packages/react/src/hooks/useTextStream.ts
@@ -25,7 +25,10 @@ export function useTextStream(topic: string) {
   );
 
   const textStreamObservable = React.useMemo(() => {
-    return setupTextStream(room, topic);
+    if (!isDisconnected) {
+      return setupTextStream(room, topic);
+    }
+    return undefined;
   }, [room, topic, isDisconnected]);
 
   const textStreams = useObservableState<TextStreamData[]>(textStreamObservable, []);


### PR DESCRIPTION
Upon browser refresh we're hitting this error

https://github.com/livekit/client-sdk-js/blob/1a5a96638f42222eee323fb7947f0e336aa697fe/src/room/Room.ts#L292

we're using the useTextStream hook that was recently introduced. I believe there's a bug where when isDisconnected changes to true (upon browser refresh) then this memo runs again and it hits that invalid state.

