### PR TITLE
Bump livekit-client to 2.13.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     livekit-client:
-      specifier: ^2.11.1
-      version: 2.11.1
+      specifier: ^2.13.0
+      version: 2.13.0
 
 importers:
 
@@ -64,7 +64,7 @@ importers:
         version: link:../../packages/styles
       livekit-client:
         specifier: 'catalog:'
-        version: 2.11.1
+        version: 2.13.0
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -128,10 +128,10 @@ importers:
         version: link:../../packages/styles
       '@livekit/track-processors':
         specifier: ^0.3.2
-        version: 0.3.2(livekit-client@2.11.1)
+        version: 0.3.2(livekit-client@2.13.0)
       livekit-client:
         specifier: 'catalog:'
-        version: 2.11.1
+        version: 2.13.0
       livekit-server-sdk:
         specifier: ^2.6.1
         version: 2.6.1
@@ -171,7 +171,7 @@ importers:
         version: 1.6.13
       livekit-client:
         specifier: 'catalog:'
-        version: 2.11.1
+        version: 2.13.0
       loglevel:
         specifier: 1.9.1
         version: 1.9.1
@@ -220,13 +220,13 @@ importers:
         version: link:../core
       '@livekit/krisp-noise-filter':
         specifier: ^0.2.12
-        version: 0.2.12(livekit-client@2.11.1)
+        version: 0.2.12(livekit-client@2.13.0)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
       livekit-client:
         specifier: 'catalog:'
-        version: 2.11.1
+        version: 2.13.0
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
@@ -2097,6 +2097,9 @@ packages:
 
   '@livekit/protocol@1.36.1':
     resolution: {integrity: sha512-nN3QnITAQ5yXk7UKfotH7CRWIlEozNWeKVyFJ0/+dtSzvWP/ib+10l1DDnRYi3A1yICJOGAKFgJ5d6kmi1HCUA==}
+
+  '@livekit/protocol@1.38.0':
+    resolution: {integrity: sha512-XX6ulvsE1XCN18LVf3ydHN7Ri1Z1M1P5dQdjnm5nVDsSqUL12Vbo/4RKcRlCEXAg2qB62mKjcaVLXVwkfXggkg==}
 
   '@livekit/track-processors@0.3.2':
     resolution: {integrity: sha512-4JUCzb7yIKoVsTo8J6FTzLZJHcI6DihfX/pGRDg0SOGaxprcDPrt8jaDBBTsnGBSXHeMxl2ugN+xQjdCWzLKEA==}
@@ -6161,8 +6164,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  livekit-client@2.11.1:
-    resolution: {integrity: sha512-XoUpMLll09ptJoHcYYefez1ACRFVxNt2Jo/yDLezc8c/gBzG2QJ35qvZaATlOUSRlF1q/6VwtcnWKQMGxriZkw==}
+  livekit-client@2.13.0:
+    resolution: {integrity: sha512-Q2FAQbJt0zFBdOHIom1YRfsIYIdTC2dxJfus084w4ni4ZHwNYZ9GZQcp9zpuxFg1O36fTobLCn3B1JCSY834nw==}
 
   livekit-server-sdk@2.6.1:
     resolution: {integrity: sha512-j/8TOlahIyWnycNkuSzTv6q+win4JTbDGNH48iMsZDMnJBks9hhC9UwAO4ES42sAorIAxGkrH58hxt4KdTkZaQ==}
@@ -10031,9 +10034,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@livekit/krisp-noise-filter@0.2.12(livekit-client@2.11.1)':
+  '@livekit/krisp-noise-filter@0.2.12(livekit-client@2.13.0)':
     dependencies:
-      livekit-client: 2.11.1
+      livekit-client: 2.13.0
 
   '@livekit/mutex@1.1.1': {}
 
@@ -10041,11 +10044,15 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
-  '@livekit/track-processors@0.3.2(livekit-client@2.11.1)':
+  '@livekit/protocol@1.38.0':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
+  '@livekit/track-processors@0.3.2(livekit-client@2.13.0)':
     dependencies:
       '@mediapipe/holistic': 0.5.1675471629
       '@mediapipe/tasks-vision': 0.10.9
-      livekit-client: 2.11.1
+      livekit-client: 2.13.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -15591,10 +15598,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  livekit-client@2.11.1:
+  livekit-client@2.13.0:
     dependencies:
       '@livekit/mutex': 1.1.1
-      '@livekit/protocol': 1.36.1
+      '@livekit/protocol': 1.38.0
       events: 3.3.0
       loglevel: 1.9.2
       sdp-transform: 2.15.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,4 @@ packages:
   - 'tooling/*'
 
 catalog:
-  livekit-client: ^2.11.1
+  livekit-client: ^2.13.0


### PR DESCRIPTION
I want to ensure the data channel ordering change can get pulled through to react native so bumping this here so i can bump it there.