### PR TITLE
fix(react): recreate Krisp processor per track

### DIFF
--- a/.changeset/krisp-processor-per-track.md
+++ b/.changeset/krisp-processor-per-track.md
@@ -2,4 +2,4 @@
 '@livekit/components-react': patch
 ---
 
-Fix `useKrispNoiseFilter` throwing `InvalidAccessError` on the second session when `Room.disconnect()` + reconnect republishes the microphone. The hook now treats `LocalAudioTrack.getProcessor()` as the source of truth and creates a fresh `KrispNoiseFilterProcessor` per track, avoiding reuse of a processor whose internal audio graph is bound to a now-closed `AudioContext`.
+Fix `useKrispNoiseFilter` throwing `InvalidAccessError` on the second session when `Room.disconnect()` + reconnect republishes the microphone. The hook now treats `LocalAudioTrack.getProcessor()` as the source of truth and creates a fresh `KrispNoiseFilterProcessor` per track, avoiding reuse of a processor whose internal audio graph is bound to a now-closed `AudioContext`. Also tightens the cancellation race when `setProcessor` resolves after the effect was cancelled, guards the returned `processor` against non-Krisp `TrackProcessor`s set by other modules, and detaches the processor on track change / unmount so a caller-owned `trackRef` is left in the state it started in.

