### PR TITLE
Correct ChatToggle 🆚 ToggleChat

### DIFF
--- a/packages/react/src/components/controls/ChatToggle.tsx
+++ b/packages/react/src/components/controls/ChatToggle.tsx
@@ -12,7 +12,7 @@ export interface ChatToggleProps extends React.ButtonHTMLAttributes<HTMLButtonEl
  * @example
  * ```tsx
  * <LiveKitRoom>
- *   <ToggleChat />
+ *   <ChatToggle />
  * </LiveKitRoom>
  * ```
  * @public


### PR DESCRIPTION
It appears this may have been a mistake left over from an earlier version...?