### PR TITLE
Ensure subject is completed when unsubscribed

### DIFF
--- a/.changeset/afraid-glasses-cross.md
+++ b/.changeset/afraid-glasses-cross.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-core": patch
+---
+
+Ensure subject is completed when unsubscribed


### PR DESCRIPTION
Make it more obvious and fail safe that the devicechange listener gets removed once the observable is being unsubscribed