### PR TITLE
Fix `useParticipantTracks` not including local participant

### DIFF
--- a/.changeset/chilly-forks-act.md
+++ b/.changeset/chilly-forks-act.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+Fix `useParticipantTracks` to include local participant

--- a/packages/react/src/hooks/useParticipantTracks.ts
+++ b/packages/react/src/hooks/useParticipantTracks.ts
@@ -4,7 +4,7 @@ import { participantTracksObservable } from '@livekit/components-core';
 import { useObservableState } from './internal';
 import type { Track } from 'livekit-client';
 import { useMaybeParticipantContext } from '../context';
-import { useRemoteParticipants } from './useRemoteParticipants';
+import { useParticipants } from './useParticipants';
 
 /**
  * `useParticipantTracks` is a custom React that allows you to get tracks of a specific participant only, by specifiying the participant's identity.
@@ -16,14 +16,14 @@ export function useParticipantTracks(
   participantIdentity?: string,
 ): TrackReference[] {
   const participantContext = useMaybeParticipantContext();
-  const remoteParticipants = useRemoteParticipants({ updateOnlyOn: [] });
+  const participants = useParticipants({ updateOnlyOn: [] });
 
   const p = React.useMemo(() => {
     if (participantIdentity) {
-      return remoteParticipants.find((p) => p.identity === participantIdentity);
+      return participants.find((p) => p.identity === participantIdentity);
     }
     return participantContext;
-  }, [participantIdentity, remoteParticipants, participantContext]);
+  }, [participantIdentity, participants, participantContext]);
 
   const observable = React.useMemo(() => {
     if (!p) {


### PR DESCRIPTION
Hi.
`useParticipantTracks` previously included local participant tracks, which make sense with the hook's name