### PR TITLE
Update readme to include agents sdk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import {
 } from "@livekit/components-react";
 
 // Generated credentials manually and put them here
-// Or, generate them another way: FIXME: add docs link here!
+// Or, generate them another way: https://github.com/livekit/client-sdk-js?tab=readme-ov-file#generating-a-urltoken-with-tokensource
 const tokenSource = TokenSource.literal({
   serverUrl: "wss://my-livekit-server",
   participantToken: 'generated-jwt',


### PR DESCRIPTION
There's not a ton I added here, but I think this at least starts to point users in the direction of agents in the readme versus what was there previously.

Merging blocked on https://github.com/livekit/components-js/pull/1207 and broader docs updates (link placeholders need to be replaced with the eventual docs link urls)