### PR TITLE
Pull audio track from avatar worker in useVoiceAssistant

### DIFF
--- a/.changeset/tender-eyes-run.md
+++ b/.changeset/tender-eyes-run.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Pull audio track from avatar worker in useVoiceAssistant

--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -86,10 +86,7 @@ export type ChatOptions = {
 };
 
 // @public (undocumented)
-export function computeMenuPosition(button: HTMLElement, menu: HTMLElement): Promise<{
-    x: number;
-    y: number;
-}>;
+export function computeMenuPosition(button: HTMLElement, menu: HTMLElement, onUpdate?: (x: number, y: number) => void): () => void;
 
 // @public (undocumented)
 export function connectedParticipantObserver(room: Room, identity: string, options?: ConnectedParticipantObserverOptions): Observable<RemoteParticipant | undefined>;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -1256,16 +1256,12 @@ export interface VideoTrackProps extends React_2.VideoHTMLAttributes<HTMLVideoEl
 
 // @beta (undocumented)
 export interface VoiceAssistant {
-    // (undocumented)
     agent: RemoteParticipant | undefined;
-    // (undocumented)
     agentAttributes: RemoteParticipant['attributes'] | undefined;
-    // (undocumented)
     agentTranscriptions: ReceivedTranscriptionSegment[];
-    // (undocumented)
     audioTrack: TrackReference_3 | undefined;
-    // (undocumented)
     state: AgentState;
+    videoTrack: TrackReference_3 | undefined;
 }
 
 // @beta (undocumented)

--- a/packages/react/src/hooks/useVoiceAssistant.ts
+++ b/packages/react/src/hooks/useVoiceAssistant.ts
@@ -23,11 +23,29 @@ export type AgentState =
  * @beta
  */
 export interface VoiceAssistant {
+  /**
+   * The agent participant.
+   */
   agent: RemoteParticipant | undefined;
+  /**
+   * The current state of the agent.
+   */
   state: AgentState;
+  /**
+   * The microphone track published by the agent or associated avatar worker (if any).
+   */
   audioTrack: TrackReference | undefined;
+  /**
+   * The camera track published by the agent or associated avatar worker (if any).
+   */
   videoTrack: TrackReference | undefined;
+  /**
+   * The transcriptions of the agent's microphone track (if any).
+   */
   agentTranscriptions: ReceivedTranscriptionSegment[];
+  /**
+   * The agent's participant attributes.
+   */
   agentAttributes: RemoteParticipant['attributes'] | undefined;
 }
 

--- a/packages/react/src/hooks/useVoiceAssistant.ts
+++ b/packages/react/src/hooks/useVoiceAssistant.ts
@@ -43,19 +43,18 @@ const state_attribute = 'lk.agent.state';
  * @beta
  */
 export function useVoiceAssistant(): VoiceAssistant {
-  const agent = useRemoteParticipants().find(
+  const remoteParticipants = useRemoteParticipants();
+  const agent = remoteParticipants.find(
     (p) => p.kind === ParticipantKind.AGENT && !('lk.publish_on_behalf' in p.attributes),
   );
-  const worker = useRemoteParticipants().find(
+  const worker = remoteParticipants.find(
     (p) =>
       p.kind === ParticipantKind.AGENT && p.attributes['lk.publish_on_behalf'] === agent?.identity,
   );
-  const agentAudioTrack = useParticipantTracks([Track.Source.Microphone], agent?.identity)[0];
-  const agentVideoTrack = useParticipantTracks([Track.Source.Camera], agent?.identity)[0];
-  const workerAudioTrack = useParticipantTracks([Track.Source.Microphone], worker?.identity)[0];
-  const workerVideoTrack = useParticipantTracks([Track.Source.Camera], worker?.identity)[0];
-  const audioTrack = agentAudioTrack ?? workerAudioTrack;
-  const videoTrack = agentVideoTrack ?? workerVideoTrack;
+  const agentTracks = useParticipantTracks([Track.Source.Microphone, Track.Source.Camera], agent?.identity);
+  const workerTracks = useParticipantTracks([Track.Source.Microphone, Track.Source.Camera], worker?.identity);
+  const audioTrack = agentTracks.find((t) => t.source === Track.Source.Microphone) ?? workerTracks.find((t) => t.source === Track.Source.Microphone);
+  const videoTrack = agentTracks.find((t) => t.source === Track.Source.Camera) ?? workerTracks.find((t) => t.source === Track.Source.Camera);
   const { segments: agentTranscriptions } = useTrackTranscription(audioTrack);
   const connectionState = useConnectionState();
   const { attributes } = useParticipantAttributes({ participant: agent });

--- a/packages/react/src/hooks/useVoiceAssistant.ts
+++ b/packages/react/src/hooks/useVoiceAssistant.ts
@@ -51,10 +51,20 @@ export function useVoiceAssistant(): VoiceAssistant {
     (p) =>
       p.kind === ParticipantKind.AGENT && p.attributes['lk.publish_on_behalf'] === agent?.identity,
   );
-  const agentTracks = useParticipantTracks([Track.Source.Microphone, Track.Source.Camera], agent?.identity);
-  const workerTracks = useParticipantTracks([Track.Source.Microphone, Track.Source.Camera], worker?.identity);
-  const audioTrack = agentTracks.find((t) => t.source === Track.Source.Microphone) ?? workerTracks.find((t) => t.source === Track.Source.Microphone);
-  const videoTrack = agentTracks.find((t) => t.source === Track.Source.Camera) ?? workerTracks.find((t) => t.source === Track.Source.Camera);
+  const agentTracks = useParticipantTracks(
+    [Track.Source.Microphone, Track.Source.Camera],
+    agent?.identity,
+  );
+  const workerTracks = useParticipantTracks(
+    [Track.Source.Microphone, Track.Source.Camera],
+    worker?.identity,
+  );
+  const audioTrack =
+    agentTracks.find((t) => t.source === Track.Source.Microphone) ??
+    workerTracks.find((t) => t.source === Track.Source.Microphone);
+  const videoTrack =
+    agentTracks.find((t) => t.source === Track.Source.Camera) ??
+    workerTracks.find((t) => t.source === Track.Source.Camera);
   const { segments: agentTranscriptions } = useTrackTranscription(audioTrack);
   const connectionState = useConnectionState();
   const { attributes } = useParticipantAttributes({ participant: agent });


### PR DESCRIPTION
1. ensure avatar worker is never returned by useVoiceAssistant
2. check avatar worker for audio track if main agent doesn't have one
3. add video track to useVoiceAssistant

There's a remaining bug which is that useTrackTranscriptions doesn't work, as the agent won't publish legacy transcriptions if it has no audio track id. so we either need to fix something in the agents sdk so it can publish them anyways or just port this hook over to text streams

but for now this fixes the agent playground for video + audio at least