### PR TITLE
fix(shadcn): correct DEST_PROP_TYPES_PATH env var name

### DIFF
--- a/packages/shadcn/.env.example
+++ b/packages/shadcn/.env.example
@@ -1,2 +1,2 @@
 DEST_REGISTRY_PATH=/path/to/dest/folder
-DEST_PROP_TYPE_PATH=/path/to/dest/folder
+DEST_PROP_TYPES_PATH=/path/to/dest/folder


### PR DESCRIPTION
## Issue
No linked ticket — small doc/config fix found during workspace cleanup.

## Overview
- Fixed a typo in `packages/shadcn/.env.example`
- `DEST_PROP_TYPE_PATH` → `DEST_PROP_TYPES_PATH` so the example matches the actual expected env var name

## Testing
- No functional code changed; nothing to preview on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)