### PR TITLE
Pass options param to useGridLayout through GridLayout component

### DIFF
--- a/packages/react/src/components/layout/GridLayout.tsx
+++ b/packages/react/src/components/layout/GridLayout.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { UseParticipantsOptions } from '../../hooks';
 import { useGridLayout, usePagination, useSwipe } from '../../hooks';
 import { mergeProps } from '../../utils';
-import type { TrackReferenceOrPlaceholder } from '@livekit/components-core';
+import type { TrackReferenceOrPlaceholder, GridLayoutDefinition } from '@livekit/components-core';
 import { TrackLoop } from '../TrackLoop';
 import { PaginationControl } from '../controls/PaginationControl';
 import { PaginationIndicator } from '../controls/PaginationIndicator';
@@ -12,6 +12,7 @@ export interface GridLayoutProps
   extends React.HTMLAttributes<HTMLDivElement>, Pick<UseParticipantsOptions, 'updateOnlyOn'> {
   children: React.ReactNode;
   tracks: TrackReferenceOrPlaceholder[];
+  gridLayouts?: GridLayoutDefinition[];
 }
 
 /**
@@ -30,14 +31,14 @@ export interface GridLayoutProps
  * ```
  * @public
  */
-export function GridLayout({ tracks, ...props }: GridLayoutProps) {
+export function GridLayout({ tracks, gridLayouts, ...props }: GridLayoutProps) {
   const gridEl = React.createRef<HTMLDivElement>();
 
   const elementProps = React.useMemo(
     () => mergeProps(props, { className: 'lk-grid-layout' }),
     [props],
   );
-  const { layout } = useGridLayout(gridEl, tracks.length);
+  const { layout } = useGridLayout(gridEl, tracks.length, gridLayouts ? { gridLayouts } : undefined);
   const pagination = usePagination(layout.maxTiles, tracks);
 
   useSwipe(gridEl, {


### PR DESCRIPTION
## Summary

This PR exposes `useGridLayout`'s existing `gridLayouts` option through the `GridLayout` component.

Consumers can now pass custom `GridLayoutDefinition[]` values directly to `GridLayout` without needing to use `useGridLayout` themselves.

## Changes

- add an optional `gridLayouts?: GridLayoutDefinition[]` prop to `GridLayout`
- forward `gridLayouts` from `GridLayout` into `useGridLayout`
- preserve existing behavior when `gridLayouts` is not provided

## Why

`useGridLayout` already supports custom grid layout definitions, but that flexibility was not available through the higher-level `GridLayout` component. This change closes that gap and makes layout customization available without dropping down to the hook layer.