### PR TITLE
fix(react): forward track to setupDeviceSelector in useMediaDeviceSelect

### DIFF
--- a/.changeset/forward-track-to-device-selector.md
+++ b/.changeset/forward-track-to-device-selector.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Forward the local `track` to `setupDeviceSelector` in `useMediaDeviceSelect` so `setActiveMediaDevice` switches the microphone or camera in pre-join / preview mode (no connected room).

--- a/packages/react/src/hooks/useMediaDeviceSelect.test.ts
+++ b/packages/react/src/hooks/useMediaDeviceSelect.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react';
+import type * as ComponentsCore from '@livekit/components-core';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { useMediaDeviceSelect } from './useMediaDeviceSelect';
+
+// Minimal subscribable so we avoid touching navigator.mediaDevices in jsdom.
+const noopObserver = { subscribe: () => ({ unsubscribe: () => {} }) };
+
+// Mock only the device enumeration + logging so jsdom does not touch navigator.mediaDevices.
+// The real setupDeviceSelector is kept so we exercise the actual track-forwarding behaviour.
+vi.mock('@livekit/components-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof ComponentsCore>();
+  return {
+    ...actual,
+    createMediaDeviceObserver: () => noopObserver,
+    log: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useMediaDeviceSelect in preview mode', () => {
+  test('forwards the local track so setActiveMediaDevice switches the device', async () => {
+    // A preview track as returned by usePreviewTracks / createLocalTracks.
+    const setDeviceId = vi.fn().mockResolvedValue(undefined);
+    const getDeviceId = vi.fn().mockResolvedValue('mic-2');
+    const mockLocalTrack = {
+      setDeviceId,
+      getDeviceId,
+      mediaStreamTrack: { label: 'Fake Microphone 2' },
+    } as unknown as Parameters<typeof useMediaDeviceSelect>[0]['track'];
+
+    // No room and no RoomContext => preview mode (roomFallback becomes new Room()).
+    const { result } = renderHook(() =>
+      useMediaDeviceSelect({ kind: 'audioinput', track: mockLocalTrack }),
+    );
+
+    await act(async () => {
+      await result.current.setActiveMediaDevice('mic-2');
+    });
+
+    // In preview mode the only way to actually switch the device is via the track.
+    expect(setDeviceId).toHaveBeenCalledWith('mic-2');
+  });
+});

--- a/packages/react/src/hooks/useMediaDeviceSelect.ts
+++ b/packages/react/src/hooks/useMediaDeviceSelect.ts
@@ -60,7 +60,7 @@ export function useMediaDeviceSelect({
     roomFallback?.getActiveDevice(kind) ?? 'default',
   );
   const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
-    () => setupDeviceSelector(kind, roomFallback),
+    () => setupDeviceSelector(kind, roomFallback, track),
     [kind, roomFallback, track],
   );
 


### PR DESCRIPTION
Closes #1315

## Root cause

`useMediaDeviceSelect` keeps `track` in its `useMemo` dependency array but never forwards it to `setupDeviceSelector`.

`packages/react/src/hooks/useMediaDeviceSelect.ts` (line 62-65):

```ts
const { className, activeDeviceObservable, setActiveMediaDevice } = React.useMemo(
  () => setupDeviceSelector(kind, roomFallback), // track is a dep but never passed
  [kind, roomFallback, track],
);
```

`packages/core/src/components/mediaDeviceSelect.ts` defines a 3-arg signature and branches on the track:

```ts
export function setupDeviceSelector(
  kind: MediaDeviceKind,
  room: Room,
  localTrack?: LocalAudioTrack | LocalVideoTrack,
) {
  ...
  const setActiveMediaDevice = async (id, options = {}) => {
    if (localTrack) {
      await localTrack.setDeviceId(...);   // preview / pre-join path
    } else if (room) {
      await room.switchActiveDevice(...);  // no-ops on the dummy `new Room()`
    }
  };
}
```

In pre-join / preview UIs there is no connected room, so `roomFallback` is a dummy `new Room()`. Because `localTrack` is `undefined`, `setActiveMediaDevice` takes the `room.switchActiveDevice` branch, which does nothing on that dummy room. The result is that `setActiveMediaDevice` silently fails to switch the mic or camera before joining.

## The fix

```diff
-    () => setupDeviceSelector(kind, roomFallback),
+    () => setupDeviceSelector(kind, roomFallback, track),
     [kind, roomFallback, track],
```

`track` is already in the `useMemo` deps, so no dependency-array change is needed. This is purely additive forwarding of an already-tracked value.

## Proof (verify-first)

I reproduced the bug with a deterministic test BEFORE writing the fix.

The test renders `useMediaDeviceSelect({ kind: 'audioinput', track })` in preview mode (no room, no RoomContext, so `roomFallback` is a fresh `new Room()`) with a spy `track.setDeviceId`, calls `setActiveMediaDevice('mic-2')`, and asserts the track was switched. It keeps the real `setupDeviceSelector` (only the device enumeration and logging are mocked so jsdom does not touch `navigator.mediaDevices`).

RED on current code (`packages/react`):

```
 × forwards the local track so setActiveMediaDevice switches the device
 FAIL src/hooks/useMediaDeviceSelect.test.ts > useMediaDeviceSelect in preview mode > forwards the local track so setActiveMediaDevice switches the device
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'mic-2' ]
 Number of calls: 0
   45|     expect(setDeviceId).toHaveBeenCalledWith('mic-2');
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

GREEN after the fix:

```
 ✓ src/hooks/useMediaDeviceSelect.test.ts (1 test)
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Full suites stay green: `packages/react` 8 passed, `packages/core` 98 passed. `pnpm build` (all packages), lint, and format check are clean.

## Risk

None expected. The change only forwards a value that was already a memo dependency, and the preview-track code path in `setupDeviceSelector` already existed and was simply unreachable from this hook.

## Out of scope

While testing I noticed a separate UI-feedback quirk: `setupDeviceSelector` updates an internal `activeDeviceSubject` but returns the room-event-based `activeDeviceObservable`, so the active-item highlight does not reflect a preview-mode switch even after this fix. That is a distinct issue from #1315 (which is about the switch itself not happening) and is not addressed here.
