### PR TITLE
Add new useRpc hook prototype

### DIFF
--- a/.changeset/wild-ways-enter.md
+++ b/.changeset/wild-ways-enter.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Add new useRpc hook

--- a/examples/nextjs/pages/simple.tsx
+++ b/examples/nextjs/pages/simple.tsx
@@ -13,6 +13,8 @@ import {
   useTracks,
   SessionEvent,
   useEvents,
+  useRpc,
+  rpc,
 } from '@livekit/components-react';
 import { Track, TokenSource, MediaDeviceFailure } from 'livekit-client';
 import type { NextPage } from 'next';
@@ -70,6 +72,26 @@ const SimpleExample: NextPage = () => {
       'Error acquiring camera or microphone permissions. Please make sure you grant the necessary permissions in your browser and reload the tab',
     );
   }, []);
+
+  const { performRpc } = useRpc(session, {
+    getUserLocation: rpc.json(async (payload: { highAccuracy: boolean }, data) => {
+      const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, {
+          enableHighAccuracy: payload.highAccuracy,
+          timeout: data.responseTimeout * 1000,
+        });
+      });
+      return {
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+      };
+    }),
+  });
+
+  // const result = await performRpc(rpc.json<{ text: string }, { summary: string }>({
+  //   method: 'getUserLocation',
+  //   payload: { highAccuracy: true },
+  // });
 
   return (
     <div className={styles.container} data-lk-theme="default">

--- a/examples/nextjs/pages/simple.tsx
+++ b/examples/nextjs/pages/simple.tsx
@@ -88,10 +88,7 @@ const SimpleExample: NextPage = () => {
     }),
   });
 
-  // const result = await performRpc(rpc.json<{ text: string }, { summary: string }>({
-  //   method: 'getUserLocation',
-  //   payload: { highAccuracy: true },
-  // });
+  const [participantIdentity, setParticipantIdentity] = useState('');
 
   return (
     <div className={styles.container} data-lk-theme="default">
@@ -104,6 +101,19 @@ const SimpleExample: NextPage = () => {
             {connect ? 'Disconnect' : 'Connect'}
           </button>
         )}
+
+        <input type="text" placeholder="participant id" value={participantIdentity} onChange={e => setParticipantIdentity(e.target.value)} />
+        <button onClick={async () => {
+          const result = await performRpc(rpc.json<{ highAccuracy: boolean }, { latitude: number; longitude: number }>({
+            destinationIdentity: participantIdentity,
+            method: 'getUserLocation',
+            payload: { highAccuracy: true },
+          }));
+          console.log('Result:', result);
+        }}>
+          Call getUserLocation
+        </button>
+
         <SessionProvider session={session}>
           <RoomName />
           <ConnectionState />

--- a/examples/nextjs/pages/simple.tsx
+++ b/examples/nextjs/pages/simple.tsx
@@ -13,8 +13,6 @@ import {
   useTracks,
   SessionEvent,
   useEvents,
-  useRpc,
-  rpc,
 } from '@livekit/components-react';
 import { Track, TokenSource, MediaDeviceFailure } from 'livekit-client';
 import type { NextPage } from 'next';
@@ -73,23 +71,6 @@ const SimpleExample: NextPage = () => {
     );
   }, []);
 
-  const { performRpc } = useRpc(session, {
-    getUserLocation: rpc.json(async (payload: { highAccuracy: boolean }, data) => {
-      const position = await new Promise<GeolocationPosition>((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(resolve, reject, {
-          enableHighAccuracy: payload.highAccuracy,
-          timeout: data.responseTimeout * 1000,
-        });
-      });
-      return {
-        latitude: position.coords.latitude,
-        longitude: position.coords.longitude,
-      };
-    }),
-  });
-
-  const [participantIdentity, setParticipantIdentity] = useState('');
-
   return (
     <div className={styles.container} data-lk-theme="default">
       <main className={styles.main}>
@@ -101,19 +82,6 @@ const SimpleExample: NextPage = () => {
             {connect ? 'Disconnect' : 'Connect'}
           </button>
         )}
-
-        <input type="text" placeholder="participant id" value={participantIdentity} onChange={e => setParticipantIdentity(e.target.value)} />
-        <button onClick={async () => {
-          const result = await performRpc(rpc.json<{ highAccuracy: boolean }, { latitude: number; longitude: number }>({
-            destinationIdentity: participantIdentity,
-            method: 'getUserLocation',
-            payload: { highAccuracy: true },
-          }));
-          console.log('Result:', result);
-        }}>
-          Call getUserLocation
-        </button>
-
         <SessionProvider session={session}>
           <RoomName />
           <ConnectionState />

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -373,6 +373,11 @@ export interface GridLayoutProps extends React_2.HTMLAttributes<HTMLDivElement>,
 
 export { isTrackReference }
 
+// Warning: (ae-internal-missing-underscore) The name "isUseSessionReturn" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export function isUseSessionReturn(value: unknown): value is UseSessionReturn;
+
 // @public (undocumented)
 export const LayoutContext: React_2.Context<LayoutContextType | undefined>;
 
