### PR TITLE
feat(shadcn): theme mode for aura visualizer and `all` registry item

### DIFF
--- a/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { StoryObj } from '@storybook/react-vite';
+import { useTheme } from 'next-themes';
 import { AgentSessionProvider } from '../../.storybook/lk-decorators/AgentSessionProvider';
 import { AgentSessionView_01, AgentSessionView_01Props } from '@agents-ui';
 
 export default {
   component: AgentSessionView_01,
   decorators: [AgentSessionProvider],
-  render: (args: AgentSessionView_01Props) => <AgentSessionView_01 {...args} />,
+  render: (args: AgentSessionView_01Props) => {
+    const { resolvedTheme = 'dark' } = useTheme();
+    return (
+      <AgentSessionView_01 themeMode={resolvedTheme as 'dark' | 'light'} {...args} />
+    );
+  },
   args: {
     className: 'h-screen w-screen',
     supportsChatInput: true,

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -167,7 +167,6 @@ export function AgentSessionView_01({
   supportsVideoInput = true,
   supportsScreenShare = true,
   isPreConnectBufferEnabled = true,
-
   audioVisualizerType,
   audioVisualizerColor,
   audioVisualizerColorShift,
@@ -184,7 +183,7 @@ export function AgentSessionView_01({
 }: React.ComponentProps<'section'> & AgentSessionView_01Props) {
   const session = useSessionContext();
   const { messages } = useSessionMessages(session);
-  const [chatOpen, setChatOpen] = useState(false);
+  const [isChatOpen, setIsChatOpen] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const { state: agentState } = useAgent();
 
@@ -216,7 +215,7 @@ export function AgentSessionView_01({
 
       <div className="absolute top-0 bottom-[135px] flex w-full flex-col md:bottom-[170px]">
         <AnimatePresence>
-          {chatOpen && (
+          {isChatOpen && (
             <motion.div
               {...CHAT_MOTION_PROPS}
               className="flex h-full w-full flex-col gap-4 space-y-3 transition-opacity duration-300 ease-out"
@@ -232,7 +231,7 @@ export function AgentSessionView_01({
       </div>
       {/* Tile layout */}
       <TileLayout
-        chatOpen={chatOpen}
+        isChatOpen={isChatOpen}
         themeMode={themeMode}
         audioVisualizerType={audioVisualizerType}
         audioVisualizerColor={audioVisualizerColor}
@@ -270,10 +269,10 @@ export function AgentSessionView_01({
           <AgentControlBar
             variant="livekit"
             controls={controls}
-            isChatOpen={chatOpen}
+            isChatOpen={isChatOpen}
             isConnected={session.isConnected}
             onDisconnect={session.end}
-            onIsChatOpenChange={setChatOpen}
+            onIsChatOpenChange={setIsChatOpen}
           />
         </div>
       </motion.div>

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -103,6 +103,12 @@ export function Fade({ top = false, bottom = false, className }: FadeProps) {
 
 export interface AgentSessionView_01Props {
   /**
+   * Theme mode forwarded to the aura visualizer (`audioVisualizerType="aura"`) so
+   * the shader's blend mode adapts to the theme mode.
+   * Ignored by other visualizer types.
+   */
+  themeMode?: 'dark' | 'light';
+  /**
    * Message shown above the controls before the first chat message is sent.
    *
    * @default 'Agent is listening, ask it a question'
@@ -171,6 +177,7 @@ export function AgentSessionView_01({
   audioVisualizerRadialBarCount,
   audioVisualizerRadialRadius,
   audioVisualizerWaveLineWidth,
+  themeMode,
   ref,
   className,
   ...props
@@ -226,6 +233,7 @@ export function AgentSessionView_01({
       {/* Tile layout */}
       <TileLayout
         chatOpen={chatOpen}
+        themeMode={themeMode}
         audioVisualizerType={audioVisualizerType}
         audioVisualizerColor={audioVisualizerColor}
         audioVisualizerColorShift={audioVisualizerColorShift}

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
@@ -18,6 +18,7 @@ const MotionAgentAudioVisualizerRadial = motion.create(AgentAudioVisualizerRadia
 const MotionAgentAudioVisualizerWave = motion.create(AgentAudioVisualizerWave);
 
 interface AudioVisualizerProps extends MotionProps {
+  themeMode?: 'dark' | 'light';
   isChatOpen: boolean;
   audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
   audioVisualizerColor?: `#${string}`;
@@ -32,6 +33,8 @@ interface AudioVisualizerProps extends MotionProps {
 }
 
 export function AudioVisualizer({
+  themeMode,
+  isChatOpen,
   audioVisualizerType = 'bar',
   audioVisualizerColor,
   audioVisualizerColorShift = 0.3,
@@ -41,7 +44,6 @@ export function AudioVisualizer({
   audioVisualizerGridRowCount = 15,
   audioVisualizerGridColumnCount = 15,
   audioVisualizerWaveLineWidth = 3,
-  isChatOpen,
   className,
   ...props
 }: AudioVisualizerProps) {
@@ -55,6 +57,7 @@ export function AudioVisualizer({
           audioTrack={audioTrack}
           color={audioVisualizerColor}
           colorShift={audioVisualizerColorShift}
+          themeMode={themeMode}
           className={cn('size-[300px] md:size-[450px]', className)}
           {...props}
         />

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
@@ -69,7 +69,8 @@ export function useLocalTrackRef(source: Track.Source) {
 }
 
 interface TileLayoutProps {
-  chatOpen: boolean;
+  themeMode?: 'dark' | 'light';
+  isChatOpen: boolean;
   audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
   audioVisualizerColor?: `#${string}`;
   audioVisualizerColorShift?: number;
@@ -82,7 +83,8 @@ interface TileLayoutProps {
 }
 
 export function TileLayout({
-  chatOpen,
+  themeMode,
+  isChatOpen,
   audioVisualizerType,
   audioVisualizerColor,
   audioVisualizerColorShift,
@@ -101,7 +103,7 @@ export function TileLayout({
   const isScreenShareEnabled = screenShareTrack && !screenShareTrack.publication.isMuted;
   const hasSecondTile = isCameraEnabled || isScreenShareEnabled;
 
-  const animationDelay = chatOpen ? 0 : 0.15;
+  const animationDelay = isChatOpen ? 0 : 0.15;
   const isAvatar = agentVideoTrack !== undefined;
   const videoWidth = agentVideoTrack?.publication.dimensions?.width ?? 0;
   const videoHeight = agentVideoTrack?.publication.dimensions?.height ?? 0;
@@ -114,9 +116,9 @@ export function TileLayout({
           <div
             className={cn([
               'grid',
-              !chatOpen && tileViewClassNames.agentChatClosed,
-              chatOpen && hasSecondTile && tileViewClassNames.agentChatOpenWithSecondTile,
-              chatOpen && !hasSecondTile && tileViewClassNames.agentChatOpenWithoutSecondTile,
+              !isChatOpen && tileViewClassNames.agentChatClosed,
+              isChatOpen && hasSecondTile && tileViewClassNames.agentChatOpenWithSecondTile,
+              isChatOpen && !hasSecondTile && tileViewClassNames.agentChatOpenWithoutSecondTile,
             ])}
           >
             <AnimatePresence mode="popLayout">
@@ -136,7 +138,7 @@ export function TileLayout({
                   <AudioVisualizer
                     key="audio-visualizer"
                     initial={{ scale: 1 }}
-                    animate={{ scale: chatOpen ? 0.2 : 1 }}
+                    animate={{ scale: isChatOpen ? 0.2 : 1 }}
                     transition={{
                       ...ANIMATION_TRANSITION,
                       delay: animationDelay,
@@ -150,11 +152,12 @@ export function TileLayout({
                     audioVisualizerGridRowCount={audioVisualizerGridRowCount}
                     audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
                     audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
-                    isChatOpen={chatOpen}
+                    themeMode={themeMode}
+                    isChatOpen={isChatOpen}
                     className={cn(
                       'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
                       'bg-background rounded-[50px] border border-transparent transition-[border,drop-shadow]',
-                      chatOpen && 'border-input shadow-2xl/10 delay-200',
+                      isChatOpen && 'border-input shadow-2xl/10 delay-200',
                     )}
                     style={{ color: audioVisualizerColor }}
                   />
@@ -177,7 +180,7 @@ export function TileLayout({
                     maskImage:
                       'radial-gradient(circle, rgba(0, 0, 0, 1) 0, rgba(0, 0, 0, 1) 500px, transparent 500px)',
                     filter: 'blur(0px)',
-                    borderRadius: chatOpen ? 6 : 12,
+                    borderRadius: isChatOpen ? 6 : 12,
                   }}
                   transition={{
                     ...ANIMATION_TRANSITION,
@@ -191,14 +194,14 @@ export function TileLayout({
                   }}
                   className={cn(
                     'overflow-hidden bg-black drop-shadow-xl/80',
-                    chatOpen ? 'h-[90px]' : 'h-auto w-full',
+                    isChatOpen ? 'h-[90px]' : 'h-auto w-full',
                   )}
                 >
                   <VideoTrack
                     width={videoWidth}
                     height={videoHeight}
                     trackRef={agentVideoTrack}
-                    className={cn(chatOpen && 'size-[90px] object-cover')}
+                    className={cn(isChatOpen && 'size-[90px] object-cover')}
                   />
                 </motion.div>
               )}
@@ -208,8 +211,8 @@ export function TileLayout({
           <div
             className={cn([
               'grid',
-              chatOpen && tileViewClassNames.secondTileChatOpen,
-              !chatOpen && tileViewClassNames.secondTileChatClosed,
+              isChatOpen && tileViewClassNames.secondTileChatOpen,
+              !isChatOpen && tileViewClassNames.secondTileChatClosed,
             ])}
           >
             {/* Camera & Screen Share */}

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "index.ts",
   "scripts": {
-    "registry:build": "rm -rf dist && shadcn build --output ./dist/r && pnpm registry:doc-gen",
+    "registry:build": "pnpm test && rm -rf dist && shadcn build --output ./dist/r && pnpm registry:doc-gen",
     "registry:serve": "python3 -m http.server 3210 -d ./dist",
     "registry:doc-gen": "node --experimental-strip-types --env-file=.env.local ./scripts/doc-gen.ts",
     "registry:update": "pnpm registry:build && node --experimental-strip-types --env-file=.env.local ./scripts/update.ts",

--- a/packages/shadcn/registry.json
+++ b/packages/shadcn/registry.json
@@ -331,7 +331,7 @@
       "name": "all",
       "type": "registry:item",
       "title": "All",
-      "description": "Installs every component in the @agents-ui registry.",
+      "description": "Installs every component in the @agents-ui registry (excluding the nextjs-api-token-route).",
       "files": [],
       "registryDependencies": [
         "@agents-ui/agent-disconnect-button",
@@ -348,7 +348,6 @@
         "@agents-ui/agent-chat-indicator",
         "@agents-ui/agent-chat-transcript",
         "@agents-ui/react-shader-toy",
-        "@agents-ui/nextjs-api-token-route",
         "@agents-ui/agent-session-view-01"
       ]
     }

--- a/packages/shadcn/registry.json
+++ b/packages/shadcn/registry.json
@@ -326,6 +326,31 @@
       ],
       "dependencies": ["@livekit/components-react@^2.0.0", "livekit-client@^2.0.0", "motion"],
       "categories": ["agents", "blocks"]
+    },
+    {
+      "name": "all",
+      "type": "registry:item",
+      "title": "All",
+      "description": "Installs every component in the @agents-ui registry.",
+      "files": [],
+      "registryDependencies": [
+        "@agents-ui/agent-disconnect-button",
+        "@agents-ui/agent-track-toggle",
+        "@agents-ui/agent-track-control",
+        "@agents-ui/agent-control-bar",
+        "@agents-ui/agent-audio-visualizer-bar",
+        "@agents-ui/agent-audio-visualizer-radial",
+        "@agents-ui/agent-audio-visualizer-grid",
+        "@agents-ui/agent-audio-visualizer-wave",
+        "@agents-ui/agent-audio-visualizer-aura",
+        "@agents-ui/agent-session-provider",
+        "@agents-ui/start-audio-button",
+        "@agents-ui/agent-chat-indicator",
+        "@agents-ui/agent-chat-transcript",
+        "@agents-ui/react-shader-toy",
+        "@agents-ui/nextjs-api-token-route",
+        "@agents-ui/agent-session-view-01"
+      ]
     }
   ]
 }

--- a/packages/shadcn/tests/agent-track-control.test.tsx
+++ b/packages/shadcn/tests/agent-track-control.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AgentTrackControl } from '@/components/agents-ui/agent-track-control';
+import * as LiveKitComponents from '@livekit/components-react';
+
+const setActiveMediaDeviceMock = vi.fn();
+
+vi.mock('@livekit/components-react', async () => {
+  const actual = await vi.importActual('@livekit/components-react');
+  return {
+    ...actual,
+    useMaybeRoomContext: vi.fn(() => ({ id: 'room' })),
+    useMediaDeviceSelect: vi.fn(() => ({
+      devices: [],
+      activeDeviceId: 'device-1',
+      setActiveMediaDevice: setActiveMediaDeviceMock,
+    })),
+  };
+});
+
+vi.mock('@/components/agents-ui/agent-track-toggle', () => ({
+  AgentTrackToggle: ({ source, pressed, pending, disabled, children, onPressedChange }: any) => (
+    <button
+      type="button"
+      data-testid="track-toggle"
+      data-source={source}
+      data-pending={pending ? 'true' : 'false'}
+      aria-pressed={pressed ? 'true' : 'false'}
+      disabled={disabled}
+      onClick={() => onPressedChange?.(!pressed)}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/agents-ui/agent-audio-visualizer-bar', () => ({
+  AgentAudioVisualizerBar: ({ state, audioTrack, children }: any) => (
+    <div
+      data-testid="audio-visualizer"
+      data-state={state}
+      data-has-track={audioTrack ? 'true' : 'false'}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children, onOpenChange, onValueChange, value }: any) => (
+    <div data-testid="device-select" data-value={value}>
+      <button type="button" data-testid="open-select" onClick={() => onOpenChange?.(true)}>
+        Open
+      </button>
+      <button type="button" data-testid="choose-device" onClick={() => onValueChange?.('device-2')}>
+        Choose
+      </button>
+      {children}
+    </div>
+  ),
+  SelectContent: ({ children }: any) => <div data-testid="select-content">{children}</div>,
+  SelectItem: ({ children, value }: any) => (
+    <div data-testid="select-item" data-value={value}>
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children, className }: any) => (
+    <button type="button" data-testid="select-trigger" className={className}>
+      {children}
+    </button>
+  ),
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+}));
+
+describe('AgentTrackControl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+      devices: [],
+      activeDeviceId: 'device-1',
+      setActiveMediaDevice: setActiveMediaDeviceMock,
+    } as any);
+  });
+
+  describe('Rendering', () => {
+    it('renders the track toggle with source and pressed state', () => {
+      render(<AgentTrackControl kind="audioinput" source="microphone" pressed />);
+
+      const toggle = screen.getByTestId('track-toggle');
+      expect(toggle).toHaveAttribute('data-source', 'microphone');
+      expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('applies className to the control wrapper', () => {
+      const { container } = render(
+        <AgentTrackControl kind="videoinput" source="camera" className="custom-control" />,
+      );
+
+      expect(container.firstChild).toHaveClass('custom-control');
+    });
+
+    it('passes pending and disabled state to the toggle', () => {
+      render(<AgentTrackControl kind="audioinput" source="microphone" pending disabled />);
+
+      const toggle = screen.getByTestId('track-toggle');
+      expect(toggle).toHaveAttribute('data-pending', 'true');
+      expect(toggle).toBeDisabled();
+    });
+  });
+
+  describe('Track Toggle', () => {
+    it('calls onPressedChange when the toggle is clicked', async () => {
+      const user = userEvent.setup();
+      const handlePressedChange = vi.fn();
+
+      render(
+        <AgentTrackControl
+          kind="audioinput"
+          source="microphone"
+          pressed={false}
+          onPressedChange={handlePressedChange}
+        />,
+      );
+
+      await user.click(screen.getByTestId('track-toggle'));
+
+      expect(handlePressedChange).toHaveBeenCalledWith(true);
+    });
+
+    it('renders microphone visualizer when an audio track is provided', () => {
+      render(
+        <AgentTrackControl
+          kind="audioinput"
+          source="microphone"
+          pressed
+          audioTrack={{ source: 'microphone' } as any}
+        />,
+      );
+
+      const visualizer = screen.getByTestId('audio-visualizer');
+      expect(visualizer).toHaveAttribute('data-state', 'speaking');
+      expect(visualizer).toHaveAttribute('data-has-track', 'true');
+    });
+
+    it('disconnects the microphone visualizer when pressed is false', () => {
+      render(
+        <AgentTrackControl
+          kind="audioinput"
+          source="microphone"
+          pressed={false}
+          audioTrack={{ source: 'microphone' } as any}
+        />,
+      );
+
+      const visualizer = screen.getByTestId('audio-visualizer');
+      expect(visualizer).toHaveAttribute('data-state', 'disconnected');
+      expect(visualizer).toHaveAttribute('data-has-track', 'false');
+    });
+  });
+
+  describe('Device Select', () => {
+    it('does not render the device select when fewer than two devices are available', () => {
+      vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+        devices: [{ deviceId: 'device-1', label: 'Built-in Mic' }],
+        activeDeviceId: 'device-1',
+        setActiveMediaDevice: setActiveMediaDeviceMock,
+      } as any);
+
+      render(<AgentTrackControl kind="audioinput" source="microphone" />);
+
+      expect(screen.queryByTestId('device-select')).not.toBeInTheDocument();
+    });
+
+    it('filters empty device ids before rendering options', () => {
+      vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+        devices: [
+          { deviceId: '', label: 'Default' },
+          { deviceId: 'device-1', label: 'Built-in Mic' },
+          { deviceId: 'device-2', label: 'USB Mic' },
+        ],
+        activeDeviceId: 'device-1',
+        setActiveMediaDevice: setActiveMediaDeviceMock,
+      } as any);
+
+      render(<AgentTrackControl kind="audioinput" source="microphone" />);
+
+      expect(screen.getAllByTestId('select-item')).toHaveLength(2);
+      expect(screen.queryByText('Default')).not.toBeInTheDocument();
+    });
+
+    it('requests permissions when the device select opens', async () => {
+      const user = userEvent.setup();
+      vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+        devices: [
+          { deviceId: 'device-1', label: 'Built-in Camera' },
+          { deviceId: 'device-2', label: 'USB Camera' },
+        ],
+        activeDeviceId: 'device-1',
+        setActiveMediaDevice: setActiveMediaDeviceMock,
+      } as any);
+
+      render(<AgentTrackControl kind="videoinput" source="camera" />);
+
+      expect(LiveKitComponents.useMediaDeviceSelect).toHaveBeenLastCalledWith(
+        expect.objectContaining({ requestPermissions: false }),
+      );
+
+      await user.click(screen.getByTestId('open-select'));
+
+      expect(LiveKitComponents.useMediaDeviceSelect).toHaveBeenLastCalledWith(
+        expect.objectContaining({ requestPermissions: true }),
+      );
+    });
+
+    it('updates the active media device and calls onActiveDeviceChange', async () => {
+      const user = userEvent.setup();
+      const handleActiveDeviceChange = vi.fn();
+      vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+        devices: [
+          { deviceId: 'device-1', label: 'Built-in Mic' },
+          { deviceId: 'device-2', label: 'USB Mic' },
+        ],
+        activeDeviceId: 'device-1',
+        setActiveMediaDevice: setActiveMediaDeviceMock,
+      } as any);
+
+      render(
+        <AgentTrackControl
+          kind="audioinput"
+          source="microphone"
+          onActiveDeviceChange={handleActiveDeviceChange}
+        />,
+      );
+
+      await user.click(screen.getByTestId('choose-device'));
+
+      expect(setActiveMediaDeviceMock).toHaveBeenCalledWith('device-2');
+      expect(handleActiveDeviceChange).toHaveBeenCalledWith('device-2');
+    });
+  });
+});

--- a/packages/shadcn/tests/mocks/next-server.ts
+++ b/packages/shadcn/tests/mocks/next-server.ts
@@ -1,0 +1,5 @@
+export class NextResponse extends Response {
+  static json(data: unknown, init?: ResponseInit) {
+    return new Response(JSON.stringify(data), init);
+  }
+}

--- a/packages/shadcn/tests/nextjs-api-token-route.test.ts
+++ b/packages/shadcn/tests/nextjs-api-token-route.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const routeMocks = vi.hoisted(() => ({
+  accessTokenInstances: [] as any[],
+  roomConfigurationFromJson: vi.fn((value: unknown) => ({ type: 'room-config', value })),
+}));
+
+vi.mock('next/server', () => ({
+  NextResponse: class MockNextResponse extends Response {
+    static json(data: unknown, init?: ResponseInit) {
+      return new Response(JSON.stringify(data), init);
+    }
+  },
+}));
+
+vi.mock('livekit-server-sdk', () => ({
+  AccessToken: class MockAccessToken {
+    args: unknown[];
+    addGrant = vi.fn();
+    toJwt = vi.fn(async () => 'participant-token');
+    roomConfig: unknown;
+
+    constructor(...args: unknown[]) {
+      this.args = args;
+      routeMocks.accessTokenInstances.push(this);
+    }
+  },
+}));
+
+vi.mock('@livekit/protocol', () => ({
+  RoomConfiguration: class MockRoomConfiguration {
+    static fromJson = routeMocks.roomConfigurationFromJson;
+  },
+}));
+
+async function importRoute(env: Record<string, string | undefined> = {}) {
+  vi.resetModules();
+  routeMocks.accessTokenInstances.length = 0;
+  routeMocks.roomConfigurationFromJson.mockClear();
+
+  vi.stubEnv('NODE_ENV', env.NODE_ENV ?? 'development');
+  vi.stubEnv('LIVEKIT_URL', env.LIVEKIT_URL);
+  vi.stubEnv('LIVEKIT_API_KEY', env.LIVEKIT_API_KEY);
+  vi.stubEnv('LIVEKIT_API_SECRET', env.LIVEKIT_API_SECRET);
+
+  return import('@/components/agents-ui/nextjs-api-token-route');
+}
+
+describe('nextjs-api-token-route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('exports revalidate set to zero', async () => {
+    const route = await importRoute();
+
+    expect(route.revalidate).toBe(0);
+  });
+
+  it('throws outside development mode', async () => {
+    const { POST } = await importRoute({
+      NODE_ENV: 'production',
+      LIVEKIT_URL: 'wss://livekit.example',
+      LIVEKIT_API_KEY: 'api-key',
+      LIVEKIT_API_SECRET: 'api-secret',
+    });
+
+    await expect(
+      POST(new Request('https://example.test/token', { method: 'POST' })),
+    ).rejects.toThrow('THIS API ROUTE IS INSECURE');
+  });
+
+  it('returns a 500 response when required environment variables are missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { POST } = await importRoute({
+      LIVEKIT_API_KEY: 'api-key',
+      LIVEKIT_API_SECRET: 'api-secret',
+    });
+
+    const response = await POST(new Request('https://example.test/token', { method: 'POST' }));
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response?.status).toBe(500);
+    await expect(response?.text()).resolves.toBe('LIVEKIT_URL is not defined');
+    expect(errorSpy).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('creates a participant token and returns connection details', async () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0.1234).mockReturnValueOnce(0.5678);
+    const { POST } = await importRoute({
+      LIVEKIT_URL: 'wss://livekit.example',
+      LIVEKIT_API_KEY: 'api-key',
+      LIVEKIT_API_SECRET: 'api-secret',
+    });
+
+    const response = await POST(
+      new Request('https://example.test/token', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+    );
+    const data = await response?.json();
+
+    expect(data).toEqual({
+      serverUrl: 'wss://livekit.example',
+      roomName: 'voice_assistant_room_5678',
+      participantName: 'user',
+      participantToken: 'participant-token',
+    });
+    expect(response?.headers.get('Cache-Control')).toBe('no-store');
+
+    const token = routeMocks.accessTokenInstances[0];
+    expect(token.args).toEqual([
+      'api-key',
+      'api-secret',
+      {
+        identity: 'voice_assistant_user_1234',
+        name: 'user',
+        ttl: '15m',
+      },
+    ]);
+    expect(token.addGrant).toHaveBeenCalledWith({
+      room: 'voice_assistant_room_5678',
+      roomJoin: true,
+      canPublish: true,
+      canPublishData: true,
+      canSubscribe: true,
+    });
+    expect(token.roomConfig).toBeInstanceOf(Object);
+  });
+
+  it('parses room_config from the request body', async () => {
+    const roomConfig = { agents: [{ agentName: 'support' }] };
+    const { POST } = await importRoute({
+      LIVEKIT_URL: 'wss://livekit.example',
+      LIVEKIT_API_KEY: 'api-key',
+      LIVEKIT_API_SECRET: 'api-secret',
+    });
+
+    await POST(
+      new Request('https://example.test/token', {
+        method: 'POST',
+        body: JSON.stringify({ room_config: roomConfig }),
+      }),
+    );
+
+    expect(routeMocks.roomConfigurationFromJson).toHaveBeenCalledWith(roomConfig, {
+      ignoreUnknownFields: true,
+    });
+    expect(routeMocks.accessTokenInstances[0].roomConfig).toEqual({
+      type: 'room-config',
+      value: roomConfig,
+    });
+  });
+});

--- a/packages/shadcn/tests/use-agent-control-bar.test.ts
+++ b/packages/shadcn/tests/use-agent-control-bar.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { Track } from 'livekit-client';
+import { useInputControls, usePublishPermissions } from '@/hooks/agents-ui/use-agent-control-bar';
+import * as LiveKitComponents from '@livekit/components-react';
+
+const saveAudioInputEnabledMock = vi.fn();
+const saveVideoInputEnabledMock = vi.fn();
+const saveAudioInputDeviceIdMock = vi.fn();
+const saveVideoInputDeviceIdMock = vi.fn();
+const microphoneToggleMock = vi.fn();
+const cameraToggleMock = vi.fn();
+const screenShareToggleMock = vi.fn();
+
+const toggleState = {
+  microphone: { enabled: false, pending: false, toggle: microphoneToggleMock },
+  camera: { enabled: false, pending: false, toggle: cameraToggleMock },
+  screenShare: { enabled: false, pending: false, toggle: screenShareToggleMock },
+};
+
+vi.mock('@livekit/components-react', async () => {
+  const actual = await vi.importActual('@livekit/components-react');
+  return {
+    ...actual,
+    useLocalParticipantPermissions: vi.fn(() => ({
+      canPublish: true,
+      canPublishSources: [],
+      canPublishData: true,
+    })),
+    usePersistentUserChoices: vi.fn(() => ({
+      saveAudioInputEnabled: saveAudioInputEnabledMock,
+      saveVideoInputEnabled: saveVideoInputEnabledMock,
+      saveAudioInputDeviceId: saveAudioInputDeviceIdMock,
+      saveVideoInputDeviceId: saveVideoInputDeviceIdMock,
+    })),
+    useSessionContext: vi.fn(() => ({
+      local: { microphoneTrack: { source: Track.Source.Microphone } },
+    })),
+    useTrackToggle: vi.fn(({ source }) => {
+      if (source === Track.Source.Camera) {
+        return toggleState.camera;
+      }
+      if (source === Track.Source.ScreenShare) {
+        return toggleState.screenShare;
+      }
+      return toggleState.microphone;
+    }),
+  };
+});
+
+describe('usePublishPermissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(LiveKitComponents.useLocalParticipantPermissions).mockReturnValue({
+      canPublish: true,
+      canPublishSources: [],
+      canPublishData: true,
+    } as any);
+  });
+
+  it('allows all publish sources when no source restriction is present', () => {
+    const { result } = renderHook(() => usePublishPermissions());
+
+    expect(result.current).toEqual({
+      camera: true,
+      microphone: true,
+      screenShare: true,
+      data: true,
+    });
+  });
+
+  it('maps restricted publish sources to camera, microphone, and screen share', () => {
+    vi.mocked(LiveKitComponents.useLocalParticipantPermissions).mockReturnValue({
+      canPublish: true,
+      canPublishSources: [2],
+      canPublishData: false,
+    } as any);
+
+    const { result } = renderHook(() => usePublishPermissions());
+
+    expect(result.current).toEqual({
+      camera: false,
+      microphone: true,
+      screenShare: false,
+      data: false,
+    });
+  });
+
+  it('denies all media sources when canPublish is false', () => {
+    vi.mocked(LiveKitComponents.useLocalParticipantPermissions).mockReturnValue({
+      canPublish: false,
+      canPublishSources: [],
+      canPublishData: true,
+    } as any);
+
+    const { result } = renderHook(() => usePublishPermissions());
+
+    expect(result.current).toEqual({
+      camera: false,
+      microphone: false,
+      screenShare: false,
+      data: true,
+    });
+  });
+});
+
+describe('useInputControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toggleState.microphone = { enabled: false, pending: false, toggle: microphoneToggleMock };
+    toggleState.camera = { enabled: false, pending: false, toggle: cameraToggleMock };
+    toggleState.screenShare = { enabled: false, pending: false, toggle: screenShareToggleMock };
+  });
+
+  it('returns the microphone track from the session context', () => {
+    const { result } = renderHook(() => useInputControls());
+
+    expect(result.current.microphoneTrack).toEqual({ source: Track.Source.Microphone });
+  });
+
+  it('creates track toggles for microphone, camera, and screen share', () => {
+    renderHook(() => useInputControls());
+
+    expect(LiveKitComponents.useTrackToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ source: Track.Source.Microphone }),
+    );
+    expect(LiveKitComponents.useTrackToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ source: Track.Source.Camera }),
+    );
+    expect(LiveKitComponents.useTrackToggle).toHaveBeenCalledWith(
+      expect.objectContaining({ source: Track.Source.ScreenShare }),
+    );
+  });
+
+  it('persists selected audio and video device ids', () => {
+    const { result } = renderHook(() => useInputControls());
+
+    act(() => {
+      result.current.handleAudioDeviceChange('audio-device');
+      result.current.handleVideoDeviceChange('video-device');
+    });
+
+    expect(saveAudioInputDeviceIdMock).toHaveBeenCalledWith('audio-device');
+    expect(saveVideoInputDeviceIdMock).toHaveBeenCalledWith('video-device');
+  });
+
+  it('persists microphone enabled preference after toggling', async () => {
+    const { result } = renderHook(() => useInputControls());
+
+    await act(async () => {
+      await result.current.microphoneToggle.toggle(true);
+    });
+
+    expect(microphoneToggleMock).toHaveBeenCalledWith(true);
+    expect(saveAudioInputEnabledMock).toHaveBeenCalledWith(true);
+  });
+
+  it('turns off screen share before enabling camera', async () => {
+    toggleState.screenShare = { enabled: true, pending: false, toggle: screenShareToggleMock };
+    const { result } = renderHook(() => useInputControls());
+
+    await act(async () => {
+      await result.current.cameraToggle.toggle(true);
+    });
+
+    expect(screenShareToggleMock).toHaveBeenCalledWith(false);
+    expect(cameraToggleMock).toHaveBeenCalledWith(true);
+    expect(saveVideoInputEnabledMock).toHaveBeenCalledWith(true);
+  });
+
+  it('turns off camera before enabling screen share', async () => {
+    toggleState.camera = { enabled: true, pending: false, toggle: cameraToggleMock };
+    const { result } = renderHook(() => useInputControls());
+
+    await act(async () => {
+      await result.current.screenShareToggle.toggle(true);
+    });
+
+    expect(cameraToggleMock).toHaveBeenCalledWith(false);
+    expect(screenShareToggleMock).toHaveBeenCalledWith(true);
+  });
+
+  it('routes device errors with the matching track source', () => {
+    const handleDeviceError = vi.fn();
+    const { result } = renderHook(() => useInputControls({ onDeviceError: handleDeviceError }));
+    const microphoneError = new Error('microphone error');
+    const cameraError = new Error('camera error');
+
+    act(() => {
+      result.current.handleMicrophoneDeviceSelectError(microphoneError);
+      result.current.handleCameraDeviceSelectError(cameraError);
+    });
+
+    expect(handleDeviceError).toHaveBeenCalledWith({
+      source: Track.Source.Microphone,
+      error: microphoneError,
+    });
+    expect(handleDeviceError).toHaveBeenCalledWith({
+      source: Track.Source.Camera,
+      error: cameraError,
+    });
+  });
+
+  it('passes preventSave when saveUserChoices is false', () => {
+    renderHook(() => useInputControls({ saveUserChoices: false }));
+
+    expect(LiveKitComponents.usePersistentUserChoices).toHaveBeenCalledWith({
+      preventSave: true,
+    });
+  });
+});

--- a/packages/shadcn/vitest.config.ts
+++ b/packages/shadcn/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './'),
+      'next/server': path.resolve(__dirname, './tests/mocks/next-server.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Closes CLT-2913.

### Theme-aware aura in session view

- Adds `themeMode?: 'dark' | 'light'` to `AgentSessionView_01`
- Threads it through `TileLayout` -> `AudioVisualizer` -> `AgentAudioVisualizerAura`
- Updates the Storybook story to use `next-themes` resolved theme
- Renames internal chat state/props from `chatOpen` to `isChatOpen`

### Registry updates

- Adds `@agents-ui/all` as a meta registry item
- Installs supported `@agents-ui` components via `registryDependencies`
- Excludes `nextjs-api-token-route` from `all` because it is an app route, not a drop-in component
- Runs shadcn tests before `registry:build`

### Test coverage

- Adds tests for `AgentTrackControl`
- Adds tests for `usePublishPermissions` and `useInputControls`
- Adds tests for `nextjs-api-token-route`
- Adds a Vitest `next/server` alias for route tests

## Verification

- [x] `pnpm --dir packages/shadcn test` (22 files, 274 tests)
- [x] `pnpm --dir packages/shadcn test -- agent-track-control.test.tsx use-agent-control-bar.test.ts nextjs-api-token-route.test.ts` (3 files, 26 tests)
- [x] `git diff origin/main... --check`
- [x] `shadcn build` emits `dist/r/all.json`
- [x] Manual Storybook check: `AgentSessionView-01` + `audioVisualizerType: 'aura'` follows theme toggles

## Notes

- Full `registry:build` still requires `packages/shadcn/.env.local` for the doc-gen step in this workspace.
- Package-wide `tsc --noEmit` still reports existing unrelated config/type issues.
