### PR TITLE
fix(shadcn): re-fetch labeled devices when track already acquired

### DIFF
--- a/docs/storybook/stories/agents-ui/AgentTrackControl.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentTrackControl.stories.tsx
@@ -47,7 +47,7 @@ export default {
 export const Default: StoryObj<AgentTrackControlProps> = {
   render: (args: AgentTrackControlProps) => {
     const [isCameraPressed, setIsCameraPressed] = React.useState(true);
-    const [isMicrophonePressed, setIsMicrophonePressed] = React.useState(false);
+    const [isMicrophonePressed, setIsMicrophonePressed] = React.useState(true);
     const [isScreenSharePressed, setIsScreenSharePressed] = React.useState(true);
     const { microphoneTrack } = useAgent();
 

--- a/packages/shadcn/components/agents-ui/agent-track-control.tsx
+++ b/packages/shadcn/components/agents-ui/agent-track-control.tsx
@@ -74,6 +74,18 @@ const selectVariants = cva(
 type TrackDeviceSelectProps = React.ComponentProps<typeof SelectTrigger> &
   VariantProps<typeof selectVariants> & {
     /**
+     * The type of media device (audioinput or videoinput).
+     */
+    kind: MediaDeviceKind;
+    /**
+     * Array of available devices
+     */
+    devices: MediaDeviceInfo[];
+    /**
+     * Active device ID
+     */
+    activeDeviceId?: string;
+    /**
      * The size of the select.
      * @defaultValue 'default'
      */
@@ -84,29 +96,13 @@ type TrackDeviceSelectProps = React.ComponentProps<typeof SelectTrigger> &
      */
     variant?: 'default' | 'outline' | null;
     /**
-     * The type of media device (audioinput or videoinput).
-     */
-    kind: MediaDeviceKind;
-    /**
-     * The track source to control (Microphone, Camera, or ScreenShare).
-     */
-    track?: LocalAudioTrack | LocalVideoTrack | undefined;
-    /**
-     * Whether a track of this kind has already been acquired/published elsewhere.
-     */
-    pressed?: boolean;
-    /**
      * Whether to request permissions for the media device.
      */
     requestPermissions?: boolean;
     /**
-     * Callback when a media device error occurs.
+     * Callback when the select is opened or closed.
      */
-    onMediaDeviceError?: (error: Error) => void;
-    /**
-     * Callback when the device list changes.
-     */
-    onDeviceListChange?: (devices: MediaDeviceInfo[]) => void;
+    onOpen: (open: boolean) => void;
     /**
      * Callback when the active device changes.
      */
@@ -124,63 +120,32 @@ type TrackDeviceSelectProps = React.ComponentProps<typeof SelectTrigger> &
  *   size="sm"
  *   variant="outline"
  *   kind="audioinput"
- *   track={micTrackRef}
+ *   devices={devices}
+ *   activeDeviceId={activeDeviceId}
+ *   onOpen={setOpen}
+ *   onActiveDeviceChange={setActiveDeviceId}
  * />
  * ```
  */
 function TrackDeviceSelect({
   kind,
-  track,
-  pressed,
+  devices,
+  activeDeviceId,
   size = 'default',
   variant = 'default',
-  requestPermissions = false,
-  onMediaDeviceError,
-  onDeviceListChange,
-  onActiveDeviceChange,
   className,
+  onOpen,
+  onActiveDeviceChange,
   ...props
 }: TrackDeviceSelectProps) {
-  const room = useMaybeRoomContext();
   const [open, setOpen] = useState(false);
-  const [requestPermissionsState, setRequestPermissionsState] = useState(requestPermissions);
-  const { devices, activeDeviceId, setActiveMediaDevice } = useMediaDeviceSelect({
-    room,
-    kind,
-    track,
-    requestPermissions: requestPermissionsState,
-    onError: onMediaDeviceError,
-  });
-
-  useEffect(() => {
-    onDeviceListChange?.(devices);
-  }, [devices, onDeviceListChange]);
-
-  useEffect(() => {
-    // A track was already acquired elsewhere (e.g. session.start()), so permission is already
-    // granted — safe to fetch labeled devices without a second getUserMedia prompt. Without
-    // this, the list stays label-less until a page reload, since the device observer only
-    // re-fetches when `requestPermissions` changes value.
-    if (pressed) {
-      setRequestPermissionsState(true);
-    }
-  }, [pressed]);
 
   const handleOpenChange = (open: boolean) => {
     setOpen(open);
-    if (open) {
-      setRequestPermissionsState(true);
-    }
+    onOpen(open);
   };
 
-  const handleActiveDeviceChange = (deviceId: string) => {
-    setActiveMediaDevice(deviceId);
-    onActiveDeviceChange?.(deviceId);
-  };
-
-  const filteredDevices = useMemo(() => devices.filter((d) => d.deviceId !== ''), [devices]);
-
-  if (filteredDevices.length < 2) {
+  if (devices.length < 2) {
     return null;
   }
 
@@ -189,7 +154,7 @@ function TrackDeviceSelect({
       open={open}
       value={activeDeviceId}
       onOpenChange={handleOpenChange}
-      onValueChange={handleActiveDeviceChange}
+      onValueChange={onActiveDeviceChange}
     >
       <SelectTrigger className={cn(selectVariants({ size, variant }), className)} {...props}>
         {size !== 'sm' && (
@@ -197,7 +162,7 @@ function TrackDeviceSelect({
         )}
       </SelectTrigger>
       <SelectContent position="popper">
-        {filteredDevices.map((device) => (
+        {devices.map((device) => (
           <SelectItem key={device.deviceId} value={device.deviceId} className="font-mono text-xs">
             {device.label}
           </SelectItem>
@@ -232,13 +197,13 @@ export type AgentTrackControlProps = VariantProps<typeof toggleVariants> & {
    */
   disabled?: boolean;
   /**
-   * Additional CSS class names to apply to the container.
-   */
-  className?: string;
-  /**
    * The audio track reference for visualization (only for microphone).
    */
   audioTrack?: TrackReferenceOrPlaceholder;
+  /**
+   * Additional CSS class names to apply to the container.
+   */
+  className?: string;
   /**
    * Callback when the pressed state changes.
    */
@@ -283,6 +248,45 @@ export function AgentTrackControl({
   onMediaDeviceError,
   onActiveDeviceChange,
 }: AgentTrackControlProps) {
+  const room = useMaybeRoomContext();
+  const [requestPermissionsState, setRequestPermissionsState] = useState(false);
+  const { devices, activeDeviceId, setActiveMediaDevice } = useMediaDeviceSelect({
+    room,
+    kind,
+    requestPermissions: requestPermissionsState,
+    onError: onMediaDeviceError,
+  });
+
+  useEffect(() => {
+    // A track was already acquired elsewhere (e.g. session.start()), so permission is already
+    // granted — safe to fetch labeled devices without a second getUserMedia prompt. Without
+    // this, the list stays label-less until a page reload, since the device observer only
+    // re-fetches when `requestPermissions` changes value. Screen share has no `kind` and no
+    // associated device list, so it should never trigger a mic/camera permission request.
+    if (pressed && kind) {
+      setRequestPermissionsState(true);
+    }
+  }, [pressed, kind]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      setRequestPermissionsState(true);
+    }
+  };
+
+  const handleActiveDeviceChange = (deviceId: string) => {
+    setActiveMediaDevice(deviceId);
+    onActiveDeviceChange?.(deviceId);
+  };
+
+  const filteredDevices = useMemo(() => devices.filter((d) => d.deviceId !== ''), [devices]);
+  // Before permission is granted, the browser reports devices with blank ids, which get filtered
+  // out here — that's an *unknown* device count, not a confirmed empty one. Only treat it as
+  // "no devices" once a permission-gated check has actually run and still come up empty;
+  // otherwise the toggle disables itself before the user ever gets a chance to grant permission.
+  const noDevices = Boolean(kind) && requestPermissionsState && filteredDevices.length === 0;
+  const resolvedPressed = pressed && !noDevices;
+
   return (
     <div
       className={cn(
@@ -292,11 +296,11 @@ export function AgentTrackControl({
       )}
     >
       <AgentTrackToggle
-        variant={variant ?? 'default'}
         source={source}
-        pressed={pressed}
         pending={pending}
-        disabled={disabled}
+        variant={variant ?? 'default'}
+        pressed={resolvedPressed}
+        disabled={noDevices || disabled}
         onPressedChange={onPressedChange}
         className="peer/track group/track focus:z-10 has-[.audiovisualizer]:w-auto has-[.audiovisualizer]:px-3 has-[~_button]:rounded-r-none has-[~_button]:border-r-0 has-[~_button]:pr-2 has-[~_button]:pl-3"
       >
@@ -304,8 +308,8 @@ export function AgentTrackControl({
           <AgentAudioVisualizerBar
             size="icon"
             barCount={3}
-            state={pressed ? 'speaking' : 'disconnected'}
-            audioTrack={pressed ? audioTrack : undefined}
+            state={resolvedPressed ? 'speaking' : 'disconnected'}
+            audioTrack={resolvedPressed ? audioTrack : undefined}
             className="audiovisualizer flex h-6 w-auto items-center justify-center gap-0.5"
           >
             <span
@@ -323,14 +327,14 @@ export function AgentTrackControl({
           size="sm"
           kind={kind}
           variant={variant}
-          pressed={pressed}
-          requestPermissions={false}
-          onMediaDeviceError={onMediaDeviceError}
-          onActiveDeviceChange={onActiveDeviceChange}
+          devices={filteredDevices}
+          activeDeviceId={activeDeviceId}
+          onOpen={handleOpenChange}
+          onActiveDeviceChange={handleActiveDeviceChange}
           className={cn([
             'relative',
             'before:bg-border before:absolute before:inset-y-0 before:left-0 before:my-2.5 before:w-px has-[~_button]:before:content-[""]',
-            !pressed && 'before:bg-destructive/20',
+            !resolvedPressed && 'before:bg-destructive/20',
           ])}
         />
       )}

--- a/packages/shadcn/components/agents-ui/agent-track-control.tsx
+++ b/packages/shadcn/components/agents-ui/agent-track-control.tsx
@@ -92,6 +92,10 @@ type TrackDeviceSelectProps = React.ComponentProps<typeof SelectTrigger> &
      */
     track?: LocalAudioTrack | LocalVideoTrack | undefined;
     /**
+     * Whether a track of this kind has already been acquired/published elsewhere.
+     */
+    pressed?: boolean;
+    /**
      * Whether to request permissions for the media device.
      */
     requestPermissions?: boolean;
@@ -127,13 +131,14 @@ type TrackDeviceSelectProps = React.ComponentProps<typeof SelectTrigger> &
 function TrackDeviceSelect({
   kind,
   track,
+  pressed,
   size = 'default',
   variant = 'default',
-  className,
   requestPermissions = false,
   onMediaDeviceError,
   onDeviceListChange,
   onActiveDeviceChange,
+  className,
   ...props
 }: TrackDeviceSelectProps) {
   const room = useMaybeRoomContext();
@@ -150,6 +155,16 @@ function TrackDeviceSelect({
   useEffect(() => {
     onDeviceListChange?.(devices);
   }, [devices, onDeviceListChange]);
+
+  useEffect(() => {
+    // A track was already acquired elsewhere (e.g. session.start()), so permission is already
+    // granted — safe to fetch labeled devices without a second getUserMedia prompt. Without
+    // this, the list stays label-less until a page reload, since the device observer only
+    // re-fetches when `requestPermissions` changes value.
+    if (pressed) {
+      setRequestPermissionsState(true);
+    }
+  }, [pressed]);
 
   const handleOpenChange = (open: boolean) => {
     setOpen(open);
@@ -308,6 +323,7 @@ export function AgentTrackControl({
           size="sm"
           kind={kind}
           variant={variant}
+          pressed={pressed}
           requestPermissions={false}
           onMediaDeviceError={onMediaDeviceError}
           onActiveDeviceChange={onActiveDeviceChange}

--- a/packages/shadcn/tests/agent-track-control.test.tsx
+++ b/packages/shadcn/tests/agent-track-control.test.tsx
@@ -76,8 +76,10 @@ vi.mock('@/components/ui/select', () => ({
 describe('AgentTrackControl', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // A single real device by default — tests that care about the zero-device edge case
+    // override this explicitly rather than relying on an empty list by accident.
     vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
-      devices: [],
+      devices: [{ deviceId: 'device-1', label: 'Built-in Mic' }],
       activeDeviceId: 'device-1',
       setActiveMediaDevice: setActiveMediaDeviceMock,
     } as any);
@@ -156,6 +158,40 @@ describe('AgentTrackControl', () => {
       const visualizer = screen.getByTestId('audio-visualizer');
       expect(visualizer).toHaveAttribute('data-state', 'disconnected');
       expect(visualizer).toHaveAttribute('data-has-track', 'false');
+    });
+
+    it('does not disable the toggle before permissions have ever been requested, even with no devices observed yet', () => {
+      vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+        devices: [],
+        activeDeviceId: undefined,
+        setActiveMediaDevice: setActiveMediaDeviceMock,
+      } as any);
+
+      render(<AgentTrackControl kind="audioinput" source="microphone" pressed={false} />);
+
+      expect(screen.getByTestId('track-toggle')).not.toBeDisabled();
+    });
+
+    it('disables and forces the toggle off once a permission-gated check confirms there are no devices', () => {
+      vi.mocked(LiveKitComponents.useMediaDeviceSelect).mockReturnValue({
+        devices: [],
+        activeDeviceId: undefined,
+        setActiveMediaDevice: setActiveMediaDeviceMock,
+      } as any);
+
+      render(<AgentTrackControl kind="audioinput" source="microphone" pressed />);
+
+      const toggle = screen.getByTestId('track-toggle');
+      expect(toggle).toBeDisabled();
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('never requests mic/camera permission for screen share, which has no device kind', () => {
+      render(<AgentTrackControl kind={undefined as any} source="screen_share" pressed />);
+
+      expect(LiveKitComponents.useMediaDeviceSelect).toHaveBeenLastCalledWith(
+        expect.objectContaining({ requestPermissions: false }),
+      );
     });
   });
 


### PR DESCRIPTION
## Issue

[DGN-650](https://linear.app/livekit/issue/DGN-650/fix-trackselector-bug)

`TrackDeviceSelect` didn't render device options after accepting the `getUserMedia` prompt when the track was already acquired elsewhere (e.g. via `session.start()`)

Also discovered that buttons aren't disabled + `!pressed` if no tracks are available.

## Solution

- Refactored `AgentTrackControl` to handle track fetching so its aware if tracks are available/unavailable
- Disabled toggle if tracks are not available
- Sets `pressed=false` if tracks are not available
- Fetches labeled devices automatically if track was already acquired elsewhere (e.g. `session.start()`)

## Testing

Open [/?path=/story/agents-ui-agenttrackcontrol--default ](https://components-js-storybook-5kld-git-ty-new-branch.staging.livekit.io/?path=/story/agents-ui-agenttrackcontrol--default) in incognito mode (or reset user media permissions)

- [x] TrackSelect appears after user permission is accepted
- [x] `AgentTrackControl` is disabled and not pressed if user permission are denied