### PR TITLE
fix(core): surface final lk.transcription_final for user transcriptions

### DIFF
--- a/packages/core/src/components/textStream.ts
+++ b/packages/core/src/components/textStream.ts
@@ -87,6 +87,12 @@ export function setupTextStream(room: Room, topic: string): Observable<TextStrea
               textStreams[index] = {
                 ...textStreams[index],
                 text: accumulatedText,
+                // Carry the latest streamInfo forward. Transcription updates for a
+                // segment arrive as separate streams sharing the same lk.segment_id;
+                // keeping the original streamInfo would freeze attributes that change
+                // over the segment's lifetime — notably lk.transcription_final flipping
+                // "false" -> "true" on the final user STT result.
+                streamInfo: reader.info,
               };
 
               // Emit the updated array


### PR DESCRIPTION
## Summary

`useTranscriptions` reports a stale `lk.transcription_final` for **user STT** segments —
it stays `"false"` even after the segment is finalized. Agent (TTS) segments are
unaffected and correctly report `"true"`.

## Root cause

Transcription updates for a segment arrive as separate text streams sharing the same
`lk.segment_id`. `setupTextStream` dedupes by that id, but when it finds an existing
entry it updates only `text` and keeps the `streamInfo` captured from the **first**
stream it saw for the segment:

```ts
textStreams[index] = {
  ...textStreams[index],
  text: accumulatedText,
  // streamInfo never refreshed
};
```

Because `streamInfo.attributes` is frozen at the first interim update, any attribute that
changes over the life of a segment is lost. For user STT the first stream is an interim
result with `lk.transcription_final="false"`; the finalizing stream (`"true"`) replaces
only `.text`, so consumers never observe the final flag. Agent segments happen to work
because the first stream they see already carries `lk.transcription_final="true"`.

## Fix

Carry the latest `streamInfo` forward on update:

```ts
textStreams[index] = {
  ...textStreams[index],
  text: accumulatedText,
  streamInfo: reader.info,
};
```

`reader.info` for a later stream is a refresh of the same segment's info — `lk.segment_id`
is still present (dedup is unaffected), and `lk.transcription_final` / `lk.transcribed_track_id`
etc. are brought up to date.

## Reproduction

Frontend renders `useTranscriptions()[i].streamInfo.attributes['lk.transcription_final']`
and talks to a livekit-agents agent with STT enabled. The agent's `user_input_transcribed`
event reports `is_final=True`, but the UI shows `"false"` for every user segment.

## Testing

- `pnpm --filter @livekit/components-core build` — passes
- `pnpm --filter @livekit/components-core test` — 98/98 passing
- Verified end-to-end against a live agent: user segments now flip to `final="true"` on finalization.

## Changeset

`@livekit/components-core` — patch: Fix `useTranscriptions` reporting a stale
`lk.transcription_final` (and other mutable stream attributes) for user STT segments;
`setupTextStream` now carries the latest `streamInfo` forward on segment updates.

## Notes

- Orthogonal to #1346 (transcription ordering) — both touch the same object literal but
  different fields, so they don't conflict.
- Producer side is correct; this is purely a consumer-side fix in `@livekit/components-core`.
