### PR TITLE
Update `LiveKitRoom` connection logic

### DIFF
--- a/.changeset/pink-paths-pick.md
+++ b/.changeset/pink-paths-pick.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Update LiveKitRoom connection logic to be more robust

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -375,6 +375,7 @@ export const LiveKitRoom: (props: React_2.PropsWithChildren<LiveKitRoomProps> & 
 export interface LiveKitRoomProps extends Omit<React_2.HTMLAttributes<HTMLDivElement>, 'onError'> {
     audio?: AudioCaptureOptions | boolean;
     connect?: boolean;
+    connectionSideEffect?: (room: Room) => Promise<void>;
     connectOptions?: RoomConnectOptions;
     // @internal (undocumented)
     featureFlags?: FeatureFlags;

--- a/packages/react/src/components/LiveKitRoom.tsx
+++ b/packages/react/src/components/LiveKitRoom.tsx
@@ -79,6 +79,12 @@ export interface LiveKitRoomProps extends Omit<React.HTMLAttributes<HTMLDivEleme
   simulateParticipants?: number | undefined;
 
   /**
+   * Optional side effect to run in parallel with the connection process.
+   * This can be used to enable the microphone preconnect buffer / etc
+   */
+  connectionSideEffect?: (room: Room) => Promise<void>;
+
+  /**
    * @internal
    */
   featureFlags?: FeatureFlags;


### PR DESCRIPTION
Initially, I made https://github.com/livekit/components-js/pull/1197, which aimed to create a react hook for managing a room connection. However, after some comments were left and I started digging in to the codebase a bit deeper, I noticed that there was already a mechanism in place to support this - `LiveKitRoom` / `useLiveKitRoom`. Embarrassingly, this is also called out right in the README... 🤦 

So, ditch the old attempt and instead update this pre-existing abstraction to use the connection behavior from the previous change. In addition, it looks like there isn't a means to support the microphone preconnect audio buffer logic with the existing implementation, so add a mechanism to do that.

I ported `agent-starter-react` over to use this mechanism here: https://github.com/livekit-examples/agent-starter-react/pull/225