### PR TITLE
Make the agents sdk beta-tagged before official release

### DIFF
--- a/packages/core/etc/components-core.api.md
+++ b/packages/core/etc/components-core.api.md
@@ -444,7 +444,7 @@ export interface ReceivedDataMessage<T extends string | undefined = string> exte
     from?: Participant;
 }
 
-// @public (undocumented)
+// @beta (undocumented)
 export type ReceivedMessage = ReceivedUserTranscriptionMessage | ReceivedAgentTranscriptionMessage | ReceivedChatMessage;
 
 // @public (undocumented)

--- a/packages/core/src/messages/types.ts
+++ b/packages/core/src/messages/types.ts
@@ -38,7 +38,7 @@ export type ReceivedAgentTranscriptionMessage = ReceivedMessageWithType<
   }
 >;
 
-/** @public */
+/** @beta */
 export type ReceivedMessage =
   | ReceivedUserTranscriptionMessage
   | ReceivedAgentTranscriptionMessage

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -72,14 +72,14 @@ import { TranscriptionSegment } from 'livekit-client';
 import { VideoCaptureOptions } from 'livekit-client';
 import { WidgetState } from '@livekit/components-core';
 
-// @public (undocumented)
+// @beta (undocumented)
 export type AgentCallbacks = {
     [AgentEvent.CameraChanged]: (newTrack: TrackReference | undefined) => void;
     [AgentEvent.MicrophoneChanged]: (newTrack: TrackReference | undefined) => void;
     [AgentEvent.StateChanged]: (newAgentState: AgentState) => void;
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export enum AgentEvent {
     // (undocumented)
     CameraChanged = "cameraChanged",
@@ -91,7 +91,7 @@ export enum AgentEvent {
 
 // Warning: (ae-forgotten-export) The symbol "AgentSdkStates" needs to be exported by the entry point index.docs.d.ts
 //
-// @public
+// @beta
 export type AgentState = 'disconnected' | 'connecting' | 'pre-connect-buffering' | 'failed' | AgentSdkStates;
 
 // @public (undocumented)
@@ -486,12 +486,12 @@ export { MessageEncoder }
 // @public (undocumented)
 export type MessageFormatter = (message: string) => React_2.ReactNode;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type MessagesCallbacks = {
     [MessagesEvent.MessageReceived]: (message: ReceivedMessage) => void;
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export enum MessagesEvent {
     MessageReceived = "messageReceived"
 }
@@ -654,14 +654,14 @@ export const ScreenShareIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.El
 // @internal (undocumented)
 export const ScreenShareStopIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type SessionCallbacks = {
     [SessionEvent.ConnectionStateChanged]: (newAgentConnectionState: ConnectionState_2) => void;
     [SessionEvent.MediaDevicesError]: (error: Error) => void;
     [SessionEvent.EncryptionError]: (error: Error) => void;
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type SessionConnectOptions = {
     signal?: AbortSignal;
     tracks?: {
@@ -673,7 +673,7 @@ export type SessionConnectOptions = {
     roomConnectOptions?: RoomConnectOptions;
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export enum SessionEvent {
     // (undocumented)
     ConnectionStateChanged = "connectionStateChanged",
@@ -681,10 +681,10 @@ export enum SessionEvent {
     MediaDevicesError = "mediaDevicesError"
 }
 
-// @public
+// @beta
 export function SessionProvider(props: SessionProviderProps): React_2.JSX.Element;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type SessionProviderProps = {
     session: UseSessionReturn;
     children: React_2.ReactNode;
@@ -705,7 +705,7 @@ export const StartAudio: (props: AllowAudioPlaybackProps & React_2.RefAttributes
 // @public
 export const StartMediaButton: (props: AllowMediaPlaybackProps & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactNode;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type SwitchActiveDeviceOptions = {
     exact?: boolean;
 };
@@ -782,13 +782,13 @@ export const UnfocusToggleIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.
 
 // Warning: (ae-forgotten-export) The symbol "SessionStub" needs to be exported by the entry point index.docs.d.ts
 //
-// @public
+// @beta
 export function useAgent(session?: SessionStub): UseAgentReturn;
 
 // Warning: (ae-forgotten-export) The symbol "AgentStateCases" needs to be exported by the entry point index.docs.d.ts
 // Warning: (ae-forgotten-export) The symbol "AgentActions" needs to be exported by the entry point index.docs.d.ts
 //
-// @public (undocumented)
+// @beta (undocumented)
 export type UseAgentReturn = AgentStateCases & AgentActions;
 
 // @alpha
@@ -877,7 +877,7 @@ export function useEnsureParticipant(participant?: Participant): Participant;
 // @public
 export function useEnsureRoom(room?: Room): Room;
 
-// @public
+// @beta
 export function useEnsureSession(session?: UseSessionReturn): UseSessionReturn;
 
 // @public
@@ -1004,7 +1004,7 @@ export function useMaybeParticipantContext(): Participant | undefined;
 // @public
 export function useMaybeRoomContext(): Room | undefined;
 
-// @public
+// @beta
 export function useMaybeSessionContext(): UseSessionReturn | undefined;
 
 // @public
@@ -1206,21 +1206,21 @@ export type UseSequentialRoomConnectDisconnectResults<R extends Room | undefined
 
 // Warning: (ae-forgotten-export) The symbol "UseSessionConfigurableOptions" needs to be exported by the entry point index.docs.d.ts
 //
-// @public
+// @beta
 export function useSession(tokenSource: TokenSourceConfigurable, options?: UseSessionConfigurableOptions): UseSessionReturn;
 
 // Warning: (ae-forgotten-export) The symbol "UseSessionFixedOptions" needs to be exported by the entry point index.docs.d.ts
 //
-// @public
+// @beta
 export function useSession(tokenSource: TokenSourceFixed, options?: UseSessionFixedOptions): UseSessionReturn;
 
-// @public
+// @beta
 export function useSessionContext(): UseSessionReturn;
 
-// @public (undocumented)
+// @beta (undocumented)
 export function useSessionMessages(session?: UseSessionReturn): UseSessionMessagesReturn;
 
-// @public (undocumented)
+// @beta (undocumented)
 export type UseSessionMessagesReturn = {
     messages: Array<ReceivedMessage>;
     isSending: boolean;
@@ -1235,7 +1235,7 @@ export type UseSessionMessagesReturn = {
 // Warning: (ae-forgotten-export) The symbol "SessionStateDisconnected" needs to be exported by the entry point index.docs.d.ts
 // Warning: (ae-forgotten-export) The symbol "SessionActions" needs to be exported by the entry point index.docs.d.ts
 //
-// @public (undocumented)
+// @beta (undocumented)
 export type UseSessionReturn = (SessionStateConnecting | SessionStateConnected | SessionStateDisconnected) & SessionActions;
 
 // @public

--- a/packages/react/src/components/SessionProvider.tsx
+++ b/packages/react/src/components/SessionProvider.tsx
@@ -3,7 +3,7 @@ import { UseSessionReturn } from '../hooks';
 import { RoomContext } from '../context';
 import { SessionContext } from '../context/session-context';
 
-/** @public */
+/** @beta */
 export type SessionProviderProps = {
   session: UseSessionReturn;
   children: React.ReactNode;
@@ -11,7 +11,7 @@ export type SessionProviderProps = {
 
 /**
  * The `SessionProvider` component instantiates a SessionContext from the return of useSession
- * @public
+ * @beta
  */
 export function SessionProvider(props: SessionProviderProps) {
   return (

--- a/packages/react/src/context/session-context.ts
+++ b/packages/react/src/context/session-context.ts
@@ -8,7 +8,7 @@ export const SessionContext = React.createContext<UseSessionReturn | undefined>(
 /**
  * Ensures that a session is provided via context.
  * If no session is provided, an error is thrown.
- * @public
+ * @beta
  */
 export function useSessionContext() {
   const ctx = React.useContext(SessionContext);
@@ -20,7 +20,7 @@ export function useSessionContext() {
 
 /**
  * Returns the session context if it exists, otherwise undefined.
- * @public
+ * @beta
  */
 export function useMaybeSessionContext() {
   return React.useContext(SessionContext);
@@ -29,7 +29,7 @@ export function useMaybeSessionContext() {
 /**
  * Ensures that a session is provided, either via context or explicitly as a parameter.
  * If no session is provided, an error is thrown.
- * @public
+ * @beta
  */
 export function useEnsureSession(session?: UseSessionReturn) {
   const context = useMaybeSessionContext();

--- a/packages/react/src/hooks/useAgent.ts
+++ b/packages/react/src/hooks/useAgent.ts
@@ -38,7 +38,7 @@ type AgentSdkStates = 'initializing' | 'idle' | 'listening' | 'thinking' | 'spea
  * Legacy useVoiceAssistant hook:
  *   disconnected ➡️ connecting ➡️ initializing ➡️ listening/thinking/speaking
  *
- * @public
+ * @beta
  * */
 export type AgentState =
   | 'disconnected'
@@ -47,14 +47,14 @@ export type AgentState =
   | 'failed'
   | AgentSdkStates;
 
-/** @public */
+/** @beta */
 export enum AgentEvent {
   CameraChanged = 'cameraChanged',
   MicrophoneChanged = 'microphoneChanged',
   StateChanged = 'stateChanged',
 }
 
-/** @public */
+/** @beta */
 export type AgentCallbacks = {
   [AgentEvent.CameraChanged]: (newTrack: TrackReference | undefined) => void;
   [AgentEvent.MicrophoneChanged]: (newTrack: TrackReference | undefined) => void;
@@ -253,7 +253,7 @@ type AgentStateCases =
   | AgentStateUnAvailable
   | AgentStateFailed;
 
-/** @public */
+/** @beta */
 export type UseAgentReturn = AgentStateCases & AgentActions;
 
 const generateDerivedStateValues = <State extends AgentState>(state: State) =>
@@ -460,7 +460,7 @@ function useAgentWaitUntilDerivedStates(
 
 /**
  * useAgent encapculates all agent state, normalizing some quirks around how LiveKit Agents work.
- * @public
+ * @beta
  */
 export function useAgent(session?: SessionStub): UseAgentReturn {
   const sessionFromContext = useMaybeSessionContext();

--- a/packages/react/src/hooks/useSession.ts
+++ b/packages/react/src/hooks/useSession.ts
@@ -19,7 +19,7 @@ import { AgentState, useAgent, useAgentTimeoutIdStore } from './useAgent';
 import { TrackReference } from '@livekit/components-core';
 import { useLocalParticipant } from './useLocalParticipant';
 
-/** @public */
+/** @beta */
 export enum SessionEvent {
   ConnectionStateChanged = 'connectionStateChanged',
   /**
@@ -35,14 +35,14 @@ export enum SessionEvent {
   EncryptionError = 'encryptionError',
 }
 
-/** @public */
+/** @beta */
 export type SessionCallbacks = {
   [SessionEvent.ConnectionStateChanged]: (newAgentConnectionState: ConnectionState) => void;
   [SessionEvent.MediaDevicesError]: (error: Error) => void;
   [SessionEvent.EncryptionError]: (error: Error) => void;
 };
 
-/** @public */
+/** @beta */
 export type SessionConnectOptions = {
   /** Optional abort signal which if triggered will terminate connecting even if it isn't complete */
   signal?: AbortSignal;
@@ -58,7 +58,7 @@ export type SessionConnectOptions = {
   roomConnectOptions?: RoomConnectOptions;
 };
 
-/** @public */
+/** @beta */
 export type SwitchActiveDeviceOptions = {
   /**
    *  If true, adds an `exact` constraint to the getUserMedia request.
@@ -130,7 +130,7 @@ type SessionActions = {
   end: () => Promise<void>;
 };
 
-/** @public */
+/** @beta */
 export type UseSessionReturn = (
   | SessionStateConnecting
   | SessionStateConnected
@@ -280,7 +280,7 @@ function useSessionTokenSourceFetch(
 
 /**
  * A Session represents a managed connection to a Room which can contain Agents.
- * @public
+ * @beta
  */
 export function useSession(
   tokenSource: TokenSourceConfigurable,
@@ -288,7 +288,7 @@ export function useSession(
 ): UseSessionReturn;
 /**
  * A Session represents a managed connection to a Room which can contain Agents.
- * @public
+ * @beta
  */
 export function useSession(
   tokenSource: TokenSourceFixed,

--- a/packages/react/src/hooks/useSessionMessages.ts
+++ b/packages/react/src/hooks/useSessionMessages.ts
@@ -16,7 +16,7 @@ import { useChat } from './useChat';
 import { UseSessionReturn } from './useSession';
 import { useEnsureSession } from '../context';
 
-/** @public */
+/** @beta */
 export type UseSessionMessagesReturn = {
   messages: Array<ReceivedMessage>;
 
@@ -30,7 +30,7 @@ export type UseSessionMessagesReturn = {
   };
 };
 
-/** @public */
+/** @beta */
 export enum MessagesEvent {
   /**
    * Emits when a new message is received from a participant
@@ -39,12 +39,12 @@ export enum MessagesEvent {
   MessageReceived = 'messageReceived',
 }
 
-/** @public */
+/** @beta */
 export type MessagesCallbacks = {
   [MessagesEvent.MessageReceived]: (message: ReceivedMessage) => void;
 };
 
-/** @public */
+/** @beta */
 export function useSessionMessages(session?: UseSessionReturn): UseSessionMessagesReturn {
   const { room } = useEnsureSession(session);
 


### PR DESCRIPTION
- Migrated `@public` -> `@beta` in a bunch of spots
- Reran `api-extractor` in `packages/react` and `packages/core`