--- a/.changeset/krisp-processor-per-track.md
+++ b/.changeset/krisp-processor-per-track.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Fix `useKrispNoiseFilter` throwing `InvalidAccessError` on the second session when `Room.disconnect()` + reconnect republishes the microphone. The hook now treats `LocalAudioTrack.getProcessor()` as the source of truth and creates a fresh `KrispNoiseFilterProcessor` per track, avoiding reuse of a processor whose internal audio graph is bound to a now-closed `AudioContext`.

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -100,9 +100,19 @@ export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
       const processor = KrispNoiseFilter(options.filterOptions);
       try {
         await track.setProcessor(processor);
-        if (cancelled) return;
+        // If the effect was cancelled while setProcessor was in flight, the
+        // processor landed on a track the hook no longer manages (e.g. the
+        // component unmounted with the track still alive via a caller-owned
+        // trackRef). Undo the attach so the track is left as we found it.
+        if (cancelled) {
+          await track.stopProcessor();
+          return;
+        }
         await processor.setEnabled(true);
-        if (cancelled) return;
+        if (cancelled) {
+          await track.stopProcessor();
+          return;
+        }
         setIsNoiseFilterEnabled(true);
       } catch (e: any) {
         setIsNoiseFilterEnabled(false);

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -44,24 +44,17 @@ export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
   const [isNoiseFilterPending, setIsNoiseFilterPending] = React.useState(false);
   const [isNoiseFilterEnabled, setIsNoiseFilterEnabled] = React.useState(false);
   let micPublication = useLocalParticipant().microphoneTrack;
-  const [krispProcessor, setKrispProcessor] = React.useState<
-    KrispNoiseFilterProcessor | undefined
-  >();
   if (options.trackRef) {
     micPublication = options.trackRef.publication;
   }
 
   const setNoiseFilterEnabled = React.useCallback(async (enable: boolean) => {
     if (enable) {
-      const { KrispNoiseFilter, isKrispNoiseFilterSupported } =
-        await import('@livekit/krisp-noise-filter');
+      const { isKrispNoiseFilterSupported } = await import('@livekit/krisp-noise-filter');
 
       if (!isKrispNoiseFilterSupported()) {
         log.warn('LiveKit-Krisp noise filter is not supported in this browser');
         return;
-      }
-      if (!krispProcessor) {
-        setKrispProcessor(KrispNoiseFilter(options.filterOptions));
       }
     }
     setShouldEnable((prev) => {
@@ -73,37 +66,65 @@ export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
   }, []);
 
   React.useEffect(() => {
-    if (micPublication && micPublication.track instanceof LocalAudioTrack && krispProcessor) {
-      const currentProcessor = micPublication.track.getProcessor();
-      if (currentProcessor && currentProcessor.name === 'livekit-noise-filter') {
-        setIsNoiseFilterPending(true);
-        (currentProcessor as KrispNoiseFilterProcessor).setEnabled(shouldEnable).finally(() => {
-          setIsNoiseFilterPending(false);
-          setIsNoiseFilterEnabled(shouldEnable);
-        });
-      } else if (!currentProcessor && shouldEnable) {
-        setIsNoiseFilterPending(true);
-        micPublication?.track
-          ?.setProcessor(krispProcessor)
-          .then(() => krispProcessor.setEnabled(shouldEnable))
-          .then(() => {
-            setIsNoiseFilterEnabled(true);
-          })
-          .catch((e: any) => {
-            setIsNoiseFilterEnabled(false);
-            log.error('Krisp hook: error enabling filter', e);
-          })
-          .finally(() => {
-            setIsNoiseFilterPending(false);
-          });
-      }
+    const track = micPublication?.track;
+    if (!(track instanceof LocalAudioTrack)) return;
+
+    const existing = track.getProcessor();
+    // Processor already attached to this track — just sync enabled state.
+    if (existing?.name === 'livekit-noise-filter') {
+      setIsNoiseFilterPending(true);
+      (existing as KrispNoiseFilterProcessor).setEnabled(shouldEnable).finally(() => {
+        setIsNoiseFilterPending(false);
+        setIsNoiseFilterEnabled(shouldEnable);
+      });
+      return;
     }
-  }, [shouldEnable, micPublication, krispProcessor]);
+
+    if (!shouldEnable) return;
+
+    // No processor on this track and the filter is wanted on — create a fresh
+    // processor bound to this track's AudioContext and attach. Each track gets
+    // its own processor: a KrispNoiseFilterProcessor's internal audio graph is
+    // permanently bound to the AudioContext it was init'd against, so it can't
+    // be reused across mic republishes (e.g. session.end() + session.start()).
+    let cancelled = false;
+    setIsNoiseFilterPending(true);
+    (async () => {
+      const { KrispNoiseFilter, isKrispNoiseFilterSupported } =
+        await import('@livekit/krisp-noise-filter');
+      if (cancelled) return;
+      if (!isKrispNoiseFilterSupported()) {
+        setIsNoiseFilterPending(false);
+        return;
+      }
+      const processor = KrispNoiseFilter(options.filterOptions);
+      try {
+        await track.setProcessor(processor);
+        if (cancelled) return;
+        await processor.setEnabled(true);
+        if (cancelled) return;
+        setIsNoiseFilterEnabled(true);
+      } catch (e: any) {
+        setIsNoiseFilterEnabled(false);
+        log.error('Krisp hook: error enabling filter', e);
+      } finally {
+        setIsNoiseFilterPending(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldEnable, micPublication?.track, options.filterOptions]);
+
+  const processor =
+    micPublication?.track instanceof LocalAudioTrack
+      ? (micPublication.track.getProcessor() as KrispNoiseFilterProcessor | undefined)
+      : undefined;
 
   return {
     setNoiseFilterEnabled,
     isNoiseFilterEnabled,
     isNoiseFilterPending,
-    processor: krispProcessor,
+    processor,
   };
 }

--- a/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
+++ b/packages/react/src/hooks/cloud/krisp/useKrispNoiseFilter.ts
@@ -48,6 +48,9 @@ export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
     micPublication = options.trackRef.publication;
   }
 
+  const managedProcessorRef = React.useRef<KrispNoiseFilterProcessor | undefined>(undefined);
+  const managedProcessorTrackRef = React.useRef<LocalAudioTrack | undefined>(undefined);
+
   const setNoiseFilterEnabled = React.useCallback(async (enable: boolean) => {
     if (enable) {
       const { isKrispNoiseFilterSupported } = await import('@livekit/krisp-noise-filter');
@@ -105,12 +108,22 @@ export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
         // component unmounted with the track still alive via a caller-owned
         // trackRef). Undo the attach so the track is left as we found it.
         if (cancelled) {
-          await track.stopProcessor();
+          if (track.getProcessor() === processor) {
+            await track.stopProcessor();
+          }
           return;
         }
+        managedProcessorRef.current = processor;
+        managedProcessorTrackRef.current = track;
         await processor.setEnabled(true);
         if (cancelled) {
-          await track.stopProcessor();
+          if (track.getProcessor() === processor) {
+            await track.stopProcessor();
+          }
+          if (managedProcessorRef.current === processor) {
+            managedProcessorRef.current = undefined;
+            managedProcessorTrackRef.current = undefined;
+          }
           return;
         }
         setIsNoiseFilterEnabled(true);
@@ -126,9 +139,29 @@ export function useKrispNoiseFilter(options: useKrispNoiseFilterOptions = {}) {
     };
   }, [shouldEnable, micPublication?.track, options.filterOptions]);
 
-  const processor =
+  React.useEffect(
+    () => () => {
+      const track = managedProcessorTrackRef.current;
+      const processor = managedProcessorRef.current;
+      if (!track || !processor) return;
+      if (track.getProcessor() === processor) {
+        track.stopProcessor().catch((e) => {
+          log.warn('Krisp hook: error detaching processor on cleanup', e);
+        });
+      }
+      managedProcessorRef.current = undefined;
+      managedProcessorTrackRef.current = undefined;
+    },
+    [micPublication?.track],
+  );
+
+  const trackProcessor =
     micPublication?.track instanceof LocalAudioTrack
-      ? (micPublication.track.getProcessor() as KrispNoiseFilterProcessor | undefined)
+      ? micPublication.track.getProcessor()
+      : undefined;
+  const processor =
+    trackProcessor?.name === 'livekit-noise-filter'
+      ? (trackProcessor as KrispNoiseFilterProcessor)
       : undefined;
 
   return {


### PR DESCRIPTION
## Summary

Noticed with our homepage agent in www that `useKrispNoiseFilter` currently throws `InvalidAccessError: Failed to execute 'connect' on 'AudioNode': cannot connect to an AudioNode belonging to a different audio context.` on the second session any time a consumer calls `Room.disconnect()` followed by a new `session.start()` without a page reload.

## Root cause

The hook stored the `KrispNoiseFilterProcessor` in `React.useState` and only created it once (guarded by `if (!krispProcessor)`), reusing the same instance across mic republishes. A `KrispNoiseFilterProcessor`'s internal audio graph is bound to the `AudioContext` it was `init()`-ed against, and `Room.disconnect()` closes that context. When the mic republishes on a fresh `AudioContext`, attaching the cached processor to the new track calls `AudioNode.connect()` on nodes from the old (closed) context — hence the error.

Duplicating the processor into React state while `LocalAudioTrack` already owns it was the underlying design mistake; the state copy had no mechanism to track when the real processor had been destroyed out from under it.

## Fix

Three commits:

1. **`fix(react): recreate Krisp processor per track`** — remove the duplicated state and treat `LocalAudioTrack.getProcessor()` as the source of truth. A single effect handles both attach and enable/disable sync:
   - If the current track already has the Krisp processor attached, just sync `setEnabled(shouldEnable)`.
   - Otherwise, if the filter is wanted on, create a fresh `KrispNoiseFilterProcessor` bound to this track's `AudioContext` and attach it.

   Because nothing is cached across tracks, mic republishes can't produce a stale-processor-from-a-closed-context scenario.

2. **`fix(react): detach Krisp processor on cancel`** — handle the cancel-mid-attach race where `setProcessor` resolves after the effect was cancelled (e.g. unmount during attach). The IIFE checks `cancelled` after each `await` and undoes the attach via `track.stopProcessor()` so the track is left as we found it.

3. **`fix(react): guard processor cast and detach on cleanup`** — guard the returned `processor` value with a `name === 'livekit-noise-filter'` check before casting (prevents misrepresenting a non-Krisp `TrackProcessor` set by another module), and add a separate cleanup effect keyed on the track that detaches the processor on track change or unmount. Uses identity (`track.getProcessor() === processor`) so it only detaches the instance this hook owns. Closes the gap where a caller-owned `trackRef` outlives the hook's component or swaps to a different live track.

## Test plan

- [x] Reproduced on www with the homepage agent: `session.start()` → `session.end()` → `session.start()` errors on second start.
- [x] With the patched build installed, three back-to-back start/end cycles in the same tab succeed without the error and with the filter active.
- [x] Toggle reuse path still works: `setNoiseFilterEnabled` flipping false → true does not destroy and recreate the processor.
- [x] `pnpm --filter @livekit/components-react build` / `lint` / `test` all pass (no new lint warnings).
