### PR TITLE
feat: add onDeviceError callback to VideoConference component.

### DIFF
--- a/.changeset/clean-pants-exist.md
+++ b/.changeset/clean-pants-exist.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-react": patch
+---
+
+feat: add onDeviceError callback to VideoConference component.

--- a/packages/react/src/prefabs/VideoConference.tsx
+++ b/packages/react/src/prefabs/VideoConference.tsx
@@ -157,7 +157,10 @@ export function VideoConference({
                 </FocusLayoutContainer>
               </div>
             )}
-            <ControlBar onDeviceError={onDeviceError} controls={{ chat: true, settings: !!SettingsComponent }} />
+            <ControlBar
+              onDeviceError={onDeviceError}
+              controls={{ chat: true, settings: !!SettingsComponent }}
+            />
           </div>
           <Chat
             style={{ display: widgetState.showChat ? 'grid' : 'none' }}

--- a/packages/react/src/prefabs/VideoConference.tsx
+++ b/packages/react/src/prefabs/VideoConference.tsx
@@ -33,6 +33,7 @@ export interface VideoConferenceProps extends React.HTMLAttributes<HTMLDivElemen
   chatMessageDecoder?: MessageDecoder;
   /** @alpha */
   SettingsComponent?: React.ComponentType;
+  onDeviceError?: (error: { source: Track.Source; error: Error }) => void;
 }
 
 /**
@@ -58,6 +59,7 @@ export function VideoConference({
   chatMessageDecoder,
   chatMessageEncoder,
   SettingsComponent,
+  onDeviceError,
   ...props
 }: VideoConferenceProps) {
   const [widgetState, setWidgetState] = React.useState<WidgetState>({
@@ -155,7 +157,7 @@ export function VideoConference({
                 </FocusLayoutContainer>
               </div>
             )}
-            <ControlBar controls={{ chat: true, settings: !!SettingsComponent }} />
+            <ControlBar onDeviceError={onDeviceError} controls={{ chat: true, settings: !!SettingsComponent }} />
           </div>
           <Chat
             style={{ display: widgetState.showChat ? 'grid' : 'none' }}


### PR DESCRIPTION
This commit introduces an `onDeviceError` callback prop to the `VideoConference` component. The purpose of this callback is to provide parent components with a unified and flexible way to handle device-related errors, such as permission denials for camera, microphone, or screen sharing.