### PR TITLE
Group dependency updates to reduce PR noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,17 +6,25 @@
     {
       "schedule": "before 6am on the first day of the month",
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchPackageNames": ["!/^@livekit//", "!/^livekit-/"],
+      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
       "groupName": "devDependencies (non-major)"
     },
     {
       "schedule": "before 6am on the first day of the month",
-      "matchPackagePrefixes": ["@rushstack"],
+      "matchDepTypes": ["dependencies", "optionalDependencies", "peerDependencies"],
+      "matchPackageNames": ["!/^@livekit//", "!/^livekit-/"],
+      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
+      "groupName": "dependencies (non-major)"
+    },
+    {
+      "schedule": "before 6am on the first day of the month",
+      "matchPackageNames": ["/^@rushstack//"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "Rush stack (non-major)"
     },
     {
-      "matchPackagePrefixes": ["@livekit", "livekit-"],
+      "matchPackageNames": ["/^@livekit//", "/^livekit-/"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "LiveKit dependencies (non-major)"
     }


### PR DESCRIPTION
- Group non-major runtime dependency updates (dependencies / peer / optional) into a single monthly pull request, the same way `devDependencies` were already grouped. Previously each runtime dependency opened its own PR, creating a lot of pull request spam.
- Exclude livekit-* / @livekit/* from the generic groups so they keep landing in the dedicated "LiveKit dependencies" group.