### PR TITLE
Fix intersection observer

### DIFF
--- a/.changeset/fix-manage-subscription-intersection-observer.md
+++ b/.changeset/fix-manage-subscription-intersection-observer.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-react': patch
+---
+
+Fix `manageSubscription` on `VideoTrack` not following tile visibility

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -41,12 +41,25 @@ export const VideoTrack: (
   ) {
     const trackReference = useEnsureTrackRef(trackRef);
 
-    const mediaEl = React.useRef<HTMLVideoElement>(null);
+    const mediaEl = React.useRef<HTMLVideoElement | null>(null);
     React.useImperativeHandle(ref, () => mediaEl.current as HTMLVideoElement);
 
-    const intersectionEntry = useHooks.useIntersectionObserver({ root: mediaEl.current });
+    const { ref: intersectionRef, entry: intersectionEntry } = useHooks.useIntersectionObserver({
+      root: null,
+    });
 
     const [debouncedIntersectionEntry] = useHooks.useDebounceValue(intersectionEntry, 3000);
+
+    const managedPublicationRef = React.useRef<RemoteTrackPublication | null>(null);
+    const manageSubscriptionRef = React.useRef(false);
+
+    React.useEffect(() => {
+      manageSubscriptionRef.current = !!manageSubscription;
+      managedPublicationRef.current =
+        trackReference.publication instanceof RemoteTrackPublication
+          ? trackReference.publication
+          : null;
+    }, [trackReference.publication, manageSubscription]);
 
     React.useEffect(() => {
       if (
@@ -57,7 +70,7 @@ export const VideoTrack: (
       ) {
         trackReference.publication.setSubscribed(false);
       }
-    }, [debouncedIntersectionEntry, trackReference, manageSubscription]);
+    }, [debouncedIntersectionEntry, intersectionEntry, trackReference, manageSubscription]);
 
     React.useEffect(() => {
       if (
@@ -68,6 +81,14 @@ export const VideoTrack: (
         trackReference.publication.setSubscribed(true);
       }
     }, [intersectionEntry, trackReference, manageSubscription]);
+
+    React.useEffect(() => {
+      return () => {
+        if (manageSubscriptionRef.current) {
+          managedPublicationRef.current?.setSubscribed(false);
+        }
+      };
+    }, []);
 
     const {
       elementProps,
@@ -87,6 +108,16 @@ export const VideoTrack: (
       onTrackClick?.({ participant: trackReference?.participant, track: pub });
     };
 
-    return <video ref={mediaEl} {...elementProps} muted={true} onClick={clickHandler}></video>;
+    return (
+      <video
+        ref={(el) => {
+          mediaEl.current = el;
+          intersectionRef(el);
+        }}
+        {...elementProps}
+        muted={true}
+        onClick={clickHandler}
+      ></video>
+    );
   },
 );

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -116,13 +116,6 @@ export const VideoTrack: (
       [intersectionRef],
     );
 
-    return (
-      <video
-        ref={setVideoRef}
-        {...elementProps}
-        muted={true}
-        onClick={clickHandler}
-      ></video>
-    );
+    return <video ref={setVideoRef} {...elementProps} muted={true} onClick={clickHandler}></video>;
   },
 );

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -54,7 +54,7 @@ export const VideoTrack: (
     const manageSubscriptionRef = React.useRef(false);
 
     React.useEffect(() => {
-      manageSubscriptionRef.current = !!manageSubscription;
+      manageSubscriptionRef.current = Boolean(manageSubscription);
       managedPublicationRef.current =
         trackReference.publication instanceof RemoteTrackPublication
           ? trackReference.publication

--- a/packages/react/src/components/participant/VideoTrack.tsx
+++ b/packages/react/src/components/participant/VideoTrack.tsx
@@ -108,12 +108,17 @@ export const VideoTrack: (
       onTrackClick?.({ participant: trackReference?.participant, track: pub });
     };
 
+    const setVideoRef = React.useCallback(
+      (el: HTMLVideoElement | null) => {
+        mediaEl.current = el;
+        intersectionRef(el);
+      },
+      [intersectionRef],
+    );
+
     return (
       <video
-        ref={(el) => {
-          mediaEl.current = el;
-          intersectionRef(el);
-        }}
+        ref={setVideoRef}
         {...elementProps}
         muted={true}
         onClick={clickHandler}


### PR DESCRIPTION
The `usehooks-ts` v2 -> v3 migration released in `@livekit/components-react@2.3.4` (from 7cd73d75, so this has been broken since 2024 😬) changed the `useIntersectionObserver` API. In v3 the hook returns `{ ref, isIntersecting, entry }`, and the caller must attach the returned ref callback to the element being observed.

`VideoTrack` was never updated to take this into account:
- It ignored the returned ref, so the observer was attached to nothing - isIntersecting was stuck at its initial false forever.
- It passed `mediaEl.current` as root, but root is the scroll-container/viewport to measure against (default `null`), not the target element.

As a result, manageSubscription was not seeing actual visibility changes: tracks didn't subscribe when tiles became visible.

Core fix authored by @M-Blobby - I've cherry picked it over from a fork. Fixes https://github.com/livekit/components-js/issues/1325

## Todo
- [x] I haven't tested this fix in an example app, so do that and make sure it's not obviously broken in some way