### PR TITLE
fix(core): reformat union types per prettier 3.9.5

### DIFF
--- a/packages/core/src/components/chat.ts
+++ b/packages/core/src/components/chat.ts
@@ -76,8 +76,7 @@ function isIgnorableChatMessage(msg: ReceivedChatMessage | LegacyReceivedChatMes
 
 const decodeLegacyMsg = (message: Uint8Array) =>
   JSON.parse(new TextDecoder().decode(message)) as
-    | LegacyReceivedChatMessage
-    | Exclude<ReceivedChatMessage, 'type'>;
+    LegacyReceivedChatMessage | Exclude<ReceivedChatMessage, 'type'>;
 
 const encodeLegacyMsg = (message: LegacyChatMessage) =>
   new TextEncoder().encode(JSON.stringify(message));

--- a/packages/core/src/messages/types.ts
+++ b/packages/core/src/messages/types.ts
@@ -45,7 +45,5 @@ export type ReceivedAgentTranscriptionMessage = ReceivedMessageWithType<
 
 /** @beta */
 export type ReceivedMessage =
-  | ReceivedUserTranscriptionMessage
-  | ReceivedAgentTranscriptionMessage
-  | ReceivedChatMessage;
+  ReceivedUserTranscriptionMessage | ReceivedAgentTranscriptionMessage | ReceivedChatMessage;
 // TODO: images? attachments? rpc?

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -72,8 +72,7 @@ export type ParticipantIdentifier = RequireAtLeastOne<
  * @internal
  */
 export type TrackIdentifier<T extends Track.Source = Track.Source> =
-  | TrackSource<T>
-  | TrackReference;
+  TrackSource<T> | TrackReference;
 
 // ## Util Types
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &

--- a/packages/react/etc/components-react.api.md
+++ b/packages/react/etc/components-react.api.md
@@ -918,7 +918,7 @@ export function useEnsureSession(session?: UseSessionReturn): UseSessionReturn;
 export function useEnsureTrackRef(trackRef?: TrackReferenceOrPlaceholder): TrackReferenceOrPlaceholder;
 
 // @public (undocumented)
-export function useEvents<Emitter extends default_2<EventMap>, EmitterEventMap extends Emitter extends default_2<infer EM> ? EM : never, Event extends Parameters<Emitter['on']>[0], Callback extends EmitterEventMap[Event]>(instance: Emitter | {
+export function useEvents<Emitter extends default_2<EventMap>, EmitterEventMap extends (Emitter extends default_2<infer EM> ? EM : never), Event extends Parameters<Emitter['on']>[0], Callback extends EmitterEventMap[Event]>(instance: Emitter | {
     internal: {
         emitter: Emitter;
     };

--- a/packages/react/src/components/controls/PaginationControl.tsx
+++ b/packages/react/src/components/controls/PaginationControl.tsx
@@ -22,8 +22,7 @@ export function PaginationControl({
   const [interactive, setInteractive] = React.useState(false);
   React.useEffect(() => {
     let subscription:
-      | ReturnType<ReturnType<typeof createInteractingObservable>['subscribe']>
-      | undefined;
+      ReturnType<ReturnType<typeof createInteractingObservable>['subscribe']> | undefined;
     if (connectedElement) {
       subscription = createInteractingObservable(connectedElement.current, 2000).subscribe(
         setInteractive,

--- a/packages/react/src/hooks/useAgent.ts
+++ b/packages/react/src/hooks/useAgent.ts
@@ -43,11 +43,7 @@ type AgentSdkStates = 'initializing' | 'idle' | 'listening' | 'thinking' | 'spea
  * @beta
  * */
 export type AgentState =
-  | 'disconnected'
-  | 'connecting'
-  | 'pre-connect-buffering'
-  | 'failed'
-  | AgentSdkStates;
+  'disconnected' | 'connecting' | 'pre-connect-buffering' | 'failed' | AgentSdkStates;
 
 /** @beta */
 export enum AgentEvent {

--- a/packages/react/src/hooks/useEvents.ts
+++ b/packages/react/src/hooks/useEvents.ts
@@ -4,7 +4,7 @@ import TypedEventEmitter, { EventMap } from 'typed-emitter';
 /** @public */
 export function useEvents<
   Emitter extends TypedEventEmitter<EventMap>,
-  EmitterEventMap extends Emitter extends TypedEventEmitter<infer EM> ? EM : never,
+  EmitterEventMap extends (Emitter extends TypedEventEmitter<infer EM> ? EM : never),
   Event extends Parameters<Emitter['on']>[0],
   Callback extends EmitterEventMap[Event],
 >(

--- a/packages/react/src/hooks/useParticipantTracks.ts
+++ b/packages/react/src/hooks/useParticipantTracks.ts
@@ -19,8 +19,7 @@ type UseParticipantTracksOptions = {
 export function useParticipantTracks<TrackSource extends Track.Source>(
   sources: Array<TrackSource>,
   optionsOrParticipantIdentity:
-    | UseParticipantTracksOptions
-    | UseParticipantTracksOptions['participantIdentity'] = {},
+    UseParticipantTracksOptions | UseParticipantTracksOptions['participantIdentity'] = {},
 ): Array<TrackReference> {
   let participantIdentity: UseParticipantTracksOptions['participantIdentity'];
   let room: UseParticipantTracksOptions['room'];

--- a/packages/react/src/hooks/useSession.ts
+++ b/packages/react/src/hooks/useSession.ts
@@ -108,9 +108,7 @@ type SessionStateConnecting = SessionStateCommon & {
 
 type SessionStateConnected = SessionStateCommon & {
   connectionState:
-    | ConnectionState.Connected
-    | ConnectionState.Reconnecting
-    | ConnectionState.SignalReconnecting;
+    ConnectionState.Connected | ConnectionState.Reconnecting | ConnectionState.SignalReconnecting;
   isConnected: true;
 
   local: {
@@ -151,9 +149,7 @@ type SessionActions = {
 
 /** @beta */
 export type UseSessionReturn = (
-  | SessionStateConnecting
-  | SessionStateConnected
-  | SessionStateDisconnected
+  SessionStateConnecting | SessionStateConnected | SessionStateDisconnected
 ) &
   SessionActions;
 
@@ -580,9 +576,7 @@ export function useSession(
   );
 
   const conversationState = React.useMemo(():
-    | SessionStateConnecting
-    | SessionStateConnected
-    | SessionStateDisconnected => {
+    SessionStateConnecting | SessionStateConnected | SessionStateDisconnected => {
     const common: SessionStateCommon = {
       room,
       internal: sessionInternal,
@@ -775,9 +769,7 @@ export function useSession(
         console.warn('WARNING: Room.prepareConnection failed:', err);
       });
     },
-    [
-      /* note: no prepareConnection here, this effect should only ever run once! */
-    ],
+    [/* note: no prepareConnection here, this effect should only ever run once! */],
   );
 
   return React.useMemo(

--- a/tooling/api-documenter/src/markdown/MarkdownEmitter.ts
+++ b/tooling/api-documenter/src/markdown/MarkdownEmitter.ts
@@ -108,8 +108,7 @@ export class MarkdownEmitter {
       case DocNodeKind.HtmlStartTag:
       case DocNodeKind.HtmlEndTag: {
         const docHtmlTag: DocHtmlStartTag | DocHtmlEndTag = docNode as
-          | DocHtmlStartTag
-          | DocHtmlEndTag;
+          DocHtmlStartTag | DocHtmlEndTag;
         // write the HTML element verbatim into the output
         writer.write(docHtmlTag.emitAsHtml());
         break;

--- a/tooling/api-documenter/src/plugin/PluginLoader.ts
+++ b/tooling/api-documenter/src/plugin/PluginLoader.ts
@@ -34,8 +34,9 @@ export class PluginLoader {
 
         // Load the package
         const entryPoint:
-          | { apiDocumenterPluginManifest?: IApiDocumenterPluginManifest }
-          | undefined = require(resolvedEntryPointPath);
+          { apiDocumenterPluginManifest?: IApiDocumenterPluginManifest } | undefined = require(
+          resolvedEntryPointPath,
+        );
 
         if (!entryPoint) {
           throw new Error('Invalid entry point');


### PR DESCRIPTION
## Issue
No linked Linear ticket.

## Overview
CI's lint step has been broken on `main` since #1337 (prettier bump to 3.9.5) — the new prettier version collapses short multi-line union types onto one line, but the three affected files were never reformatted, so every `test` CI run since then fails at the ESLint/prettier step in `@livekit/components-core`.

## Summary of changes
Whitespace-only `prettier --write` on the three flagged files:
- `packages/core/src/components/chat.ts`
- `packages/core/src/messages/types.ts`
- `packages/core/src/types.ts`

No behavioral changes.

## Testing
- `pnpm --filter @livekit/components-core lint` — passes (previously failed with 3 `prettier/prettier` errors)