### PR TITLE
fix(shadcn): api-token-route missing room_config

### DIFF
--- a/packages/shadcn/README.md
+++ b/packages/shadcn/README.md
@@ -47,7 +47,7 @@ First add the Agents UI registry to your components.json file:
   ...
   "registries": {
      ...
-    "@agents-ui": "https://livekit.io/ui/r/{name}.json"
+    "@agents-ui": "https://livekit.com/ui/r/{name}.json"
   }
 }
 ```

--- a/packages/shadcn/components/agents-ui/nextjs-api-token-route.ts
+++ b/packages/shadcn/components/agents-ui/nextjs-api-token-route.ts
@@ -38,7 +38,9 @@ export async function POST(req: Request) {
     // Parse room config from request body.
     const body = await req.json();
     // Recreate the RoomConfiguration object from JSON object.
-    const roomConfig = RoomConfiguration.fromJson(body?.room_config, { ignoreUnknownFields: true });
+    const roomConfig = body?.room_config
+      ? RoomConfiguration.fromJson(body.room_config, { ignoreUnknownFields: true })
+      : new RoomConfiguration();
 
     // Generate participant token
     const participantName = 'user';

--- a/packages/shadcn/registry.json
+++ b/packages/shadcn/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "@agents-ui",
-  "homepage": "https://livekit.io/ui",
+  "homepage": "https://livekit.com/ui",
   "items": [
     {
       "name": "agent-disconnect-button",
@@ -291,7 +291,7 @@
     },
     {
       "name": "agent-session-view-01",
-      "author": "LiveKit (https://livekit.io)",
+      "author": "LiveKit (https://livekit.com)",
       "type": "registry:block",
       "title": "Agent Session View",
       "description": "A full-screen agent session block with transcript, controls, and I/O media tiles.",


### PR DESCRIPTION
## Issue

Related to https://github.com/livekit-examples/agent-starter-react/pull/331

```
POST /api/token 500 in 341ms
Error: cannot decode message livekit.RoomConfiguration from JSON: undefined
    at POST (app/api/token/route.ts:41:42)
```

## Solution

This is happens as the result of an empty `room_config` when `AGENT_NAME` is blank
