### PR TITLE
Allow audio output switching on iOS 26

### DIFF
--- a/packages/core/src/components/mediaDeviceSelect.ts
+++ b/packages/core/src/components/mediaDeviceSelect.ts
@@ -4,7 +4,7 @@ import {
   type LocalVideoTrack,
   type Room,
   type LocalTrack,
-  getBrowser,
+  supportsSetSinkId,
 } from 'livekit-client';
 import { BehaviorSubject } from 'rxjs';
 import { log } from '../logger';
@@ -36,9 +36,8 @@ export function setupDeviceSelector(
         id === 'default' && localTrack.mediaStreamTrack.label.startsWith('Default') ? id : actualId,
       );
     } else if (room) {
-      const browser = getBrowser();
-      if (kind === 'audiooutput' && (browser?.name === 'Safari' || browser?.os === 'iOS')) {
-        log.warn(`Switching audio output device is not supported on Safari and iOS.`);
+      if (kind === 'audiooutput' && !supportsSetSinkId()) {
+        log.warn(`Switching audio output device is not supported on Safari using iOS <26.`);
         return;
       }
       log.debug(`Switching active device of kind "${kind}" with id ${id}.`);


### PR DESCRIPTION
Requires https://github.com/livekit/client-sdk-js/pull/1635

The `audiooutput` guard in `setupDeviceSelector` was hardcoded to block on any Safari-based browser. iOS/Safari 26+ now supports `HTMLMediaElement.setSinkId()`, so the guard should defer to `supportsSetSinkId()` from `livekit-client` instead.