@@ -1237,19 +1242,14 @@ export interface UseRoomInfoOptions {
 // Warning: (ae-forgotten-export) The symbol "SerializerOutput" needs to be exported by the entry point index.docs.d.ts
 //
 // @beta
-export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(session: UseSessionReturn, methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
+export function useRpc<S extends Serializer<any, any>>(session: UseSessionReturn, methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
 
-// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "Serializer" which is marked as @beta
-// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "RpcHandler" which is marked as @beta
-// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "UseRpcOptions" which is marked as @beta
-// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "UseRpcReturn" which is marked as @beta
-//
-// @public (undocumented)
-export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
+// @beta (undocumented)
+export function useRpc<S extends Serializer<any, any>>(methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
 
 // @beta
 export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>> = {
-    from?: string | Participant;
+    fromIdentity?: string;
     serializer?: S;
 };
 

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -675,20 +675,6 @@ export const ScreenShareIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.El
 // @internal (undocumented)
 export const ScreenShareStopIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
 
-// @beta
-export type Serializer<Input = any, Output = any> = {
-    symbol: typeof SerializerSymbol;
-    parse: (raw: string) => Input;
-    serialize: (val: Output) => string;
-};
-
-// @beta
-export const serializers: {
-    json: typeof json;
-    raw: typeof raw;
-    custom: typeof custom;
-};
-
 // @beta (undocumented)
 export type SessionCallbacks = {
     [SessionEvent.ConnectionStateChanged]: (newAgentConnectionState: ConnectionState_2) => void;
@@ -1525,9 +1511,6 @@ export { WidgetState }
 //
 // src/context/layout-context.ts:10:3 - (ae-forgotten-export) The symbol "PinContextType" needs to be exported by the entry point index.docs.d.ts
 // src/context/layout-context.ts:11:3 - (ae-forgotten-export) The symbol "WidgetContextType" needs to be exported by the entry point index.docs.d.ts
-// src/hooks/useRpc.ts:95:25 - (ae-forgotten-export) The symbol "json" needs to be exported by the entry point index.docs.d.ts
-// src/hooks/useRpc.ts:95:25 - (ae-forgotten-export) The symbol "raw" needs to be exported by the entry point index.docs.d.ts
-// src/hooks/useRpc.ts:95:25 - (ae-forgotten-export) The symbol "custom" needs to be exported by the entry point index.docs.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -35,6 +35,7 @@ import { ParticipantClickEvent } from '@livekit/components-core';
 import { ParticipantEvent } from 'livekit-client';
 import { ParticipantIdentifier } from '@livekit/components-core';
 import { ParticipantPermission } from '@livekit/protocol';
+import { PerformRpcParams } from 'livekit-client';
 import { PinState } from '@livekit/components-core';
 import * as React_2 from 'react';
 import { ReceivedAgentTranscriptionMessage } from '@livekit/components-core';
@@ -49,6 +50,7 @@ import { Room } from 'livekit-client';
 import { RoomConnectOptions } from 'livekit-client';
 import { RoomEvent } from 'livekit-client';
 import { RoomOptions } from 'livekit-client';
+import { RpcInvocationData } from 'livekit-client';
 import { ScreenShareCaptureOptions } from 'livekit-client';
 import { SendTextOptions } from 'livekit-client';
 import { setLogExtension } from '@livekit/components-core';
@@ -565,6 +567,12 @@ export interface ParticipantTileProps extends React_2.HTMLAttributes<HTMLDivElem
     trackRef?: TrackReferenceOrPlaceholder;
 }
 
+// @beta (undocumented)
+export type PerformRpcFn = {
+    <Output = string, Input = unknown>(params: RpcCallParams<Input>, serializer: Serializer<Output, Input>): Promise<Output>;
+    (params: PerformRpcParams): Promise<string>;
+};
+
 export { PinState }
 
 // @public
@@ -644,6 +652,14 @@ export interface RoomNameProps extends React_2.HTMLAttributes<HTMLSpanElement> {
     childrenPosition?: 'before' | 'after';
 }
 
+// @beta
+export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & {
+    payload: Payload;
+};
+
+// @beta (undocumented)
+export type RpcHandler<Input = any, Output = any> = (payload: Input, data: RpcInvocationData) => Promise<Output>;
+
 // Warning: (ae-internal-missing-underscore) The name "ScreenShareIcon" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -653,6 +669,20 @@ export const ScreenShareIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.El
 //
 // @internal (undocumented)
 export const ScreenShareStopIcon: (props: SVGProps<SVGSVGElement>) => React_2.JSX.Element;
+
+// @beta
+export type Serializer<Input = any, Output = any> = {
+    symbol: typeof SerializerSymbol;
+    parse: (raw: string) => Input;
+    serialize: (val: Output) => string;
+};
+
+// @beta
+export const serializers: {
+    json: <Input = any, Output = any>() => Serializer<Input, Output>;
+    raw: () => Serializer<string, string>;
+    custom: <Input = any, Output = any>(params: Omit<Serializer<Input, Output>, "symbol">) => Serializer<Input, Output>;
+};
 
 // @beta (undocumented)
 export type SessionCallbacks = {
@@ -1202,6 +1232,31 @@ export interface UseRoomInfoOptions {
     // (undocumented)
     room?: Room;
 }
+
+// Warning: (ae-forgotten-export) The symbol "SerializerInput" needs to be exported by the entry point index.docs.d.ts
+// Warning: (ae-forgotten-export) The symbol "SerializerOutput" needs to be exported by the entry point index.docs.d.ts
+//
+// @beta
+export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(session: UseSessionReturn, methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
+
+// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "Serializer" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "RpcHandler" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "UseRpcOptions" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "useRpc" is marked as @public, but its signature references "UseRpcReturn" which is marked as @beta
+//
+// @public (undocumented)
+export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
+
+// @beta
+export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>> = {
+    from?: string | Participant;
+    serializer?: S;
+};
+
+// @beta (undocumented)
+export type UseRpcReturn = {
+    performRpc: PerformRpcFn;
+};
 
 // @public
 export function useSequentialRoomConnectDisconnect<R extends Room | undefined>(room: R): UseSequentialRoomConnectDisconnectResults<R>;

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -53,6 +53,9 @@ import { RoomOptions } from 'livekit-client';
 import { RpcInvocationData } from 'livekit-client';
 import { ScreenShareCaptureOptions } from 'livekit-client';
 import { SendTextOptions } from 'livekit-client';
+import { Serializer } from 'livekit-client';
+import { SerializerInput } from 'livekit-client';
+import { SerializerOutput } from 'livekit-client';
 import { setLogExtension } from '@livekit/components-core';
 import { setLogLevel } from '@livekit/components-core';
 import { SetMediaDeviceOptions } from '@livekit/components-core';
@@ -651,12 +654,6 @@ export interface RoomNameProps extends React_2.HTMLAttributes<HTMLSpanElement> {
     childrenPosition?: 'before' | 'after';
 }
 
-// @beta (undocumented)
-export type RpcCallFn = {
-    <Output = string, Input = unknown>(params: RpcCallParams<Input>, serializer: Serializer<Output, Input>): Promise<Output>;
-    (params: PerformRpcParams): Promise<string>;
-};
-
 // @beta
 export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & {
     payload: Payload;
@@ -664,6 +661,12 @@ export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & {
 
 // @beta (undocumented)
 export type RpcHandler<Input = any, Output = any> = (payload: Input, data: RpcInvocationData) => Promise<Output>;
+
+// @beta (undocumented)
+export type RpcPerformFn = {
+    <Output = string, Input = unknown>(params: RpcCallParams<Input>, serializer: Serializer<Output, Input>): Promise<Output>;
+    (params: PerformRpcParams): Promise<string>;
+};
 
 // Warning: (ae-internal-missing-underscore) The name "ScreenShareIcon" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1224,9 +1227,6 @@ export interface UseRoomInfoOptions {
     room?: Room;
 }
 
-// Warning: (ae-forgotten-export) The symbol "SerializerInput" needs to be exported by the entry point index.docs.d.ts
-// Warning: (ae-forgotten-export) The symbol "SerializerOutput" needs to be exported by the entry point index.docs.d.ts
-//
 // @beta
 export function useRpc<S extends Serializer<any, any>>(session: UseSessionReturn, methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
 
@@ -1247,7 +1247,7 @@ export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>>
 
 // @beta (undocumented)
 export type UseRpcReturn = {
-    call: RpcCallFn;
+    perform: RpcPerformFn;
 };
 
 // @public

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -572,12 +572,6 @@ export interface ParticipantTileProps extends React_2.HTMLAttributes<HTMLDivElem
     trackRef?: TrackReferenceOrPlaceholder;
 }
 
-// @beta (undocumented)
-export type PerformRpcFn = {
-    <Output = string, Input = unknown>(params: RpcCallParams<Input>, serializer: Serializer<Output, Input>): Promise<Output>;
-    (params: PerformRpcParams): Promise<string>;
-};
-
 export { PinState }
 
 // @public
@@ -657,6 +651,12 @@ export interface RoomNameProps extends React_2.HTMLAttributes<HTMLSpanElement> {
     childrenPosition?: 'before' | 'after';
 }
 
+// @beta (undocumented)
+export type RpcCallFn = {
+    <Output = string, Input = unknown>(params: RpcCallParams<Input>, serializer: Serializer<Output, Input>): Promise<Output>;
+    (params: PerformRpcParams): Promise<string>;
+};
+
 // @beta
 export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & {
     payload: Payload;
@@ -684,9 +684,9 @@ export type Serializer<Input = any, Output = any> = {
 
 // @beta
 export const serializers: {
-    json: <Input = any, Output = any>() => Serializer<Input, Output>;
-    raw: () => Serializer<string, string>;
-    custom: <Input = any, Output = any>(params: Omit<Serializer<Input, Output>, "symbol">) => Serializer<Input, Output>;
+    json: typeof json;
+    raw: typeof raw;
+    custom: typeof custom;
 };
 
 // @beta (undocumented)
@@ -1247,6 +1247,12 @@ export function useRpc<S extends Serializer<any, any>>(session: UseSessionReturn
 // @beta (undocumented)
 export function useRpc<S extends Serializer<any, any>>(methodName: string, handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>, options?: UseRpcOptions<S>): UseRpcReturn;
 
+// @beta (undocumented)
+export function useRpc(session: UseSessionReturn): UseRpcReturn;
+
+// @beta (undocumented)
+export function useRpc(): UseRpcReturn;
+
 // @beta
 export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>> = {
     fromIdentity?: string;
@@ -1255,7 +1261,7 @@ export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>>
 
 // @beta (undocumented)
 export type UseRpcReturn = {
-    performRpc: PerformRpcFn;
+    call: RpcCallFn;
 };
 
 // @public
@@ -1519,6 +1525,9 @@ export { WidgetState }
 //
 // src/context/layout-context.ts:10:3 - (ae-forgotten-export) The symbol "PinContextType" needs to be exported by the entry point index.docs.d.ts
 // src/context/layout-context.ts:11:3 - (ae-forgotten-export) The symbol "WidgetContextType" needs to be exported by the entry point index.docs.d.ts
+// src/hooks/useRpc.ts:95:25 - (ae-forgotten-export) The symbol "json" needs to be exported by the entry point index.docs.d.ts
+// src/hooks/useRpc.ts:95:25 - (ae-forgotten-export) The symbol "raw" needs to be exported by the entry point index.docs.d.ts
+// src/hooks/useRpc.ts:95:25 - (ae-forgotten-export) The symbol "custom" needs to be exported by the entry point index.docs.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -70,3 +70,15 @@ export {
 } from './useAgent';
 export * from './useEvents';
 export * from './useSessionMessages';
+export {
+  type RpcRawHandler,
+  type RpcMethodDescriptor,
+  type RpcMethod,
+  type PerformRpcDescriptor,
+  type RpcJsonParams,
+  type UseRpcOptions,
+  type PerformRpcFn,
+  type UseRpcReturn,
+  rpc,
+  useRpc,
+} from './useRpc';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -71,14 +71,14 @@ export {
 export * from './useEvents';
 export * from './useSessionMessages';
 export {
-  type RpcRawHandler,
-  type RpcMethodDescriptor,
+  type Schema,
+  type BoundSchema,
+  type RpcHandler,
   type RpcMethod,
   type PerformRpcDescriptor,
-  type RpcJsonParams,
   type UseRpcOptions,
   type PerformRpcFn,
   type UseRpcReturn,
-  rpc,
+  schema,
   useRpc,
 } from './useRpc';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -71,14 +71,12 @@ export {
 export * from './useEvents';
 export * from './useSessionMessages';
 export {
-  type Schema,
-  type BoundSchema,
+  type Serializer,
   type RpcHandler,
-  type RpcMethod,
-  type PerformRpcDescriptor,
+  type RpcCallParams,
   type UseRpcOptions,
   type PerformRpcFn,
   type UseRpcReturn,
-  schema,
+  serializers,
   useRpc,
 } from './useRpc';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -71,12 +71,10 @@ export {
 export * from './useEvents';
 export * from './useSessionMessages';
 export {
-  type Serializer,
   type RpcHandler,
   type RpcCallParams,
   type UseRpcOptions,
   type RpcCallFn,
   type UseRpcReturn,
-  serializers,
   useRpc,
 } from './useRpc';

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -75,7 +75,7 @@ export {
   type RpcHandler,
   type RpcCallParams,
   type UseRpcOptions,
-  type PerformRpcFn,
+  type RpcCallFn,
   type UseRpcReturn,
   serializers,
   useRpc,

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -74,7 +74,7 @@ export {
   type RpcHandler,
   type RpcCallParams,
   type UseRpcOptions,
-  type RpcCallFn,
+  type RpcPerformFn,
   type UseRpcReturn,
   useRpc,
 } from './useRpc';

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -21,13 +21,18 @@ export type RpcMethodDescriptor<Input = string, Output = string> = {
 
 /** @beta */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RpcMethod<Input = any, Output = any> = RpcRawHandler | RpcMethodDescriptor<Input, Output>;
+export type RpcMethod<Input = any, Output = any> =
+  | RpcRawHandler
+  | RpcMethodDescriptor<Input, Output>;
 
 /** @beta */
-export type PerformRpcDescriptor<Input = string, Output = string> = Omit<PerformRpcParams, 'payload'> & {
+export type PerformRpcDescriptor<Input = string, Output = string> = Omit<
+  PerformRpcParams,
+  'payload'
+> & {
   parse?: (raw: string) => Output;
   serialize?: (val: Input) => string;
-  payload: Input,
+  payload: Input;
 };
 
 /** @beta */
@@ -39,7 +44,6 @@ export type UseRpcOptions = {
   /** Only accept RPCs from this participant. Others receive UNSUPPORTED_METHOD. */
   from?: string | Participant;
 };
-
 
 /**
  * Namespace for RPC helpers.
@@ -72,13 +76,15 @@ export const rpc = (() => {
   /* Overload: payload mode (for performRpc) */
   function json<Input, Output>(value: RpcJsonParams<Input>): PerformRpcDescriptor<Input, Output>;
   function json<Input, Output>(
-    handlerOrValue: RpcJsonParams<Input> | ((payload: Input, data: RpcInvocationData) => Promise<Output>)
+    handlerOrValue:
+      | RpcJsonParams<Input>
+      | ((payload: Input, data: RpcInvocationData) => Promise<Output>),
   ): RpcMethodDescriptor<Input, Output> | PerformRpcDescriptor<Input, Output> {
     if (typeof handlerOrValue === 'function') {
       return {
         parse: (raw: string) => JSON.parse(raw),
         serialize: (val: unknown) => JSON.stringify(val),
-        handler: handlerOrValue as RpcMethodDescriptor<Input, Output>["handler"],
+        handler: handlerOrValue as RpcMethodDescriptor<Input, Output>['handler'],
       };
     }
 
@@ -114,7 +120,10 @@ function isUseSessionReturn(value: unknown): value is UseSessionReturn {
   );
 }
 
-async function resolveHandler<Input, Output>(method: RpcMethod<Input, Output>, data: RpcInvocationData): Promise<string> {
+async function resolveHandler<Input, Output>(
+  method: RpcMethod<Input, Output>,
+  data: RpcInvocationData,
+): Promise<string> {
   if (typeof method === 'function') {
     return method(data);
   }
@@ -138,7 +147,7 @@ async function resolveHandler<Input, Output>(method: RpcMethod<Input, Output>, d
     } catch (e) {
       throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
     }
-  } else if (typeof result !== "string") {
+  } else if (typeof result !== 'string') {
     throw RpcError.builtIn(
       'APPLICATION_ERROR',
       `Failed to serialize RPC response: return value from handler function not string. Did you mean to include a "serialize" RpcMethod key?`,
@@ -183,10 +192,7 @@ export function useRpc(
   methods?: Record<string, RpcMethod>,
   options?: UseRpcOptions,
 ): UseRpcReturn;
-export function useRpc(
-  methods?: Record<string, RpcMethod>,
-  options?: UseRpcOptions,
-): UseRpcReturn;
+export function useRpc(methods?: Record<string, RpcMethod>, options?: UseRpcOptions): UseRpcReturn;
 export function useRpc(
   methodsOrSession?: Record<string, RpcMethod> | UseSessionReturn,
   optionsOrMethods?: UseRpcOptions | Record<string, RpcMethod>,
@@ -235,7 +241,10 @@ export function useRpc(
         const from = optionsRef.current?.from;
         const fromIdentity = typeof from === 'string' ? from : from?.identity;
         if (fromIdentity && data.callerIdentity !== fromIdentity) {
-          throw RpcError.builtIn('UNSUPPORTED_METHOD', `Method not available for caller ${data.callerIdentity}`);
+          throw RpcError.builtIn(
+            'UNSUPPORTED_METHOD',
+            `Method not available for caller ${data.callerIdentity}`,
+          );
         }
 
         // Resolve the latest handler from the ref

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -1,0 +1,278 @@
+import * as React from 'react';
+import {
+  type Participant,
+  RpcError,
+  type RpcInvocationData,
+  type PerformRpcParams,
+} from 'livekit-client';
+
+import { useEnsureSession } from '../context';
+import type { UseSessionReturn } from './useSession';
+
+/** @beta */
+export type RpcRawHandler = (data: RpcInvocationData) => Promise<string>;
+
+/** @beta */
+export type RpcMethodDescriptor<Input = string, Output = string> = {
+  parse?: (raw: string) => Input;
+  serialize?: (val: Output) => string;
+  handler: (payload: Input, context: RpcInvocationData) => Promise<Output>;
+};
+
+/** @beta */
+export type RpcMethod<Input = unknown, Output = unknown> = RpcRawHandler | RpcMethodDescriptor<Input, Output>;
+
+type PerformRpcDescriptor<Input = string, Output = string> = Omit<PerformRpcParams, 'payload'> & {
+  parse?: (raw: string) => Output;
+  serialize?: (val: Input) => string;
+  payload: Input,
+};
+
+/** @beta */
+export type RpcJsonParams<Input = unknown> = Omit<PerformRpcParams, 'payload'> & { payload: Input };
+
+/** Options for {@link useRpc}.
+ * @beta */
+export type UseRpcOptions = {
+  /** Only accept RPCs from this participant. Others receive UNSUPPORTED_METHOD. */
+  from?: string | Participant;
+};
+
+
+/**
+ * Namespace for RPC helpers.
+ *
+ * `rpc.json` can be used in two ways:
+ *
+ * **Handler mode** (for registering methods via {@link useRpc}):
+ * ```ts
+ * useRpc({
+ *   myMethod: rpc.json(async (payload: MyInput, ctx) => {
+ *     return { result: 'value' };
+ *   }),
+ * });
+ * ```
+ *
+ * **Payload mode** (for outbound calls via `performRpc`):
+ * ```ts
+ * const result = await performRpc(rpc.json<MyInput, MyOutput>(
+ *   { destinationIdentity: '...', method: 'myMethod', payload: { key: 'value' } },
+ * ));
+ * ```
+ *
+ * @beta
+ */
+export const rpc = (() => {
+  /* Overload: handler mode (for useRpc methods record) */
+  function json<Input, Output>(
+    handler: (payload: Input, data: RpcInvocationData) => Promise<Output>,
+  ): RpcMethodDescriptor<Input, Output>;
+  /* Overload: payload mode (for performRpc) */
+  function json<Input, Output>(value: RpcJsonParams<Input>): PerformRpcDescriptor<Output>;
+  function json<Input, Output>(
+    handlerOrValue: RpcJsonParams<Input> | ((payload: Input, data: RpcInvocationData) => Promise<Output>)
+  ): RpcMethodDescriptor<Input, Output> | PerformRpcDescriptor<Input, Output> {
+    if (typeof handlerOrValue === 'function') {
+      return {
+        parse: (raw: string) => JSON.parse(raw),
+        serialize: (val: unknown) => JSON.stringify(val),
+        handler: handlerOrValue as RpcMethodDescriptor<Input, Output>["handler"],
+      };
+    }
+
+    return {
+      ...handlerOrValue,
+      parse: (raw: string) => JSON.parse(raw),
+      serialize: (val: unknown) => JSON.stringify(val),
+    };
+  }
+
+  return {
+    json,
+  };
+})();
+
+/** @beta */
+export type PerformRpcFn = {
+  <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>): Promise<Output>;
+};
+
+/** @beta */
+export type UseRpcReturn = {
+  performRpc: PerformRpcFn;
+};
+
+async function resolveHandler<Input, Output>(method: RpcMethod<Input, Output>, data: RpcInvocationData): Promise<string> {
+  if (typeof method === 'function') {
+    return method(data);
+  }
+
+  let parsed: Input;
+  if (method.parse) {
+    try {
+      parsed = method.parse(data.payload);
+    } catch (e) {
+      throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
+    }
+  } else {
+    parsed = data.payload as Input;
+  }
+
+  const result = await method.handler(parsed, data);
+
+  if (method.serialize) {
+    try {
+      return method.serialize(result);
+    } catch (e) {
+      throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
+    }
+  } else if (typeof result !== "string") {
+    throw RpcError.builtIn(
+      'APPLICATION_ERROR',
+      `Failed to serialize RPC response: return value from handler function not string. Did you mean to include a "serialize" RpcMethod key?`,
+    );
+  } else {
+    return result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useRpc hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook for declarative RPC method registration and outbound RPC calls.
+ *
+ * Registers handler functions for incoming RPC method calls and returns a `performRpc` function
+ * for making outbound RPC calls to other participants.
+ *
+ * Handlers are registered on mount and unregistered on unmount. The effect lifecycle is driven
+ * by the set of method names — handler function identity does not matter (they are captured by
+ * ref), so inline functions work without `useCallback`.
+ *
+ * @example
+ * ```tsx
+ * const { performRpc } = useRpc({
+ *   // JSON handler via preset
+ *   getUserLocation: rpc.json(async (payload: { highAccuracy: boolean }, ctx) => {
+ *     const pos = await getPosition(payload.highAccuracy);
+ *     return { lat: pos.coords.latitude, lng: pos.coords.longitude };
+ *   }),
+ *
+ *   // Raw string handler
+ *   getTimezone: async (data) => Intl.DateTimeFormat().resolvedOptions().timeZone,
+ * }, { from: session.agent });
+ * ```
+ *
+ * @beta
+ */
+export function useRpc(
+  methods?: Record<string, RpcMethod>,
+  options?: UseRpcOptions,
+): UseRpcReturn;
+export function useRpc(
+  session?: UseSessionReturn,
+  methods?: Record<string, RpcMethod>,
+  options?: UseRpcOptions,
+): UseRpcReturn;
+export function useRpc(
+  methodsOrSession?: Record<string, RpcMethod> | UseSessionReturn,
+  optionsOrMethods?: UseRpcOptions | Record<string, RpcMethod>,
+  maybeOptions?: UseRpcOptions,
+): UseRpcReturn {
+  let methods, options, session;
+  if (methodsOrSession?.room) {
+    session = methodsOrSession as UseSessionReturn;
+    methods = optionsOrMethods as Record<string, RpcMethod>;
+    options = maybeOptions!;
+  } else {
+    methods = methodsOrSession as Record<string, RpcMethod>;
+    options = optionsOrMethods as UseRpcOptions;
+  }
+
+  const { room } = useEnsureSession(session);
+
+  // Ref that always holds the latest handlers — updated synchronously on render
+  const handlersRef = React.useRef(methods);
+  handlersRef.current = methods;
+
+  // Ref that always holds the latest options (for participant filter)
+  const optionsRef = React.useRef(options);
+  optionsRef.current = options;
+
+  // Derive a stable string from the sorted method name set for the effect dependency.
+  // The effect only re-runs when methods are added or removed, not when handler bodies change.
+  const methodNamesEffectKey = React.useMemo(
+    () =>
+      Object.keys(methods ?? {})
+        .sort()
+        .join('\0'),
+    [methods],
+  );
+
+  React.useEffect(() => {
+    const currentMethods = handlersRef.current ?? {};
+    const names = Object.keys(currentMethods);
+
+    for (const name of names) {
+      room.registerRpcMethod(name, async (data: RpcInvocationData) => {
+        // Participant filter
+        const from = optionsRef.current?.from;
+        const fromIdentity = typeof from === 'string' ? from : from?.identity;
+        if (fromIdentity && data.callerIdentity !== fromIdentity) {
+          throw RpcError.builtIn('UNSUPPORTED_METHOD', `Method not available for caller ${data.callerIdentity}`);
+        }
+
+        // Resolve the latest handler from the ref
+        const handler = handlersRef.current?.[name];
+        if (!handler) {
+          throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${name}"`);
+        }
+
+        return resolveHandler(handler, data);
+      });
+    }
+
+    return () => {
+      for (const name of names) {
+        room.unregisterRpcMethod(name);
+      }
+    };
+  }, [room, methodNamesEffectKey]);
+
+  // Stable performRpc function with overloads
+  const performRpc: PerformRpcFn = React.useCallback(
+    async <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>) => {
+      let serialized: string;
+      if (params.serialize) {
+        try {
+          serialized = params.serialize(params.payload);
+        } catch (e) {
+          throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC payload: ${e}`);
+        }
+      } else {
+        serialized = params.payload as string;
+      }
+
+      const rawResponse = await room.localParticipant.performRpc({
+        destinationIdentity: params.destinationIdentity,
+        method: params.method,
+        payload: serialized,
+        responseTimeout: params.responseTimeout,
+      });
+
+      if (params.parse) {
+        try {
+          return params.parse(rawResponse);
+        } catch (e) {
+          throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
+        }
+      } else {
+        return rawResponse as Output;
+      }
+    },
+    [room],
+  );
+
+  return React.useMemo(() => ({ performRpc }), [performRpc]);
+}

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -10,19 +10,22 @@ import { useEnsureSession } from '../context';
 import type { UseSessionReturn } from './useSession';
 
 /** @beta */
-export type RpcRawHandler = (data: RpcInvocationData) => Promise<string>;
+export type RpcHandler<Input = any, Output = any> = (
+  payload: Input,
+  data: RpcInvocationData,
+) => Promise<Output>;
 
 /** @beta */
 export type RpcMethodDescriptor<Input = string, Output = string> = {
   parse?: (raw: string) => Input;
   serialize?: (val: Output) => string;
-  handler: (payload: Input, context: RpcInvocationData) => Promise<Output>;
+  handler: RpcHandler<Input, Output>;
 };
 
 /** @beta */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RpcMethod<Input = any, Output = any> =
-  | RpcRawHandler
+  | RpcHandler<Input, Output>
   | RpcMethodDescriptor<Input, Output>;
 
 /** @beta */
@@ -43,6 +46,10 @@ export type RpcJsonParams<Input = unknown> = Omit<PerformRpcParams, 'payload'> &
 export type UseRpcOptions = {
   /** Only accept RPCs from this participant. Others receive UNSUPPORTED_METHOD. */
   from?: string | Participant;
+
+  defaultSerializer?: <Input, Output>(
+    handler: (payload: Input, data: RpcInvocationData) => Promise<Output>,
+  ) => RpcMethodDescriptor<Input, Output>;
 };
 
 /**
@@ -95,8 +102,35 @@ export const rpc = (() => {
     };
   }
 
+  /* Overload: handler mode (for useRpc methods record) */
+  function raw(
+    handler: (payload: string, data: RpcInvocationData) => Promise<string>,
+  ): RpcMethodDescriptor<string, string>;
+  /* Overload: payload mode (for performRpc) */
+  function raw(value: RpcJsonParams<string>): PerformRpcDescriptor<string, string>;
+  function raw(
+    handlerOrValue:
+      | RpcJsonParams<string>
+      | ((payload: string, data: RpcInvocationData) => Promise<string>),
+  ): RpcMethodDescriptor<string, string> | PerformRpcDescriptor<string, string> {
+    if (typeof handlerOrValue === 'function') {
+      return {
+        parse: (raw: string) => raw,
+        serialize: (val: string) => val,
+        handler: handlerOrValue,
+      };
+    }
+
+    return {
+      ...handlerOrValue,
+      parse: (raw: string) => raw,
+      serialize: (val: string) => val,
+    };
+  }
+
   return {
     json,
+    raw,
   };
 })();
 
@@ -120,14 +154,10 @@ function isUseSessionReturn(value: unknown): value is UseSessionReturn {
   );
 }
 
-async function resolveHandler<Input, Output>(
-  method: RpcMethod<Input, Output>,
+async function resolveDescriptor<Input, Output>(
+  method: RpcMethodDescriptor<Input, Output>,
   data: RpcInvocationData,
 ): Promise<string> {
-  if (typeof method === 'function') {
-    return method(data);
-  }
-
   let parsed: Input;
   if (method.parse) {
     try {
@@ -253,7 +283,12 @@ export function useRpc(
           throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${name}"`);
         }
 
-        return resolveHandler(handler, data);
+        if (typeof handler === 'function') {
+          const serializer = options?.defaultSerializer ?? rpc.json;
+          return resolveDescriptor(serializer(handler), data);
+        } else {
+          return resolveDescriptor(handler, data);
+        }
       });
     }
 

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -20,9 +20,11 @@ export type RpcMethodDescriptor<Input = string, Output = string> = {
 };
 
 /** @beta */
-export type RpcMethod<Input = unknown, Output = unknown> = RpcRawHandler | RpcMethodDescriptor<Input, Output>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RpcMethod<Input = any, Output = any> = RpcRawHandler | RpcMethodDescriptor<Input, Output>;
 
-type PerformRpcDescriptor<Input = string, Output = string> = Omit<PerformRpcParams, 'payload'> & {
+/** @beta */
+export type PerformRpcDescriptor<Input = string, Output = string> = Omit<PerformRpcParams, 'payload'> & {
   parse?: (raw: string) => Output;
   serialize?: (val: Input) => string;
   payload: Input,
@@ -68,7 +70,7 @@ export const rpc = (() => {
     handler: (payload: Input, data: RpcInvocationData) => Promise<Output>,
   ): RpcMethodDescriptor<Input, Output>;
   /* Overload: payload mode (for performRpc) */
-  function json<Input, Output>(value: RpcJsonParams<Input>): PerformRpcDescriptor<Output>;
+  function json<Input, Output>(value: RpcJsonParams<Input>): PerformRpcDescriptor<Input, Output>;
   function json<Input, Output>(
     handlerOrValue: RpcJsonParams<Input> | ((payload: Input, data: RpcInvocationData) => Promise<Output>)
   ): RpcMethodDescriptor<Input, Output> | PerformRpcDescriptor<Input, Output> {
@@ -101,6 +103,16 @@ export type PerformRpcFn = {
 export type UseRpcReturn = {
   performRpc: PerformRpcFn;
 };
+
+function isUseSessionReturn(value: unknown): value is UseSessionReturn {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'room' in value &&
+    'connectionState' in value &&
+    'internal' in value
+  );
+}
 
 async function resolveHandler<Input, Output>(method: RpcMethod<Input, Output>, data: RpcInvocationData): Promise<string> {
   if (typeof method === 'function') {
@@ -167,11 +179,11 @@ async function resolveHandler<Input, Output>(method: RpcMethod<Input, Output>, d
  * @beta
  */
 export function useRpc(
+  session: UseSessionReturn,
   methods?: Record<string, RpcMethod>,
   options?: UseRpcOptions,
 ): UseRpcReturn;
 export function useRpc(
-  session?: UseSessionReturn,
   methods?: Record<string, RpcMethod>,
   options?: UseRpcOptions,
 ): UseRpcReturn;
@@ -180,14 +192,17 @@ export function useRpc(
   optionsOrMethods?: UseRpcOptions | Record<string, RpcMethod>,
   maybeOptions?: UseRpcOptions,
 ): UseRpcReturn {
-  let methods, options, session;
-  if (methodsOrSession?.room) {
-    session = methodsOrSession as UseSessionReturn;
-    methods = optionsOrMethods as Record<string, RpcMethod>;
-    options = maybeOptions!;
+  let methods: Record<string, RpcMethod> | undefined;
+  let options: UseRpcOptions | undefined;
+  let session: UseSessionReturn | undefined;
+
+  if (isUseSessionReturn(methodsOrSession)) {
+    session = methodsOrSession;
+    methods = optionsOrMethods as Record<string, RpcMethod> | undefined;
+    options = maybeOptions;
   } else {
-    methods = methodsOrSession as Record<string, RpcMethod>;
-    options = optionsOrMethods as UseRpcOptions;
+    methods = methodsOrSession;
+    options = optionsOrMethods as UseRpcOptions | undefined;
   }
 
   const { room } = useEnsureSession(session);

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -108,7 +108,7 @@ export type RpcHandler<Input = any, Output = any> = (
 export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & { payload: Payload };
 
 /**
- * Options for {@link useRpc}.
+ * Options for {@link (useRpc:1)}.
  * @beta
  */
 export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>> = {
@@ -164,6 +164,7 @@ export function useRpc<S extends Serializer<any, any>>(
   handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
+/** @beta */
 export function useRpc<S extends Serializer<any, any>>(
   methodName: string,
   handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -149,21 +149,12 @@ export type RpcMethod<Input = any, Output = any> =
   | BoundSchema<Schema<Input, Output>, RpcHandler<Input, Output>>;
 
 /**
- * Parameters for an outbound {@link PerformRpcFn} call.
- *
- * `schema` is from the *sender's* perspective: `parse` decodes the *response*
- * (`Output`) and `serialize` encodes the *request* (`Input`). This is the
- * type-flipped counterpart of the handler's schema — for symmetric schemas like
- * `schema.json()` and `schema.raw()` the flip is invisible.
+ * Base RPC call parameters with an arbitrary payload type (used when the payload
+ * will be serialized by a schema).
  *
  * @beta
  */
-export type PerformRpcDescriptor<Input = string, Output = string> = Omit<
-  PerformRpcParams,
-  'payload'
-> & {
-  payload: BoundSchema<Schema<Output, Input>, Input> | string;
-};
+export type RpcCallParams = Omit<PerformRpcParams, 'payload'> & { payload: unknown };
 
 /**
  * Options for {@link useRpc}.
@@ -220,7 +211,10 @@ function isUseSessionReturn(value: unknown): value is UseSessionReturn {
 
 /** @beta */
 export type PerformRpcFn = {
-  <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>): Promise<Output>;
+  /** Schema-wrapped call: payload is serialized and response is parsed by the schema. */
+  <Output = string>(params: BoundSchema<Schema<Output, any>, RpcCallParams>): Promise<Output>;
+  /** Plain call: payload is already a string, response is returned as a string. */
+  (params: PerformRpcParams): Promise<string>;
 };
 
 /** @beta */
@@ -348,33 +342,29 @@ export function useRpc(
 
   // Stable performRpc function
   const performRpc: PerformRpcFn = React.useCallback(
-    async <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>) => {
-      let serialized: string;
-      if (isBoundSchema(params.payload)) {
+    async (params: BoundSchema<Schema<any, any>, RpcCallParams> | PerformRpcParams) => {
+      if (isBoundSchema(params)) {
+        const rpcParams = params.value as RpcCallParams;
+        let serialized: string;
         try {
-          serialized = params.payload.serialize(params.payload.value);
+          serialized = params.serialize(rpcParams.payload);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC payload: ${e}`);
         }
-      } else {
-        serialized = params.payload as string;
-      }
-
-      const rawResponse = await room.localParticipant.performRpc({
-        destinationIdentity: params.destinationIdentity,
-        method: params.method,
-        payload: serialized,
-        responseTimeout: params.responseTimeout,
-      });
-
-      if (isBoundSchema(params.payload)) {
+        const rawResponse = await room.localParticipant.performRpc({
+          destinationIdentity: rpcParams.destinationIdentity,
+          method: rpcParams.method,
+          payload: serialized,
+          responseTimeout: rpcParams.responseTimeout,
+        });
         try {
-          return params.payload.parse(rawResponse);
+          return params.parse(rawResponse);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC response: ${e}`);
         }
+      } else {
+        return room.localParticipant.performRpc(params);
       }
-      return rawResponse as Output;
     },
     [room],
   );

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -170,6 +170,10 @@ export function useRpc<S extends Serializer<any, any>>(
   handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
+/** @beta */
+export function useRpc(session: UseSessionReturn): UseRpcReturn;
+/** @beta */
+export function useRpc(): UseRpcReturn;
 export function useRpc(
   methodNameOrSession?: string | UseSessionReturn,
   handlerOrMethodName?: RpcHandler<any, any> | string,

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -32,14 +32,6 @@ export type Schema<Input = any, Output = any> = {
   serialize: (val: Output) => string;
 };
 
-/**
- * A {@link Schema} with a bound value — used to associate a handler or payload
- * with its schema in a single object.
- *
- * @beta
- */
-export type BoundSchema<S extends Schema<any, any>, V> = S & { value: V };
-
 function isSchema(v: unknown): v is Schema<any, any> {
   return (
     typeof v === 'object' &&
@@ -49,9 +41,9 @@ function isSchema(v: unknown): v is Schema<any, any> {
   );
 }
 
-function isBoundSchema(v: unknown): v is BoundSchema<Schema<any, any>, unknown> {
-  return isSchema(v) && 'value' in (v as object);
-}
+// Extract Input/Output from a Schema type for use in handler/performRpc constraints.
+type SchemaInput<S> = S extends Schema<infer Input, any> ? Input : any;
+type SchemaOutput<S> = S extends Schema<any, infer Output> ? Output : any;
 
 // ---------------------------------------------------------------------------
 // schema namespace
@@ -60,24 +52,17 @@ function isBoundSchema(v: unknown): v is BoundSchema<Schema<any, any>, unknown> 
 /**
  * Schema helpers for RPC payload encoding.
  *
- * Each function has three call forms:
- * - **No argument** — returns a plain `Schema` for use as a `defaultSchema` option or manual use
- * - **Handler argument** — infers `Input`/`Output` from the handler, returns a `BoundSchema`
- *   for inline registration in {@link useRpc}
- * - **Any other value** — returns a `BoundSchema` with that value attached (e.g. for `performRpc`)
- *
  * @example
  * ```ts
  * // Inline handler — types inferred
- * useRpc({ myMethod: schema.json(async (payload: MyInput) => myOutput) });
+ * useRpc({ myMethod: async (payload: MyInput) => myOutput }, { schema: schema.json() });
  *
  * // Override default schema for all plain handlers in this hook
- * useRpc({ myMethod: async (payload) => payload }, { defaultSchema: schema.raw() });
+ * useRpc({ myMethod: async (payload) => payload }, { schema: schema.raw() });
  *
  * // Manual schema instances
- * const a = schema.raw();                             // Schema<string, string>
+ * const a = schema.raw(); // Schema<string, string>
  * const b = schema.json<{ foo: string }, { bar: string }>(); // Schema<{ foo: string }, { bar: string }>
- * const c = schema.json<{ foo: string }, { bar: string }>(myPayload); // BoundSchema<..., typeof myPayload>
  * ```
  *
  * @beta
@@ -87,40 +72,27 @@ export const schema = (() => {
    * JSON schema — `JSON.parse` on the way in, `JSON.stringify` on the way out.
    * Defaults to `any` so individual handlers can annotate their own payload types.
    */
-  function json<Input, Output>(
-    handler: RpcHandler<Input, Output>,
-  ): BoundSchema<Schema<Input, Output>, RpcHandler<Input, Output>>;
-  function json<Input = any, Output = any>(): Schema<Input, Output>;
-  function json<Input = any, Output = any, Value = unknown>(
-    value: Value,
-  ): BoundSchema<Schema<Input, Output>, Value>;
-  function json<Input, Output, Value>(value?: Value): unknown {
-    const s: Schema<Input, Output> = {
-      symbol: SchemaSymbol,
+  function json<Input = any, Output = any>(): Schema<Input, Output> {
+    return custom({
       parse: (raw: string) => JSON.parse(raw) as Input,
       serialize: (val: unknown) => JSON.stringify(val),
-    };
-    if (typeof value === 'undefined') return s;
-    return { ...s, value };
+    });
   }
 
   /** Raw string schema — passes payloads through as plain strings with no encoding. */
-  function raw(
-    handler: RpcHandler<string, string>,
-  ): BoundSchema<Schema<string, string>, RpcHandler<string, string>>;
-  function raw(): Schema<string, string>;
-  function raw<Value = unknown>(value: Value): BoundSchema<Schema<string, string>, Value>;
-  function raw<Value>(value?: Value): unknown {
-    const s: Schema<string, string> = {
-      symbol: SchemaSymbol,
+  function raw() {
+    return custom({
       parse: (raw: string) => raw,
       serialize: (val: string) => val,
-    };
-    if (typeof value === 'undefined') return s;
-    return { ...s, value };
+    });
   }
 
-  return { json, raw };
+  /** Custom schema - allows custom defined parse and serialize functions */
+  function custom<Input = any, Output = any>(params: Omit<Schema<Input, Output>, "symbol">): Schema<Input, Output> {
+    return { ...params, symbol: SchemaSymbol };
+  }
+
+  return { json, raw, custom };
 })();
 
 // ---------------------------------------------------------------------------
@@ -133,28 +105,13 @@ export type RpcHandler<Input = any, Output = any> = (
   data: RpcInvocationData,
 ) => Promise<Output>;
 
-// Extract Input/Output from a Schema type for use in method map constraints.
-type SchemaInput<S> = S extends Schema<infer I, any> ? I : any;
-type SchemaOutput<S> = S extends Schema<any, infer O> ? O : any;
-
-/**
- * A method entry for {@link useRpc}: either a plain handler (typed by the
- * `defaultSchema`) or a `BoundSchema` that carries its own schema alongside
- * the handler.
- *
- * @beta
- */
-export type RpcMethod<Input = any, Output = any> =
-  | RpcHandler<Input, Output>
-  | BoundSchema<Schema<Input, Output>, RpcHandler<Input, Output>>;
-
 /**
  * Base RPC call parameters with an arbitrary payload type (used when the payload
  * will be serialized by a schema).
  *
  * @beta
  */
-export type RpcCallParams = Omit<PerformRpcParams, 'payload'> & { payload: unknown };
+export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & { payload: Payload };
 
 /**
  * Options for {@link useRpc}.
@@ -164,24 +121,23 @@ export type UseRpcOptions<S extends Schema<any, any> = Schema<any, any>> = {
   /** Only accept RPCs from this participant. Others will receive UNSUPPORTED_METHOD. */
   from?: string | Participant;
   /**
-   * Schema applied to plain handler entries that don't carry their own schema.
-   * Defaults to `schema.json()`.
+   * Schema applied to the data coming in and leaving the handler. Defaults to `schema.json()`
    */
-  defaultSchema?: S;
+  schema?: S;
 };
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-async function resolveWithSchema(
-  s: Omit<Schema<any, any>, 'symbol'>,
-  handler: RpcHandler<any, any>,
+async function resolveWithSchema<S extends Schema<any, any>>(
+  schema: S,
+  handler: RpcHandler<SchemaInput<S>, SchemaOutput<S>>,
   data: RpcInvocationData,
 ): Promise<string> {
-  let parsed: unknown;
+  let parsed;
   try {
-    parsed = s.parse(data.payload);
+    parsed = schema.parse(data.payload);
   } catch (e) {
     throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
   }
@@ -189,7 +145,7 @@ async function resolveWithSchema(
   const result = await handler(parsed, data);
 
   try {
-    return s.serialize(result);
+    return schema.serialize(result);
   } catch (e) {
     throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
   }
@@ -212,7 +168,7 @@ function isUseSessionReturn(value: unknown): value is UseSessionReturn {
 /** @beta */
 export type PerformRpcFn = {
   /** Schema-wrapped call: payload is serialized and response is parsed by the schema. */
-  <Output = string>(params: BoundSchema<Schema<Output, any>, RpcCallParams>): Promise<Output>;
+  <Output = string, Input = unknown>(params: RpcCallParams<Input>, schema: Schema<Output, Input>): Promise<Output>;
   /** Plain call: payload is already a string, response is returned as a string. */
   (params: PerformRpcParams): Promise<string>;
 };
@@ -221,13 +177,6 @@ export type PerformRpcFn = {
 export type UseRpcReturn = {
   performRpc: PerformRpcFn;
 };
-
-// The methods record — plain handler types are constrained by the default schema.
-type RpcMethodMap<S extends Schema<any, any>> = Record<
-  string,
-  | RpcHandler<SchemaInput<S>, SchemaOutput<S>>
-  | Omit<BoundSchema<Schema<any, any>, RpcHandler<any, any>>, 'symbol'>
->;
 
 /**
  * Hook for declarative RPC method registration and outbound RPC calls.
@@ -256,114 +205,99 @@ type RpcMethodMap<S extends Schema<any, any>> = Record<
  */
 export function useRpc<S extends Schema<any, any> = Schema<any, any>>(
   session: UseSessionReturn,
-  methods?: RpcMethodMap<S>,
+  methodName: string,
+  handler: RpcHandler<SchemaInput<S>, SchemaOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
 export function useRpc<S extends Schema<any, any> = Schema<any, any>>(
-  methods?: RpcMethodMap<S>,
+  methodName: string,
+  handler: RpcHandler<SchemaInput<S>, SchemaOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
 export function useRpc(
-  methodsOrSession?: RpcMethodMap<any> | UseSessionReturn,
-  optionsOrMethods?: UseRpcOptions<any> | RpcMethodMap<any>,
-  maybeOptions?: UseRpcOptions<any>,
+  methodNameOrSession?: string | UseSessionReturn,
+  handlerOrMethodName?: RpcHandler<any, any> | string,
+  optionsOrHandler?: UseRpcOptions<Schema<any, any>> | RpcHandler<any, any>,
+  maybeOptions?: UseRpcOptions<Schema<any, any>>,
 ): UseRpcReturn {
-  let methods: RpcMethodMap<any> | undefined;
-  let options: UseRpcOptions<any> | undefined;
   let session: UseSessionReturn | undefined;
+  let methodName: string | undefined;
+  let handler: RpcHandler<any, any> | undefined;
+  let options: UseRpcOptions<Schema<any, any>> | undefined;
 
-  if (isUseSessionReturn(methodsOrSession)) {
-    session = methodsOrSession;
-    methods = optionsOrMethods as RpcMethodMap<any> | undefined;
+  if (isUseSessionReturn(methodNameOrSession)) {
+    session = methodNameOrSession;
+    methodName = handlerOrMethodName as string;
+    handler = optionsOrHandler as RpcHandler<any, any>;
     options = maybeOptions;
   } else {
-    methods = methodsOrSession;
-    options = optionsOrMethods as UseRpcOptions<any> | undefined;
+    methodName = methodNameOrSession;
+    handler = handlerOrMethodName as RpcHandler<any, any>;
+    options = optionsOrHandler as UseRpcOptions<any>;
   }
 
   const { room } = useEnsureSession(session);
 
-  // Ref that always holds the latest handlers — updated synchronously on render
-  const handlersRef = React.useRef(methods);
-  handlersRef.current = methods;
+  // Ref that always holds the latest handler — updated synchronously on render
+  const handlerRef = React.useRef(handler);
+  handlerRef.current = handler;
 
-  // Ref that always holds the latest options (for participant filter and defaultSchema)
+  // Ref that always holds the latest options
   const optionsRef = React.useRef(options);
   optionsRef.current = options;
 
-  // Derive a stable string from the sorted method name set for the effect dependency.
-  // The effect only re-runs when methods are added or removed, not when handler bodies change.
-  const methodNamesEffectKey = React.useMemo(
-    () =>
-      Object.keys(methods ?? {})
-        .sort()
-        .join('\0'),
-    [methods],
-  );
-
   React.useEffect(() => {
-    const currentMethods = handlersRef.current ?? {};
-    const names = Object.keys(currentMethods);
-
-    for (const name of names) {
-      room.registerRpcMethod(name, async (data: RpcInvocationData) => {
-        // Participant filter
-        const from = optionsRef.current?.from;
-        const fromIdentity = typeof from === 'string' ? from : from?.identity;
-        if (fromIdentity && data.callerIdentity !== fromIdentity) {
-          throw RpcError.builtIn(
-            'UNSUPPORTED_METHOD',
-            `Method not available for caller ${data.callerIdentity}`,
-          );
-        }
-
-        const entry = handlersRef.current?.[name];
-        if (!entry) {
-          throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${name}"`);
-        }
-
-        if (typeof entry === 'function') {
-          // Plain handler — apply the default schema (json if unset)
-          const s = optionsRef.current?.defaultSchema ?? schema.json();
-          return resolveWithSchema(s, entry as RpcHandler<any, any>, data);
-        } else {
-          // Entry carries its own schema — use it directly
-          return resolveWithSchema(entry, entry.value as RpcHandler<any, any>, data);
-        }
-      });
+    if (!methodName) {
+      return;
     }
 
-    return () => {
-      for (const name of names) {
-        room.unregisterRpcMethod(name);
+    room.registerRpcMethod(methodName, async (data: RpcInvocationData) => {
+      const from = optionsRef.current?.from;
+      const fromIdentity = typeof from === 'string' ? from : from?.identity;
+      if (fromIdentity && data.callerIdentity !== fromIdentity) {
+        throw RpcError.builtIn(
+          'UNSUPPORTED_METHOD',
+          `Method not available for caller ${data.callerIdentity}`,
+        );
       }
+
+      const currentHandler = handlerRef.current;
+      if (!currentHandler) {
+        throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${methodName}"`);
+      }
+
+      const s = optionsRef.current?.schema ?? schema.json();
+      return resolveWithSchema(s, currentHandler, data);
+    });
+
+    return () => {
+      room.unregisterRpcMethod(methodName);
     };
-  }, [room, methodNamesEffectKey]);
+  }, [room, methodName]);
 
   // Stable performRpc function
   const performRpc: PerformRpcFn = React.useCallback(
-    async (params: BoundSchema<Schema<any, any>, RpcCallParams> | PerformRpcParams) => {
-      if (isBoundSchema(params)) {
-        const rpcParams = params.value as RpcCallParams;
+    async (params: RpcCallParams<unknown>, s?: Schema<any, any>) => {
+      if (isSchema(s)) {
         let serialized: string;
         try {
-          serialized = params.serialize(rpcParams.payload);
+          serialized = s.serialize(params.payload);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC payload: ${e}`);
         }
         const rawResponse = await room.localParticipant.performRpc({
-          destinationIdentity: rpcParams.destinationIdentity,
-          method: rpcParams.method,
+          destinationIdentity: params.destinationIdentity,
+          method: params.method,
           payload: serialized,
-          responseTimeout: rpcParams.responseTimeout,
+          responseTimeout: params.responseTimeout,
         });
         try {
-          return params.parse(rawResponse);
+          return s.parse(rawResponse);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC response: ${e}`);
         }
       } else {
-        return room.localParticipant.performRpc(params);
+        return room.localParticipant.performRpc(params as PerformRpcParams);
       }
     },
     [room],

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -1,98 +1,17 @@
 import * as React from 'react';
-import { RpcError, type RpcInvocationData, type PerformRpcParams } from 'livekit-client';
+import {
+  RpcError,
+  type RpcInvocationData,
+  type PerformRpcParams,
+  type Serializer,
+  isSerializer,
+  type SerializerInput,
+  type SerializerOutput,
+  serializers,
+} from 'livekit-client';
 
 import { useEnsureSession } from '../context';
 import { isUseSessionReturn, type UseSessionReturn } from './useSession';
-
-// ---------------------------------------------------------------------------
-// Serializer types + infrastructure
-// ---------------------------------------------------------------------------
-
-const SerializerSymbol = Symbol.for('lk.serializer');
-
-/**
- * A bidirectional data format descriptor for RPC payloads.
- *
- * - `parse(raw)` decodes an incoming wire string into `Input` (used by handlers)
- * - `serialize(val)` encodes an `Output` value to a wire string (used by handlers)
- *
- * For symmetric serializers (`serializers.raw`), `Input === Output === string`.
- * For `serializers.json`, both default to `any` so each handler can annotate its own types.
- * Use `serializers.custom` to supply your own `parse`/`serialize` pair.
- *
- * @beta
- */
-export type Serializer<Input = any, Output = any> = {
-  symbol: typeof SerializerSymbol;
-  parse: (raw: string) => Input;
-  serialize: (val: Output) => string;
-};
-
-function isSerializer(v: unknown): v is Serializer<any, any> {
-  return (
-    typeof v === 'object' &&
-    v !== null &&
-    'symbol' in v &&
-    (v as Record<string, unknown>)['symbol'] === SerializerSymbol
-  );
-}
-
-// Extract Input/Output from a Serializer type for use in handler/performRpc constraints.
-type SerializerInput<S> = S extends Serializer<infer Input, any> ? Input : any;
-type SerializerOutput<S> = S extends Serializer<any, infer Output> ? Output : any;
-
-/** @internal */
-function base<Input = any, Output = any>(
-  params: Omit<Serializer<Input, Output>, 'symbol'>,
-): Serializer<Input, Output> {
-  return { ...params, symbol: SerializerSymbol };
-}
-
-/**
- * JSON serializer — `JSON.parse` on the way in, `JSON.stringify` on the way out.
- * Defaults to `any` so individual handlers can annotate their own payload types.
- */
-function json<Input = any, Output = any>(): Serializer<Input, Output> {
-  return base({
-    parse: (raw: string) => JSON.parse(raw) as Input,
-    serialize: (val: unknown) => JSON.stringify(val),
-  });
-}
-
-/** Raw string serializer — passes payloads through as plain strings with no encoding. */
-function raw() {
-  return base({
-    parse: (raw: string) => raw,
-    serialize: (val: string) => val,
-  });
-}
-
-/** Custom serializer - allows custom defined parse and serialize functions */
-function custom<Input = any, Output = any>(
-  params: Omit<Serializer<Input, Output>, 'symbol'>,
-): Serializer<Input, Output> {
-  return base(params);
-}
-
-/**
- * Serializer helpers for RPC payload encoding.
- *
- * @example
- * ```ts
- * // Inline handler — types inferred
- * useRpc(session, "myMethod", async (payload: MyInput) => myOutput);
- *
- * // Override default serializer for a handler
- * useRpc(session, "myMethod", async (payload) => payload, { serializer: serializers.raw() });
- *
- * // Manual serializer instances
- * const a = serializers.raw(); // Serializer<string, string>
- * const b = serializer.json<{ foo: string }, { bar: string }>(); // Serializer<{ foo: string }, { bar: string }>
- * ```
- *
- * @beta
- */
-export const serializers = { json, raw, custom };
 
 // ---------------------------------------------------------------------------
 // RPC types

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -162,8 +162,7 @@ export type PerformRpcDescriptor<Input = string, Output = string> = Omit<
   PerformRpcParams,
   'payload'
 > & {
-  schema?: Schema<Output, Input>;
-  payload: Input;
+  payload: BoundSchema<Schema<Output, Input>, Input> | string;
 };
 
 /**
@@ -351,9 +350,9 @@ export function useRpc(
   const performRpc: PerformRpcFn = React.useCallback(
     async <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>) => {
       let serialized: string;
-      if (params.schema) {
+      if (isBoundSchema(params.payload)) {
         try {
-          serialized = params.schema.serialize(params.payload);
+          serialized = params.payload.serialize(params.payload.value);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC payload: ${e}`);
         }
@@ -368,9 +367,9 @@ export function useRpc(
         responseTimeout: params.responseTimeout,
       });
 
-      if (params.schema) {
+      if (isBoundSchema(params.payload)) {
         try {
-          return params.schema.parse(rawResponse);
+          return params.payload.parse(rawResponse);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC response: ${e}`);
         }

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -10,10 +10,10 @@ import { useEnsureSession } from '../context';
 import type { UseSessionReturn } from './useSession';
 
 // ---------------------------------------------------------------------------
-// Schema types
+// Serializer types
 // ---------------------------------------------------------------------------
 
-export const SchemaSymbol = Symbol.for('lk.schema');
+export const SerializerSymbol = Symbol.for('lk.serializer');
 
 /**
  * A bidirectional data format descriptor for RPC payloads.
@@ -21,65 +21,65 @@ export const SchemaSymbol = Symbol.for('lk.schema');
  * - `parse(raw)` decodes an incoming wire string into `Input` (used by handlers)
  * - `serialize(val)` encodes an `Output` value to a wire string (used by handlers)
  *
- * For symmetric schemas (`schema.raw`), `Input === Output === string`.
- * For `schema.json`, both default to `any` so each handler can annotate its own types.
+ * For symmetric serializers (`serializer.raw`), `Input === Output === string`.
+ * For `serializer.json`, both default to `any` so each handler can annotate its own types.
  *
  * @beta
  */
-export type Schema<Input = any, Output = any> = {
-  symbol: typeof SchemaSymbol;
+export type Serializer<Input = any, Output = any> = {
+  symbol: typeof SerializerSymbol;
   parse: (raw: string) => Input;
   serialize: (val: Output) => string;
 };
 
-function isSchema(v: unknown): v is Schema<any, any> {
+function isSerializer(v: unknown): v is Serializer<any, any> {
   return (
     typeof v === 'object' &&
     v !== null &&
     'symbol' in v &&
-    (v as Record<string, unknown>)['symbol'] === SchemaSymbol
+    (v as Record<string, unknown>)['symbol'] === SerializerSymbol
   );
 }
 
-// Extract Input/Output from a Schema type for use in handler/performRpc constraints.
-type SchemaInput<S> = S extends Schema<infer Input, any> ? Input : any;
-type SchemaOutput<S> = S extends Schema<any, infer Output> ? Output : any;
+// Extract Input/Output from a Serializer type for use in handler/performRpc constraints.
+type SerializerInput<S> = S extends Serializer<infer Input, any> ? Input : any;
+type SerializerOutput<S> = S extends Serializer<any, infer Output> ? Output : any;
 
 // ---------------------------------------------------------------------------
-// schema namespace
+// serializer namespace
 // ---------------------------------------------------------------------------
 
 /**
- * Schema helpers for RPC payload encoding.
+ * Serializer helpers for RPC payload encoding.
  *
  * @example
  * ```ts
  * // Inline handler — types inferred
- * useRpc({ myMethod: async (payload: MyInput) => myOutput }, { schema: schema.json() });
+ * useRpc(session, "myMethod", async (payload: MyInput) => myOutput);
  *
- * // Override default schema for all plain handlers in this hook
- * useRpc({ myMethod: async (payload) => payload }, { schema: schema.raw() });
+ * // Override default serializer for a handler
+ * useRpc(session, "myMethod", async (payload) => payload, { serializer: serializer.raw() });
  *
- * // Manual schema instances
- * const a = schema.raw(); // Schema<string, string>
- * const b = schema.json<{ foo: string }, { bar: string }>(); // Schema<{ foo: string }, { bar: string }>
+ * // Manual serializer instances
+ * const a = serializer.raw(); // Serializer<string, string>
+ * const b = serializer.json<{ foo: string }, { bar: string }>(); // Serializer<{ foo: string }, { bar: string }>
  * ```
  *
  * @beta
  */
-export const schema = (() => {
+export const serializer = (() => {
   /**
-   * JSON schema — `JSON.parse` on the way in, `JSON.stringify` on the way out.
+   * JSON serializer — `JSON.parse` on the way in, `JSON.stringify` on the way out.
    * Defaults to `any` so individual handlers can annotate their own payload types.
    */
-  function json<Input = any, Output = any>(): Schema<Input, Output> {
+  function json<Input = any, Output = any>(): Serializer<Input, Output> {
     return custom({
       parse: (raw: string) => JSON.parse(raw) as Input,
       serialize: (val: unknown) => JSON.stringify(val),
     });
   }
 
-  /** Raw string schema — passes payloads through as plain strings with no encoding. */
+  /** Raw string serializer — passes payloads through as plain strings with no encoding. */
   function raw() {
     return custom({
       parse: (raw: string) => raw,
@@ -87,9 +87,11 @@ export const schema = (() => {
     });
   }
 
-  /** Custom schema - allows custom defined parse and serialize functions */
-  function custom<Input = any, Output = any>(params: Omit<Schema<Input, Output>, "symbol">): Schema<Input, Output> {
-    return { ...params, symbol: SchemaSymbol };
+  /** Custom serializer - allows custom defined parse and serialize functions */
+  function custom<Input = any, Output = any>(
+    params: Omit<Serializer<Input, Output>, 'symbol'>,
+  ): Serializer<Input, Output> {
+    return { ...params, symbol: SerializerSymbol };
   }
 
   return { json, raw, custom };
@@ -107,7 +109,7 @@ export type RpcHandler<Input = any, Output = any> = (
 
 /**
  * Base RPC call parameters with an arbitrary payload type (used when the payload
- * will be serialized by a schema).
+ * will be serialized by a serializer).
  *
  * @beta
  */
@@ -117,27 +119,27 @@ export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & { paylo
  * Options for {@link useRpc}.
  * @beta
  */
-export type UseRpcOptions<S extends Schema<any, any> = Schema<any, any>> = {
+export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>> = {
   /** Only accept RPCs from this participant. Others will receive UNSUPPORTED_METHOD. */
   from?: string | Participant;
   /**
-   * Schema applied to the data coming in and leaving the handler. Defaults to `schema.json()`
+   * Serializer applied to the data coming in and leaving the handler. Defaults to `serializer.json()`
    */
-  schema?: S;
+  serializer?: S;
 };
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-async function resolveWithSchema<S extends Schema<any, any>>(
-  schema: S,
-  handler: RpcHandler<SchemaInput<S>, SchemaOutput<S>>,
+async function resolveWithSerializer<S extends Serializer<any, any>>(
+  s: S,
+  handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   data: RpcInvocationData,
 ): Promise<string> {
   let parsed;
   try {
-    parsed = schema.parse(data.payload);
+    parsed = s.parse(data.payload);
   } catch (e) {
     throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
   }
@@ -145,7 +147,7 @@ async function resolveWithSchema<S extends Schema<any, any>>(
   const result = await handler(parsed, data);
 
   try {
-    return schema.serialize(result);
+    return s.serialize(result);
   } catch (e) {
     throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
   }
@@ -167,8 +169,11 @@ function isUseSessionReturn(value: unknown): value is UseSessionReturn {
 
 /** @beta */
 export type PerformRpcFn = {
-  /** Schema-wrapped call: payload is serialized and response is parsed by the schema. */
-  <Output = string, Input = unknown>(params: RpcCallParams<Input>, schema: Schema<Output, Input>): Promise<Output>;
+  /** Serializer-wrapped call: payload is serialized and response is parsed by the serializer. */
+  <Output = string, Input = unknown>(
+    params: RpcCallParams<Input>,
+    serializer: Serializer<Output, Input>,
+  ): Promise<Output>;
   /** Plain call: payload is already a string, response is returned as a string. */
   (params: PerformRpcParams): Promise<string>;
 };
@@ -181,49 +186,42 @@ export type UseRpcReturn = {
 /**
  * Hook for declarative RPC method registration and outbound RPC calls.
  *
- * Registers handler functions for incoming RPC calls and returns a `performRpc`
- * function for outbound calls. Handlers are registered on mount and unregistered
- * on unmount. The effect lifecycle is driven by the set of method names — handler
- * identity does not matter (captured by ref), so inline functions work without
- * `useCallback`.
+ * Registers a handler for an incoming RPC method and returns a `performRpc`
+ * function for outbound calls. The handler is registered on mount and
+ * unregistered on unmount. Handler identity does not matter (captured by ref),
+ * so inline functions work without `useCallback`.
  *
  * @example
  * ```tsx
- * const { performRpc } = useRpc({
- *   // Schema inferred from handler types
- *   getUserLocation: schema.json(async (payload: { highAccuracy: boolean }) => {
- *     const pos = await getPosition(payload.highAccuracy);
- *     return { lat: pos.coords.latitude, lng: pos.coords.longitude };
- *   }),
- *
- *   // Plain handler — uses default schema (json)
- *   getTimezone: async () => Intl.DateTimeFormat().resolvedOptions().timeZone,
- * }, { from: session.agent });
+ * const { performRpc } = useRpc(session, "getUserLocation", async (payload: { highAccuracy: boolean }) => {
+ *   const pos = await getPosition(payload.highAccuracy);
+ *   return { lat: pos.coords.latitude, lng: pos.coords.longitude };
+ * });
  * ```
  *
  * @beta
  */
-export function useRpc<S extends Schema<any, any> = Schema<any, any>>(
+export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(
   session: UseSessionReturn,
   methodName: string,
-  handler: RpcHandler<SchemaInput<S>, SchemaOutput<S>>,
+  handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
-export function useRpc<S extends Schema<any, any> = Schema<any, any>>(
+export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(
   methodName: string,
-  handler: RpcHandler<SchemaInput<S>, SchemaOutput<S>>,
+  handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
 export function useRpc(
   methodNameOrSession?: string | UseSessionReturn,
   handlerOrMethodName?: RpcHandler<any, any> | string,
-  optionsOrHandler?: UseRpcOptions<Schema<any, any>> | RpcHandler<any, any>,
-  maybeOptions?: UseRpcOptions<Schema<any, any>>,
+  optionsOrHandler?: UseRpcOptions<Serializer<any, any>> | RpcHandler<any, any>,
+  maybeOptions?: UseRpcOptions<Serializer<any, any>>,
 ): UseRpcReturn {
   let session: UseSessionReturn | undefined;
   let methodName: string | undefined;
   let handler: RpcHandler<any, any> | undefined;
-  let options: UseRpcOptions<Schema<any, any>> | undefined;
+  let options: UseRpcOptions<Serializer<any, any>> | undefined;
 
   if (isUseSessionReturn(methodNameOrSession)) {
     session = methodNameOrSession;
@@ -263,11 +261,14 @@ export function useRpc(
 
       const currentHandler = handlerRef.current;
       if (!currentHandler) {
-        throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${methodName}"`);
+        throw RpcError.builtIn(
+          'APPLICATION_ERROR',
+          `No handler registered for method "${methodName}"`,
+        );
       }
 
-      const s = optionsRef.current?.schema ?? schema.json();
-      return resolveWithSchema(s, currentHandler, data);
+      const s = optionsRef.current?.serializer ?? serializer.json();
+      return resolveWithSerializer(s, currentHandler, data);
     });
 
     return () => {
@@ -277,8 +278,8 @@ export function useRpc(
 
   // Stable performRpc function
   const performRpc: PerformRpcFn = React.useCallback(
-    async (params: RpcCallParams<unknown>, s?: Schema<any, any>) => {
-      if (isSchema(s)) {
+    async (params: RpcCallParams<unknown>, s?: Serializer<any, any>) => {
+      if (isSerializer(s)) {
         let serialized: string;
         try {
           serialized = s.serialize(params.payload);

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -248,7 +248,10 @@ export function useRpc(
 
   // Stable performRpc function
   const performRpc: PerformRpcFn = React.useCallback(
-    async (params: RpcCallParams<unknown>, serializer?: Serializer<any, any>) => {
+    async (
+      params: RpcCallParams<unknown>,
+      serializer: Serializer<any, any> = serializers.json(),
+    ) => {
       if (isSerializer(serializer)) {
         let serialized: string;
         try {

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -41,6 +41,39 @@ function isSerializer(v: unknown): v is Serializer<any, any> {
 type SerializerInput<S> = S extends Serializer<infer Input, any> ? Input : any;
 type SerializerOutput<S> = S extends Serializer<any, infer Output> ? Output : any;
 
+/** @internal */
+function base<Input = any, Output = any>(
+  params: Omit<Serializer<Input, Output>, 'symbol'>,
+): Serializer<Input, Output> {
+  return { ...params, symbol: SerializerSymbol };
+}
+
+/**
+ * JSON serializer — `JSON.parse` on the way in, `JSON.stringify` on the way out.
+ * Defaults to `any` so individual handlers can annotate their own payload types.
+ */
+function json<Input = any, Output = any>(): Serializer<Input, Output> {
+  return base({
+    parse: (raw: string) => JSON.parse(raw) as Input,
+    serialize: (val: unknown) => JSON.stringify(val),
+  });
+}
+
+/** Raw string serializer — passes payloads through as plain strings with no encoding. */
+function raw() {
+  return base({
+    parse: (raw: string) => raw,
+    serialize: (val: string) => val,
+  });
+}
+
+/** Custom serializer - allows custom defined parse and serialize functions */
+function custom<Input = any, Output = any>(
+  params: Omit<Serializer<Input, Output>, 'symbol'>,
+): Serializer<Input, Output> {
+  return base(params);
+}
+
 /**
  * Serializer helpers for RPC payload encoding.
  *
@@ -59,35 +92,7 @@ type SerializerOutput<S> = S extends Serializer<any, infer Output> ? Output : an
  *
  * @beta
  */
-export const serializers = (() => {
-  /**
-   * JSON serializer — `JSON.parse` on the way in, `JSON.stringify` on the way out.
-   * Defaults to `any` so individual handlers can annotate their own payload types.
-   */
-  function json<Input = any, Output = any>(): Serializer<Input, Output> {
-    return custom({
-      parse: (raw: string) => JSON.parse(raw) as Input,
-      serialize: (val: unknown) => JSON.stringify(val),
-    });
-  }
-
-  /** Raw string serializer — passes payloads through as plain strings with no encoding. */
-  function raw() {
-    return custom({
-      parse: (raw: string) => raw,
-      serialize: (val: string) => val,
-    });
-  }
-
-  /** Custom serializer - allows custom defined parse and serialize functions */
-  function custom<Input = any, Output = any>(
-    params: Omit<Serializer<Input, Output>, 'symbol'>,
-  ): Serializer<Input, Output> {
-    return { ...params, symbol: SerializerSymbol };
-  }
-
-  return { json, raw, custom };
-})();
+export const serializers = { json, raw, custom };
 
 // ---------------------------------------------------------------------------
 // RPC types

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -1,19 +1,14 @@
 import * as React from 'react';
-import {
-  type Participant,
-  RpcError,
-  type RpcInvocationData,
-  type PerformRpcParams,
-} from 'livekit-client';
+import { RpcError, type RpcInvocationData, type PerformRpcParams } from 'livekit-client';
 
 import { useEnsureSession } from '../context';
-import type { UseSessionReturn } from './useSession';
+import { isUseSessionReturn, type UseSessionReturn } from './useSession';
 
 // ---------------------------------------------------------------------------
-// Serializer types
+// Serializer types + infrastructure
 // ---------------------------------------------------------------------------
 
-export const SerializerSymbol = Symbol.for('lk.serializer');
+const SerializerSymbol = Symbol.for('lk.serializer');
 
 /**
  * A bidirectional data format descriptor for RPC payloads.
@@ -45,10 +40,6 @@ function isSerializer(v: unknown): v is Serializer<any, any> {
 // Extract Input/Output from a Serializer type for use in handler/performRpc constraints.
 type SerializerInput<S> = S extends Serializer<infer Input, any> ? Input : any;
 type SerializerOutput<S> = S extends Serializer<any, infer Output> ? Output : any;
-
-// ---------------------------------------------------------------------------
-// serializer namespace
-// ---------------------------------------------------------------------------
 
 /**
  * Serializer helpers for RPC payload encoding.
@@ -122,47 +113,12 @@ export type RpcCallParams<Payload> = Omit<PerformRpcParams, 'payload'> & { paylo
  */
 export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>> = {
   /** Only accept RPCs from this participant. Others will receive UNSUPPORTED_METHOD. */
-  from?: string | Participant;
+  fromIdentity?: string;
   /**
    * Serializer applied to the data coming in and leaving the handler. Defaults to `serializers.json()`
    */
   serializer?: S;
 };
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-async function resolveWithSerializer<S extends Serializer<any, any>>(
-  serializer: S,
-  handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
-  data: RpcInvocationData,
-): Promise<string> {
-  let parsed;
-  try {
-    parsed = serializer.parse(data.payload);
-  } catch (e) {
-    throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
-  }
-
-  const result = await handler(parsed, data);
-
-  try {
-    return serializer.serialize(result);
-  } catch (e) {
-    throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
-  }
-}
-
-function isUseSessionReturn(value: unknown): value is UseSessionReturn {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'room' in value &&
-    'connectionState' in value &&
-    'internal' in value
-  );
-}
 
 // ---------------------------------------------------------------------------
 // useRpc hook
@@ -202,13 +158,13 @@ export type UseRpcReturn = {
  *
  * @beta
  */
-export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(
+export function useRpc<S extends Serializer<any, any>>(
   session: UseSessionReturn,
   methodName: string,
   handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   options?: UseRpcOptions<S>,
 ): UseRpcReturn;
-export function useRpc<S extends Serializer<any, any> = Serializer<any, any>>(
+export function useRpc<S extends Serializer<any, any>>(
   methodName: string,
   handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   options?: UseRpcOptions<S>,
@@ -251,8 +207,7 @@ export function useRpc(
     }
 
     room.registerRpcMethod(methodName, async (data: RpcInvocationData) => {
-      const from = optionsRef.current?.from;
-      const fromIdentity = typeof from === 'string' ? from : from?.identity;
+      const fromIdentity = optionsRef.current?.fromIdentity;
       if (fromIdentity && data.callerIdentity !== fromIdentity) {
         throw RpcError.builtIn(
           'UNSUPPORTED_METHOD',
@@ -268,8 +223,22 @@ export function useRpc(
         );
       }
 
-      const s = optionsRef.current?.serializer ?? serializers.json();
-      return resolveWithSerializer(s, currentHandler, data);
+      const serializer = optionsRef.current?.serializer ?? serializers.json();
+
+      let parsed;
+      try {
+        parsed = serializer.parse(data.payload);
+      } catch (e) {
+        throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
+      }
+
+      const result = await currentHandler(parsed, data);
+
+      try {
+        return serializer.serialize(result);
+      } catch (e) {
+        throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
+      }
     });
 
     return () => {
@@ -279,11 +248,11 @@ export function useRpc(
 
   // Stable performRpc function
   const performRpc: PerformRpcFn = React.useCallback(
-    async (params: RpcCallParams<unknown>, s?: Serializer<any, any>) => {
-      if (isSerializer(s)) {
+    async (params: RpcCallParams<unknown>, serializer?: Serializer<any, any>) => {
+      if (isSerializer(serializer)) {
         let serialized: string;
         try {
-          serialized = s.serialize(params.payload);
+          serialized = serializer.serialize(params.payload);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC payload: ${e}`);
         }
@@ -294,7 +263,7 @@ export function useRpc(
           responseTimeout: params.responseTimeout,
         });
         try {
-          return s.parse(rawResponse);
+          return serializer.parse(rawResponse);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC response: ${e}`);
         }

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -49,7 +49,7 @@ export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>>
 // ---------------------------------------------------------------------------
 
 /** @beta */
-export type RpcCallFn = {
+export type RpcPerformFn = {
   /** Serializer-wrapped call: payload is serialized and response is parsed by the serializer. */
   <Output = string, Input = unknown>(
     params: RpcCallParams<Input>,
@@ -61,7 +61,7 @@ export type RpcCallFn = {
 
 /** @beta */
 export type UseRpcReturn = {
-  call: RpcCallFn;
+  perform: RpcPerformFn;
 };
 
 /**
@@ -176,7 +176,7 @@ export function useRpc(
   }, [room, methodName]);
 
   // Stable rpc calling function
-  const callRpc: RpcCallFn = React.useCallback(
+  const performRpc: RpcPerformFn = React.useCallback(
     async (
       params: RpcCallParams<unknown>,
       serializer: Serializer<any, any> = serializers.json(),
@@ -206,5 +206,5 @@ export function useRpc(
     [room],
   );
 
-  return React.useMemo(() => ({ call: callRpc }), [callRpc]);
+  return React.useMemo(() => ({ perform: performRpc }), [performRpc]);
 }

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -21,8 +21,9 @@ export const SerializerSymbol = Symbol.for('lk.serializer');
  * - `parse(raw)` decodes an incoming wire string into `Input` (used by handlers)
  * - `serialize(val)` encodes an `Output` value to a wire string (used by handlers)
  *
- * For symmetric serializers (`serializer.raw`), `Input === Output === string`.
- * For `serializer.json`, both default to `any` so each handler can annotate its own types.
+ * For symmetric serializers (`serializers.raw`), `Input === Output === string`.
+ * For `serializers.json`, both default to `any` so each handler can annotate its own types.
+ * Use `serializers.custom` to supply your own `parse`/`serialize` pair.
  *
  * @beta
  */
@@ -58,16 +59,16 @@ type SerializerOutput<S> = S extends Serializer<any, infer Output> ? Output : an
  * useRpc(session, "myMethod", async (payload: MyInput) => myOutput);
  *
  * // Override default serializer for a handler
- * useRpc(session, "myMethod", async (payload) => payload, { serializer: serializer.raw() });
+ * useRpc(session, "myMethod", async (payload) => payload, { serializer: serializers.raw() });
  *
  * // Manual serializer instances
- * const a = serializer.raw(); // Serializer<string, string>
+ * const a = serializers.raw(); // Serializer<string, string>
  * const b = serializer.json<{ foo: string }, { bar: string }>(); // Serializer<{ foo: string }, { bar: string }>
  * ```
  *
  * @beta
  */
-export const serializer = (() => {
+export const serializers = (() => {
   /**
    * JSON serializer — `JSON.parse` on the way in, `JSON.stringify` on the way out.
    * Defaults to `any` so individual handlers can annotate their own payload types.
@@ -123,7 +124,7 @@ export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>>
   /** Only accept RPCs from this participant. Others will receive UNSUPPORTED_METHOD. */
   from?: string | Participant;
   /**
-   * Serializer applied to the data coming in and leaving the handler. Defaults to `serializer.json()`
+   * Serializer applied to the data coming in and leaving the handler. Defaults to `serializers.json()`
    */
   serializer?: S;
 };
@@ -133,13 +134,13 @@ export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>>
 // ---------------------------------------------------------------------------
 
 async function resolveWithSerializer<S extends Serializer<any, any>>(
-  s: S,
+  serializer: S,
   handler: RpcHandler<SerializerInput<S>, SerializerOutput<S>>,
   data: RpcInvocationData,
 ): Promise<string> {
   let parsed;
   try {
-    parsed = s.parse(data.payload);
+    parsed = serializer.parse(data.payload);
   } catch (e) {
     throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
   }
@@ -147,7 +148,7 @@ async function resolveWithSerializer<S extends Serializer<any, any>>(
   const result = await handler(parsed, data);
 
   try {
-    return s.serialize(result);
+    return serializer.serialize(result);
   } catch (e) {
     throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
   }
@@ -267,7 +268,7 @@ export function useRpc(
         );
       }
 
-      const s = optionsRef.current?.serializer ?? serializer.json();
+      const s = optionsRef.current?.serializer ?? serializers.json();
       return resolveWithSerializer(s, currentHandler, data);
     });
 

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -130,7 +130,7 @@ export type UseRpcOptions<S extends Serializer<any, any> = Serializer<any, any>>
 // ---------------------------------------------------------------------------
 
 /** @beta */
-export type PerformRpcFn = {
+export type RpcCallFn = {
   /** Serializer-wrapped call: payload is serialized and response is parsed by the serializer. */
   <Output = string, Input = unknown>(
     params: RpcCallParams<Input>,
@@ -142,7 +142,7 @@ export type PerformRpcFn = {
 
 /** @beta */
 export type UseRpcReturn = {
-  performRpc: PerformRpcFn;
+  call: RpcCallFn;
 };
 
 /**
@@ -256,8 +256,8 @@ export function useRpc(
     };
   }, [room, methodName]);
 
-  // Stable performRpc function
-  const performRpc: PerformRpcFn = React.useCallback(
+  // Stable rpc calling function
+  const callRpc: RpcCallFn = React.useCallback(
     async (
       params: RpcCallParams<unknown>,
       serializer: Serializer<any, any> = serializers.json(),
@@ -287,5 +287,5 @@ export function useRpc(
     [room],
   );
 
-  return React.useMemo(() => ({ performRpc }), [performRpc]);
+  return React.useMemo(() => ({ call: callRpc }), [callRpc]);
 }

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -13,6 +13,8 @@ import type { UseSessionReturn } from './useSession';
 // Schema types
 // ---------------------------------------------------------------------------
 
+export const SchemaSymbol = Symbol.for('lk.schema');
+
 /**
  * A bidirectional data format descriptor for RPC payloads.
  *
@@ -25,7 +27,7 @@ import type { UseSessionReturn } from './useSession';
  * @beta
  */
 export type Schema<Input = any, Output = any> = {
-  isSchema: true;
+  symbol: typeof SchemaSymbol;
   parse: (raw: string) => Input;
   serialize: (val: Output) => string;
 };
@@ -42,8 +44,8 @@ function isSchema(v: unknown): v is Schema<any, any> {
   return (
     typeof v === 'object' &&
     v !== null &&
-    'isSchema' in v &&
-    (v as Record<string, unknown>)['isSchema'] === true
+    'symbol' in v &&
+    (v as Record<string, unknown>)['symbol'] === SchemaSymbol
   );
 }
 
@@ -94,7 +96,7 @@ export const schema = (() => {
   ): BoundSchema<Schema<Input, Output>, Value>;
   function json<Input, Output, Value>(value?: Value): unknown {
     const s: Schema<Input, Output> = {
-      isSchema: true,
+      symbol: SchemaSymbol,
       parse: (raw: string) => JSON.parse(raw) as Input,
       serialize: (val: unknown) => JSON.stringify(val),
     };
@@ -110,7 +112,7 @@ export const schema = (() => {
   function raw<Value = unknown>(value: Value): BoundSchema<Schema<string, string>, Value>;
   function raw<Value>(value?: Value): unknown {
     const s: Schema<string, string> = {
-      isSchema: true,
+      symbol: SchemaSymbol,
       parse: (raw: string) => raw,
       serialize: (val: string) => val,
     };

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -184,7 +184,7 @@ export type UseRpcOptions<S extends Schema<any, any> = Schema<any, any>> = {
 // ---------------------------------------------------------------------------
 
 async function resolveWithSchema(
-  s: Schema<any, any>,
+  s: Omit<Schema<any, any>, 'symbol'>,
   handler: RpcHandler<any, any>,
   data: RpcInvocationData,
 ): Promise<string> {
@@ -232,7 +232,7 @@ export type UseRpcReturn = {
 type RpcMethodMap<S extends Schema<any, any>> = Record<
   string,
   | RpcHandler<SchemaInput<S>, SchemaOutput<S>>
-  | BoundSchema<Schema<any, any>, RpcHandler<any, any>>
+  | Omit<BoundSchema<Schema<any, any>, RpcHandler<any, any>>, 'symbol'>
 >;
 
 /**
@@ -328,13 +328,13 @@ export function useRpc(
           throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${name}"`);
         }
 
-        if (isBoundSchema(entry)) {
-          // Entry carries its own schema — use it directly
-          return resolveWithSchema(entry, entry.value as RpcHandler<any, any>, data);
-        } else {
+        if (typeof entry === 'function') {
           // Plain handler — apply the default schema (json if unset)
           const s = optionsRef.current?.defaultSchema ?? schema.json();
           return resolveWithSchema(s, entry as RpcHandler<any, any>, data);
+        } else {
+          // Entry carries its own schema — use it directly
+          return resolveWithSchema(entry, entry.value as RpcHandler<any, any>, data);
         }
       });
     }

--- a/packages/react/src/hooks/useRpc.ts
+++ b/packages/react/src/hooks/useRpc.ts
@@ -9,140 +9,199 @@ import {
 import { useEnsureSession } from '../context';
 import type { UseSessionReturn } from './useSession';
 
+// ---------------------------------------------------------------------------
+// Schema types
+// ---------------------------------------------------------------------------
+
+/**
+ * A bidirectional data format descriptor for RPC payloads.
+ *
+ * - `parse(raw)` decodes an incoming wire string into `Input` (used by handlers)
+ * - `serialize(val)` encodes an `Output` value to a wire string (used by handlers)
+ *
+ * For symmetric schemas (`schema.raw`), `Input === Output === string`.
+ * For `schema.json`, both default to `any` so each handler can annotate its own types.
+ *
+ * @beta
+ */
+export type Schema<Input = any, Output = any> = {
+  isSchema: true;
+  parse: (raw: string) => Input;
+  serialize: (val: Output) => string;
+};
+
+/**
+ * A {@link Schema} with a bound value — used to associate a handler or payload
+ * with its schema in a single object.
+ *
+ * @beta
+ */
+export type BoundSchema<S extends Schema<any, any>, V> = S & { value: V };
+
+function isSchema(v: unknown): v is Schema<any, any> {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'isSchema' in v &&
+    (v as Record<string, unknown>)['isSchema'] === true
+  );
+}
+
+function isBoundSchema(v: unknown): v is BoundSchema<Schema<any, any>, unknown> {
+  return isSchema(v) && 'value' in (v as object);
+}
+
+// ---------------------------------------------------------------------------
+// schema namespace
+// ---------------------------------------------------------------------------
+
+/**
+ * Schema helpers for RPC payload encoding.
+ *
+ * Each function has three call forms:
+ * - **No argument** — returns a plain `Schema` for use as a `defaultSchema` option or manual use
+ * - **Handler argument** — infers `Input`/`Output` from the handler, returns a `BoundSchema`
+ *   for inline registration in {@link useRpc}
+ * - **Any other value** — returns a `BoundSchema` with that value attached (e.g. for `performRpc`)
+ *
+ * @example
+ * ```ts
+ * // Inline handler — types inferred
+ * useRpc({ myMethod: schema.json(async (payload: MyInput) => myOutput) });
+ *
+ * // Override default schema for all plain handlers in this hook
+ * useRpc({ myMethod: async (payload) => payload }, { defaultSchema: schema.raw() });
+ *
+ * // Manual schema instances
+ * const a = schema.raw();                             // Schema<string, string>
+ * const b = schema.json<{ foo: string }, { bar: string }>(); // Schema<{ foo: string }, { bar: string }>
+ * const c = schema.json<{ foo: string }, { bar: string }>(myPayload); // BoundSchema<..., typeof myPayload>
+ * ```
+ *
+ * @beta
+ */
+export const schema = (() => {
+  /**
+   * JSON schema — `JSON.parse` on the way in, `JSON.stringify` on the way out.
+   * Defaults to `any` so individual handlers can annotate their own payload types.
+   */
+  function json<Input, Output>(
+    handler: RpcHandler<Input, Output>,
+  ): BoundSchema<Schema<Input, Output>, RpcHandler<Input, Output>>;
+  function json<Input = any, Output = any>(): Schema<Input, Output>;
+  function json<Input = any, Output = any, Value = unknown>(
+    value: Value,
+  ): BoundSchema<Schema<Input, Output>, Value>;
+  function json<Input, Output, Value>(value?: Value): unknown {
+    const s: Schema<Input, Output> = {
+      isSchema: true,
+      parse: (raw: string) => JSON.parse(raw) as Input,
+      serialize: (val: unknown) => JSON.stringify(val),
+    };
+    if (typeof value === 'undefined') return s;
+    return { ...s, value };
+  }
+
+  /** Raw string schema — passes payloads through as plain strings with no encoding. */
+  function raw(
+    handler: RpcHandler<string, string>,
+  ): BoundSchema<Schema<string, string>, RpcHandler<string, string>>;
+  function raw(): Schema<string, string>;
+  function raw<Value = unknown>(value: Value): BoundSchema<Schema<string, string>, Value>;
+  function raw<Value>(value?: Value): unknown {
+    const s: Schema<string, string> = {
+      isSchema: true,
+      parse: (raw: string) => raw,
+      serialize: (val: string) => val,
+    };
+    if (typeof value === 'undefined') return s;
+    return { ...s, value };
+  }
+
+  return { json, raw };
+})();
+
+// ---------------------------------------------------------------------------
+// RPC types
+// ---------------------------------------------------------------------------
+
 /** @beta */
 export type RpcHandler<Input = any, Output = any> = (
   payload: Input,
   data: RpcInvocationData,
 ) => Promise<Output>;
 
-/** @beta */
-export type RpcMethodDescriptor<Input = string, Output = string> = {
-  parse?: (raw: string) => Input;
-  serialize?: (val: Output) => string;
-  handler: RpcHandler<Input, Output>;
-};
+// Extract Input/Output from a Schema type for use in method map constraints.
+type SchemaInput<S> = S extends Schema<infer I, any> ? I : any;
+type SchemaOutput<S> = S extends Schema<any, infer O> ? O : any;
 
-/** @beta */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * A method entry for {@link useRpc}: either a plain handler (typed by the
+ * `defaultSchema`) or a `BoundSchema` that carries its own schema alongside
+ * the handler.
+ *
+ * @beta
+ */
 export type RpcMethod<Input = any, Output = any> =
   | RpcHandler<Input, Output>
-  | RpcMethodDescriptor<Input, Output>;
+  | BoundSchema<Schema<Input, Output>, RpcHandler<Input, Output>>;
 
-/** @beta */
+/**
+ * Parameters for an outbound {@link PerformRpcFn} call.
+ *
+ * `schema` is from the *sender's* perspective: `parse` decodes the *response*
+ * (`Output`) and `serialize` encodes the *request* (`Input`). This is the
+ * type-flipped counterpart of the handler's schema — for symmetric schemas like
+ * `schema.json()` and `schema.raw()` the flip is invisible.
+ *
+ * @beta
+ */
 export type PerformRpcDescriptor<Input = string, Output = string> = Omit<
   PerformRpcParams,
   'payload'
 > & {
-  parse?: (raw: string) => Output;
-  serialize?: (val: Input) => string;
+  schema?: Schema<Output, Input>;
   payload: Input;
 };
 
-/** @beta */
-export type RpcJsonParams<Input = unknown> = Omit<PerformRpcParams, 'payload'> & { payload: Input };
-
-/** Options for {@link useRpc}.
- * @beta */
-export type UseRpcOptions = {
-  /** Only accept RPCs from this participant. Others receive UNSUPPORTED_METHOD. */
-  from?: string | Participant;
-
-  defaultSerializer?: <Input, Output>(
-    handler: (payload: Input, data: RpcInvocationData) => Promise<Output>,
-  ) => RpcMethodDescriptor<Input, Output>;
-};
-
 /**
- * Namespace for RPC helpers.
- *
- * `rpc.json` can be used in two ways:
- *
- * **Handler mode** (for registering methods via {@link useRpc}):
- * ```ts
- * useRpc({
- *   myMethod: rpc.json(async (payload: MyInput, ctx) => {
- *     return { result: 'value' };
- *   }),
- * });
- * ```
- *
- * **Payload mode** (for outbound calls via `performRpc`):
- * ```ts
- * const result = await performRpc(rpc.json<MyInput, MyOutput>(
- *   { destinationIdentity: '...', method: 'myMethod', payload: { key: 'value' } },
- * ));
- * ```
- *
+ * Options for {@link useRpc}.
  * @beta
  */
-export const rpc = (() => {
-  /* Overload: handler mode (for useRpc methods record) */
-  function json<Input, Output>(
-    handler: (payload: Input, data: RpcInvocationData) => Promise<Output>,
-  ): RpcMethodDescriptor<Input, Output>;
-  /* Overload: payload mode (for performRpc) */
-  function json<Input, Output>(value: RpcJsonParams<Input>): PerformRpcDescriptor<Input, Output>;
-  function json<Input, Output>(
-    handlerOrValue:
-      | RpcJsonParams<Input>
-      | ((payload: Input, data: RpcInvocationData) => Promise<Output>),
-  ): RpcMethodDescriptor<Input, Output> | PerformRpcDescriptor<Input, Output> {
-    if (typeof handlerOrValue === 'function') {
-      return {
-        parse: (raw: string) => JSON.parse(raw),
-        serialize: (val: unknown) => JSON.stringify(val),
-        handler: handlerOrValue as RpcMethodDescriptor<Input, Output>['handler'],
-      };
-    }
-
-    return {
-      ...handlerOrValue,
-      parse: (raw: string) => JSON.parse(raw),
-      serialize: (val: unknown) => JSON.stringify(val),
-    };
-  }
-
-  /* Overload: handler mode (for useRpc methods record) */
-  function raw(
-    handler: (payload: string, data: RpcInvocationData) => Promise<string>,
-  ): RpcMethodDescriptor<string, string>;
-  /* Overload: payload mode (for performRpc) */
-  function raw(value: RpcJsonParams<string>): PerformRpcDescriptor<string, string>;
-  function raw(
-    handlerOrValue:
-      | RpcJsonParams<string>
-      | ((payload: string, data: RpcInvocationData) => Promise<string>),
-  ): RpcMethodDescriptor<string, string> | PerformRpcDescriptor<string, string> {
-    if (typeof handlerOrValue === 'function') {
-      return {
-        parse: (raw: string) => raw,
-        serialize: (val: string) => val,
-        handler: handlerOrValue,
-      };
-    }
-
-    return {
-      ...handlerOrValue,
-      parse: (raw: string) => raw,
-      serialize: (val: string) => val,
-    };
-  }
-
-  return {
-    json,
-    raw,
-  };
-})();
-
-/** @beta */
-export type PerformRpcFn = {
-  <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>): Promise<Output>;
+export type UseRpcOptions<S extends Schema<any, any> = Schema<any, any>> = {
+  /** Only accept RPCs from this participant. Others will receive UNSUPPORTED_METHOD. */
+  from?: string | Participant;
+  /**
+   * Schema applied to plain handler entries that don't carry their own schema.
+   * Defaults to `schema.json()`.
+   */
+  defaultSchema?: S;
 };
 
-/** @beta */
-export type UseRpcReturn = {
-  performRpc: PerformRpcFn;
-};
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function resolveWithSchema(
+  s: Schema<any, any>,
+  handler: RpcHandler<any, any>,
+  data: RpcInvocationData,
+): Promise<string> {
+  let parsed: unknown;
+  try {
+    parsed = s.parse(data.payload);
+  } catch (e) {
+    throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
+  }
+
+  const result = await handler(parsed, data);
+
+  try {
+    return s.serialize(result);
+  } catch (e) {
+    throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
+  }
+}
 
 function isUseSessionReturn(value: unknown): value is UseSessionReturn {
   return (
@@ -154,91 +213,77 @@ function isUseSessionReturn(value: unknown): value is UseSessionReturn {
   );
 }
 
-async function resolveDescriptor<Input, Output>(
-  method: RpcMethodDescriptor<Input, Output>,
-  data: RpcInvocationData,
-): Promise<string> {
-  let parsed: Input;
-  if (method.parse) {
-    try {
-      parsed = method.parse(data.payload);
-    } catch (e) {
-      throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC payload: ${e}`);
-    }
-  } else {
-    parsed = data.payload as Input;
-  }
-
-  const result = await method.handler(parsed, data);
-
-  if (method.serialize) {
-    try {
-      return method.serialize(result);
-    } catch (e) {
-      throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
-    }
-  } else if (typeof result !== 'string') {
-    throw RpcError.builtIn(
-      'APPLICATION_ERROR',
-      `Failed to serialize RPC response: return value from handler function not string. Did you mean to include a "serialize" RpcMethod key?`,
-    );
-  } else {
-    return result;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // useRpc hook
 // ---------------------------------------------------------------------------
 
+/** @beta */
+export type PerformRpcFn = {
+  <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>): Promise<Output>;
+};
+
+/** @beta */
+export type UseRpcReturn = {
+  performRpc: PerformRpcFn;
+};
+
+// The methods record — plain handler types are constrained by the default schema.
+type RpcMethodMap<S extends Schema<any, any>> = Record<
+  string,
+  | RpcHandler<SchemaInput<S>, SchemaOutput<S>>
+  | BoundSchema<Schema<any, any>, RpcHandler<any, any>>
+>;
+
 /**
  * Hook for declarative RPC method registration and outbound RPC calls.
  *
- * Registers handler functions for incoming RPC method calls and returns a `performRpc` function
- * for making outbound RPC calls to other participants.
- *
- * Handlers are registered on mount and unregistered on unmount. The effect lifecycle is driven
- * by the set of method names — handler function identity does not matter (they are captured by
- * ref), so inline functions work without `useCallback`.
+ * Registers handler functions for incoming RPC calls and returns a `performRpc`
+ * function for outbound calls. Handlers are registered on mount and unregistered
+ * on unmount. The effect lifecycle is driven by the set of method names — handler
+ * identity does not matter (captured by ref), so inline functions work without
+ * `useCallback`.
  *
  * @example
  * ```tsx
  * const { performRpc } = useRpc({
- *   // JSON handler via preset
- *   getUserLocation: rpc.json(async (payload: { highAccuracy: boolean }, ctx) => {
+ *   // Schema inferred from handler types
+ *   getUserLocation: schema.json(async (payload: { highAccuracy: boolean }) => {
  *     const pos = await getPosition(payload.highAccuracy);
  *     return { lat: pos.coords.latitude, lng: pos.coords.longitude };
  *   }),
  *
- *   // Raw string handler
- *   getTimezone: async (data) => Intl.DateTimeFormat().resolvedOptions().timeZone,
+ *   // Plain handler — uses default schema (json)
+ *   getTimezone: async () => Intl.DateTimeFormat().resolvedOptions().timeZone,
  * }, { from: session.agent });
  * ```
  *
  * @beta
  */
-export function useRpc(
+export function useRpc<S extends Schema<any, any> = Schema<any, any>>(
   session: UseSessionReturn,
-  methods?: Record<string, RpcMethod>,
-  options?: UseRpcOptions,
+  methods?: RpcMethodMap<S>,
+  options?: UseRpcOptions<S>,
 ): UseRpcReturn;
-export function useRpc(methods?: Record<string, RpcMethod>, options?: UseRpcOptions): UseRpcReturn;
+export function useRpc<S extends Schema<any, any> = Schema<any, any>>(
+  methods?: RpcMethodMap<S>,
+  options?: UseRpcOptions<S>,
+): UseRpcReturn;
 export function useRpc(
-  methodsOrSession?: Record<string, RpcMethod> | UseSessionReturn,
-  optionsOrMethods?: UseRpcOptions | Record<string, RpcMethod>,
-  maybeOptions?: UseRpcOptions,
+  methodsOrSession?: RpcMethodMap<any> | UseSessionReturn,
+  optionsOrMethods?: UseRpcOptions<any> | RpcMethodMap<any>,
+  maybeOptions?: UseRpcOptions<any>,
 ): UseRpcReturn {
-  let methods: Record<string, RpcMethod> | undefined;
-  let options: UseRpcOptions | undefined;
+  let methods: RpcMethodMap<any> | undefined;
+  let options: UseRpcOptions<any> | undefined;
   let session: UseSessionReturn | undefined;
 
   if (isUseSessionReturn(methodsOrSession)) {
     session = methodsOrSession;
-    methods = optionsOrMethods as Record<string, RpcMethod> | undefined;
+    methods = optionsOrMethods as RpcMethodMap<any> | undefined;
     options = maybeOptions;
   } else {
     methods = methodsOrSession;
-    options = optionsOrMethods as UseRpcOptions | undefined;
+    options = optionsOrMethods as UseRpcOptions<any> | undefined;
   }
 
   const { room } = useEnsureSession(session);
@@ -247,7 +292,7 @@ export function useRpc(
   const handlersRef = React.useRef(methods);
   handlersRef.current = methods;
 
-  // Ref that always holds the latest options (for participant filter)
+  // Ref that always holds the latest options (for participant filter and defaultSchema)
   const optionsRef = React.useRef(options);
   optionsRef.current = options;
 
@@ -277,17 +322,18 @@ export function useRpc(
           );
         }
 
-        // Resolve the latest handler from the ref
-        const handler = handlersRef.current?.[name];
-        if (!handler) {
+        const entry = handlersRef.current?.[name];
+        if (!entry) {
           throw RpcError.builtIn('APPLICATION_ERROR', `No handler registered for method "${name}"`);
         }
 
-        if (typeof handler === 'function') {
-          const serializer = options?.defaultSerializer ?? rpc.json;
-          return resolveDescriptor(serializer(handler), data);
+        if (isBoundSchema(entry)) {
+          // Entry carries its own schema — use it directly
+          return resolveWithSchema(entry, entry.value as RpcHandler<any, any>, data);
         } else {
-          return resolveDescriptor(handler, data);
+          // Plain handler — apply the default schema (json if unset)
+          const s = optionsRef.current?.defaultSchema ?? schema.json();
+          return resolveWithSchema(s, entry as RpcHandler<any, any>, data);
         }
       });
     }
@@ -299,13 +345,13 @@ export function useRpc(
     };
   }, [room, methodNamesEffectKey]);
 
-  // Stable performRpc function with overloads
+  // Stable performRpc function
   const performRpc: PerformRpcFn = React.useCallback(
     async <Input = string, Output = string>(params: PerformRpcDescriptor<Input, Output>) => {
       let serialized: string;
-      if (params.serialize) {
+      if (params.schema) {
         try {
-          serialized = params.serialize(params.payload);
+          serialized = params.schema.serialize(params.payload);
         } catch (e) {
           throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC payload: ${e}`);
         }
@@ -320,15 +366,14 @@ export function useRpc(
         responseTimeout: params.responseTimeout,
       });
 
-      if (params.parse) {
+      if (params.schema) {
         try {
-          return params.parse(rawResponse);
+          return params.schema.parse(rawResponse);
         } catch (e) {
-          throw RpcError.builtIn('APPLICATION_ERROR', `Failed to serialize RPC response: ${e}`);
+          throw RpcError.builtIn('APPLICATION_ERROR', `Failed to parse RPC response: ${e}`);
         }
-      } else {
-        return rawResponse as Output;
       }
+      return rawResponse as Output;
     },
     [room],
   );

--- a/packages/react/src/hooks/useSession.ts
+++ b/packages/react/src/hooks/useSession.ts
@@ -150,6 +150,7 @@ export type UseSessionReturn = (
 ) &
   SessionActions;
 
+/** @internal */
 export function isUseSessionReturn(value: unknown): value is UseSessionReturn {
   return (
     typeof value === 'object' &&

--- a/packages/react/src/hooks/useSession.ts
+++ b/packages/react/src/hooks/useSession.ts
@@ -150,6 +150,16 @@ export type UseSessionReturn = (
 ) &
   SessionActions;
 
+export function isUseSessionReturn(value: unknown): value is UseSessionReturn {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'room' in value &&
+    'connectionState' in value &&
+    'internal' in value
+  );
+}
+
 type UseSessionCommonOptions = {
   room?: Room;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^8.56.0
       version: 8.57.1
     livekit-client:
-      specifier: ^2.18.0
-      version: 2.18.1
+      specifier: ^2.18.2
+      version: 2.18.2
     prettier:
       specifier: ^3.8.1
       version: 3.8.1
@@ -76,7 +76,7 @@ importers:
         version: link:../../packages/styles
       livekit-client:
         specifier: 'catalog:'
-        version: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+        version: 2.18.2(@types/dom-mediacapture-record@1.0.22)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -161,10 +161,10 @@ importers:
         version: link:../../packages/styles
       '@livekit/track-processors':
         specifier: ^0.3.2
-        version: 0.3.3(livekit-client@2.18.1(@types/dom-mediacapture-record@1.0.22))
+        version: 0.3.3(livekit-client@2.18.2(@types/dom-mediacapture-record@1.0.22))
       livekit-client:
         specifier: 'catalog:'
-        version: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+        version: 2.18.2(@types/dom-mediacapture-record@1.0.22)
       livekit-server-sdk:
         specifier: ^2.6.1
         version: 2.14.2
@@ -207,7 +207,7 @@ importers:
         version: 1.7.4
       livekit-client:
         specifier: 'catalog:'
-        version: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+        version: 2.18.2(@types/dom-mediacapture-record@1.0.22)
       loglevel:
         specifier: 1.9.1
         version: 1.9.1
@@ -259,7 +259,7 @@ importers:
         version: link:../core
       '@livekit/krisp-noise-filter':
         specifier: ^0.2.12 || ^0.3.0
-        version: 0.2.12(livekit-client@2.18.1(@types/dom-mediacapture-record@1.0.22))
+        version: 0.2.12(livekit-client@2.18.2(@types/dom-mediacapture-record@1.0.22))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -271,7 +271,7 @@ importers:
         version: 6.1.3
       livekit-client:
         specifier: 'catalog:'
-        version: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+        version: 2.18.2(@types/dom-mediacapture-record@1.0.22)
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
@@ -386,7 +386,7 @@ importers:
         version: 6.1.3
       livekit-client:
         specifier: 'catalog:'
-        version: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+        version: 2.18.2(@types/dom-mediacapture-record@1.0.22)
       livekit-server-sdk:
         specifier: ^2.13.2
         version: 2.14.2
@@ -6498,8 +6498,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  livekit-client@2.18.1:
-    resolution: {integrity: sha512-nGjuEEV1mVN01EcAMwGIwG3J1gpBMqwn2V4R6W/8zz9Rah1CaAohIm6AMLG7BdctQpyeh34dfAOLfDodIsWyYA==}
+  livekit-client@2.18.2:
+    resolution: {integrity: sha512-U8jHHySZzrNap9H9Gv3WuhZZety890RYmPfoRKiF2ymSTDyi5qAe4beR0SM6mfjkVAoChjhrSW0q7mdva7Ug2Q==}
     peerDependencies:
       '@types/dom-mediacapture-record': ^1
 
@@ -10389,9 +10389,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@livekit/krisp-noise-filter@0.2.12(livekit-client@2.18.1(@types/dom-mediacapture-record@1.0.22))':
+  '@livekit/krisp-noise-filter@0.2.12(livekit-client@2.18.2(@types/dom-mediacapture-record@1.0.22))':
     dependencies:
-      livekit-client: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.18.2(@types/dom-mediacapture-record@1.0.22)
 
   '@livekit/mutex@1.1.1': {}
 
@@ -10403,11 +10403,11 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
-  '@livekit/track-processors@0.3.3(livekit-client@2.18.1(@types/dom-mediacapture-record@1.0.22))':
+  '@livekit/track-processors@0.3.3(livekit-client@2.18.2(@types/dom-mediacapture-record@1.0.22))':
     dependencies:
       '@mediapipe/holistic': 0.5.1675471629
       '@mediapipe/tasks-vision': 0.10.9
-      livekit-client: 2.18.1(@types/dom-mediacapture-record@1.0.22)
+      livekit-client: 2.18.2(@types/dom-mediacapture-record@1.0.22)
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -16001,7 +16001,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  livekit-client@2.18.1(@types/dom-mediacapture-record@1.0.22):
+  livekit-client@2.18.2(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       '@livekit/mutex': 1.1.1
       '@livekit/protocol': 1.44.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
   - 'tooling/*'
 
 catalog:
-  livekit-client: ^2.18.0
+  livekit-client: ^2.18.2
   '@livekit/protocol': ^1.44.0
   eslint: ^8.56.0
   prettier: ^3.8.1


### PR DESCRIPTION
### Overview 
A prototype of a new `useRpc` hook aiming to simplify both sending and responding to rpc messages. 

A snapshot build was published on npm, run the below to give it a shot locally:
```sh
$ npm install --save @livekit/components-react@rpc-prototype
```

### Example usage:

Here's the server end:
```tsx
// "Server" end of RPC assumes json encoded rpc requests / responses
useRpc(session, "getUserLocation", async (payload: { highAccuracy: boolean }, data) => {
  const position = await new Promise<GeolocationPosition>((resolve, reject) => {
    navigator.geolocation.getCurrentPosition(resolve, reject, {
      enableHighAccuracy: payload.highAccuracy,
      timeout: data.responseTimeout * 1000,
    });
  });
  return {
    latitude: position.coords.latitude,
    longitude: position.coords.longitude,
  };
});

// Alternative: custom request / response serialization:
useRpc(
  session,
  "getUserLocation",
  async (payload, data) => {
    return "raw text";
  },
  // To go back to raw serialization, pass serializers.raw() explicitly here:
  { serializer: serializers.raw() },
);

// Alternative: custom request / response serialization:
useRpc(
  session,
  "getUserLocation",
  async (payload /* <= decoded from base64 */, data) => {
    return "text to base64 encode";
  },
  {
    // Fully custom serializer example (base64):
    serializer: serializers.custom({
      parse: (raw) => window.atob(raw),
      serialize: (base64) => window.btoa(base64),
    })
  }
);
```

And the client end:

```tsx
const { performRpc } = useRpc();

// The "Client" end of RPC also defaults to json:
const result = await performRpc({
  destinationIdentity: participantIdentity,
  method: 'getUserLocation',
  payload: { highAccuracy: true },
});

// Example of using a serializer in the client end as well:
const result = await performRpc({
  destinationIdentity: participantIdentity,
  method: 'getUserLocation',
  payload: "raw text",
}, serializers.raw());
```

### Todo
- [x] Add missing changeset
- [x] I can't get the api-extractor check to pass in ci (it passed locally) and can't figure out why... Debug this.
- [x] Update `livekit-client` dependency to be a version which contains the changes in https://github.com/livekit/client-sdk-js/pull/1885 to get the ci build to pass