### PR TITLE
Add examples for all useDataChannel usages to the first definition

### DIFF
--- a/.changeset/orange-birds-smash.md
+++ b/.changeset/orange-birds-smash.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-js-docs": patch
+---
+
+Add all examples to the one useDataChannel that gets documented

--- a/packages/react/src/hooks/useDataChannel.ts
+++ b/packages/react/src/hooks/useDataChannel.ts
@@ -39,8 +39,6 @@ export function useDataChannel<T extends string>(
 ): UseDataChannelReturnType<T>;
 
 /**
- * Overload for `useDataChannel` without a topic. See {@link useDataChannel} for information and usage examples.
- *
  * @public
  */
 export function useDataChannel(

--- a/packages/react/src/hooks/useDataChannel.ts
+++ b/packages/react/src/hooks/useDataChannel.ts
@@ -13,7 +13,8 @@ type UseDataChannelReturnType<T extends string | undefined = undefined> = {
 
 /**
  * The `useDataChannel` hook returns the ability to send and receive messages.
- * By optionally passing a `topic`, you can narrow down which messages are returned in the messages array.
+ * Pass an optional `topic` to narrow down which messages are returned in the messages array.
+ *
  * @remarks
  * There is only one data channel. Passing a `topic` does not open a new data channel.
  * It is only used to filter out messages with no or a different `topic`.
@@ -23,25 +24,24 @@ type UseDataChannelReturnType<T extends string | undefined = undefined> = {
  * // Send messages to all participants via the 'chat' topic.
  * const { message: latestMessage, send } = useDataChannel('chat', (msg) => console.log("message received", msg));
  * ```
+ *
+ * @example
+ * ```tsx
+ * // Receive all messages (no topic filtering)
+ * const { message: latestMessage, send } = useDataChannel((msg) => console.log("message received", msg));
+ * ```
+ *
  * @public
  */
 export function useDataChannel<T extends string>(
   topic: T,
   onMessage?: (msg: ReceivedDataMessage<T>) => void,
 ): UseDataChannelReturnType<T>;
+
 /**
- * The `useDataChannel` hook returns the ability to send and receive messages.
- * @remarks
- * There is only one data channel. Passing a `topic` does not open a new data channel.
- * It is only used to filter out messages with no or a different `topic`.
- *
- * @example
- * ```tsx
- * // Send messages to all participants
- * const { message: latestMessage, send } = useDataChannel('chat', (msg) => console.log("message received", msg));
- * ```
- * @public
- */
+ * Overload for `useDataChannel` without a topic. See `useDataChannel<T>` for more usage examples.
+ * @internal
+ *  */
 export function useDataChannel(
   onMessage?: (msg: ReceivedDataMessage) => void,
 ): UseDataChannelReturnType;

--- a/packages/react/src/hooks/useDataChannel.ts
+++ b/packages/react/src/hooks/useDataChannel.ts
@@ -39,7 +39,7 @@ export function useDataChannel<T extends string>(
 ): UseDataChannelReturnType<T>;
 
 /**
- * Overload for `useDataChannel` without a topic. See {@link useDataChannel:function(1)} for information and usage examples.
+ * Overload for `useDataChannel` without a topic. See {@link (useDataChannel:1)} for information and usage examples.
  *
  * @public
  */

--- a/packages/react/src/hooks/useDataChannel.ts
+++ b/packages/react/src/hooks/useDataChannel.ts
@@ -39,6 +39,8 @@ export function useDataChannel<T extends string>(
 ): UseDataChannelReturnType<T>;
 
 /**
+ * Overload for `useDataChannel` without a topic. See {@link useDataChannel:function(1)} for information and usage examples.
+ *
  * @public
  */
 export function useDataChannel(

--- a/packages/react/src/hooks/useDataChannel.ts
+++ b/packages/react/src/hooks/useDataChannel.ts
@@ -39,9 +39,10 @@ export function useDataChannel<T extends string>(
 ): UseDataChannelReturnType<T>;
 
 /**
- * Overload for `useDataChannel` without a topic. See `useDataChannel<T>` for more usage examples.
- * @internal
- *  */
+ * Overload for `useDataChannel` without a topic. See {@link useDataChannel} for information and usage examples.
+ *
+ * @public
+ */
 export function useDataChannel(
   onMessage?: (msg: ReceivedDataMessage) => void,
 ): UseDataChannelReturnType;


### PR DESCRIPTION
~we [currently have two entries](https://github.com/livekit/livekit/issues/3617) in the table of contents that look identical. due to the design of our docs gen, there's no good solution without tradeoffs.~

~I think the most sensible thing to do is just document only one of them, with an example of usage without a topic. alternatively we could just get rid of the overrides and keep the one method that does both and has more complex type signatures and document that, but i think this approach here is best.~

Update: @lukasIO fixed the doc gen to just drop extra overloads so this PR is now just about adding all examples to the first one. https://github.com/livekit/components-js/pull/1138