### PR TITLE
fix(shadcn): invalid postfix ++ on type assertion in ReactShaderToy

### DIFF
--- a/packages/shadcn/components/agents-ui/react-shader-toy.tsx
+++ b/packages/shadcn/components/agents-ui/react-shader-toy.tsx
@@ -821,7 +821,9 @@ export function ReactShaderToy({
     }
     if (uniformsRef.current.iFrame?.isNeeded) {
       const timeDeltaUniform = gl.getUniformLocation(shaderProgramRef.current, UNIFORM_FRAME);
-      gl.uniform1i(timeDeltaUniform, (uniformsRef.current.iFrame.value as number)++);
+      const frame = uniformsRef.current.iFrame.value as number;
+      gl.uniform1i(timeDeltaUniform, frame);
+      uniformsRef.current.iFrame.value = frame + 1;
     }
     if (texturesArrRef.current.length > 0) {
       for (let index = 0; index < texturesArrRef.current.length; index++) {


### PR DESCRIPTION
## What

Fixes invalid TypeScript on `react-shader-toy.tsx:824`.

```ts
// Before — TS error: operand of ++ must be a variable or property access
gl.uniform1i(timeDeltaUniform, (uniformsRef.current.iFrame.value as number)++);

// After
const frame = uniformsRef.current.iFrame.value as number;
gl.uniform1i(timeDeltaUniform, frame);
uniformsRef.current.iFrame.value = frame + 1;
```

## Why

Unblocks the Vercel build when this component is pulled into `web` https://github.com/livekit/web/pull/4377. 

The original expression applies postfix `++` to a type assertion, which TS rejects since assertions aren't valid l-values.

## Notes

- Preserves postfix-increment semantics: pass current frame to the uniform, then increment.
- `tsc --noEmit` on `packages/shadcn` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)