### PR TITLE
refactor(shadcn): share agent token logic between Vercel route and dev server

### DIFF
--- a/docs/storybook/.storybook/main.js
+++ b/docs/storybook/.storybook/main.js
@@ -38,56 +38,21 @@ function createStorybookTokenRoutePlugin(env) {
         }
 
         try {
-          const { AccessToken, RoomAgentDispatch, RoomConfiguration } = await import(
-            'livekit-server-sdk'
+          // Loaded via Vite's SSR pipeline (rather than `require`/`import`) since this file is
+          // plain CommonJS and `tokenCore.ts` is TypeScript, shared with the Vercel Preview
+          // route in `../api/agents-ui/token.ts`.
+          const { createAgentToken } = await server.ssrLoadModule(
+            path.resolve(__dirname, '../api/agents-ui/tokenCore.ts'),
           );
-          const LIVEKIT_URL = env.LIVEKIT_URL;
-          const API_KEY = env.LIVEKIT_API_KEY;
-          const API_SECRET = env.LIVEKIT_API_SECRET;
-          const AGENT_NAME = env.AGENT_NAME;
 
-          if (LIVEKIT_URL === undefined || LIVEKIT_URL === '') {
-            throw new Error('LIVEKIT_URL is not defined');
-          }
-          if (API_KEY === undefined || API_KEY === '') {
-            throw new Error('LIVEKIT_API_KEY is not defined');
-          }
-          if (API_SECRET === undefined || API_SECRET === '') {
-            throw new Error('LIVEKIT_API_SECRET is not defined');
-          }
-
-          const participantName = 'user';
-          const participantIdentity = `voice_assistant_user_${Math.floor(Math.random() * 10_000)}`;
-          const roomName = `voice_assistant_room_${Math.floor(Math.random() * 10_000)}`;
-          const token = new AccessToken(API_KEY, API_SECRET, {
-            identity: participantIdentity,
-            name: participantName,
-            ttl: '15m',
+          const body = await createAgentToken({
+            LIVEKIT_URL: env.LIVEKIT_URL,
+            LIVEKIT_API_KEY: env.LIVEKIT_API_KEY,
+            LIVEKIT_API_SECRET: env.LIVEKIT_API_SECRET,
+            AGENT_NAME: env.AGENT_NAME,
           });
 
-          token.addGrant({
-            room: roomName,
-            roomJoin: true,
-            canPublish: true,
-            canPublishData: true,
-            canSubscribe: true,
-          });
-
-          token.roomConfig = new RoomConfiguration({
-            agents: [new RoomAgentDispatch({ agentName: AGENT_NAME })],
-          });
-
-          sendResponse(
-            res,
-            200,
-            {
-              server_url: LIVEKIT_URL,
-              room_name: roomName,
-              participant_name: participantName,
-              participant_token: await token.toJwt(),
-            },
-            true,
-          );
+          sendResponse(res, 200, body, true);
         } catch (error) {
           console.error(error);
           const message = error instanceof Error ? error.message : String(error);

--- a/docs/storybook/api/agents-ui/token.ts
+++ b/docs/storybook/api/agents-ui/token.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { AccessToken, RoomAgentDispatch, RoomConfiguration } from 'livekit-server-sdk';
+import { createAgentToken } from './tokenCore';
 
 function sendResponse(res: VercelResponse, status: number, body: unknown, isJson: boolean) {
   res.setHeader('Cache-Control', 'no-store');
@@ -12,8 +12,9 @@ function sendResponse(res: VercelResponse, status: number, body: unknown, isJson
 }
 
 /**
- * Mirrors the local dev-only route in `.storybook/main.js`, so `AgentSessionView-01` can connect
- * to a real LiveKit room on the deployed Vercel preview, not just `pnpm dev:storybook`.
+ * Vercel Preview counterpart to the local dev-only route in `.storybook/main.js` — both share
+ * the token-minting logic in `tokenCore.ts`, so `AgentSessionView-01` can connect to a real
+ * LiveKit room on the deployed Vercel preview, not just `pnpm dev:storybook`.
  *
  * THIS ROUTE IS INSECURE: it has no authentication layer. It's intentionally allowed to run on
  * Vercel Preview deployments, but refuses to run on Vercel Production.
@@ -36,53 +37,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const LIVEKIT_URL = process.env.LIVEKIT_URL;
-    const API_KEY = process.env.LIVEKIT_API_KEY;
-    const API_SECRET = process.env.LIVEKIT_API_SECRET;
-    const AGENT_NAME = process.env.AGENT_NAME;
-
-    if (LIVEKIT_URL === undefined || LIVEKIT_URL === '') {
-      throw new Error('LIVEKIT_URL is not defined');
-    }
-    if (API_KEY === undefined || API_KEY === '') {
-      throw new Error('LIVEKIT_API_KEY is not defined');
-    }
-    if (API_SECRET === undefined || API_SECRET === '') {
-      throw new Error('LIVEKIT_API_SECRET is not defined');
-    }
-
-    const participantName = 'user';
-    const participantIdentity = `voice_assistant_user_${Math.floor(Math.random() * 10_000)}`;
-    const roomName = `voice_assistant_room_${Math.floor(Math.random() * 10_000)}`;
-    const token = new AccessToken(API_KEY, API_SECRET, {
-      identity: participantIdentity,
-      name: participantName,
-      ttl: '15m',
+    const body = await createAgentToken({
+      LIVEKIT_URL: process.env.LIVEKIT_URL,
+      LIVEKIT_API_KEY: process.env.LIVEKIT_API_KEY,
+      LIVEKIT_API_SECRET: process.env.LIVEKIT_API_SECRET,
+      AGENT_NAME: process.env.AGENT_NAME,
     });
-
-    token.addGrant({
-      room: roomName,
-      roomJoin: true,
-      canPublish: true,
-      canPublishData: true,
-      canSubscribe: true,
-    });
-
-    token.roomConfig = new RoomConfiguration({
-      agents: [new RoomAgentDispatch({ agentName: AGENT_NAME })],
-    });
-
-    sendResponse(
-      res,
-      200,
-      {
-        server_url: LIVEKIT_URL,
-        room_name: roomName,
-        participant_name: participantName,
-        participant_token: await token.toJwt(),
-      },
-      true,
-    );
+    sendResponse(res, 200, body, true);
   } catch (error) {
     console.error(error);
     const message = error instanceof Error ? error.message : String(error);

--- a/docs/storybook/api/agents-ui/tokenCore.ts
+++ b/docs/storybook/api/agents-ui/tokenCore.ts
@@ -1,0 +1,58 @@
+import { AccessToken, RoomAgentDispatch, RoomConfiguration } from 'livekit-server-sdk';
+
+export interface AgentTokenEnv {
+  LIVEKIT_URL?: string;
+  LIVEKIT_API_KEY?: string;
+  LIVEKIT_API_SECRET?: string;
+  AGENT_NAME?: string;
+}
+
+/**
+ * Mints a LiveKit AccessToken for the `AgentSessionView-01` story, dispatching the configured
+ * agent into a freshly-created room. Shared by the Vercel Preview API route
+ * (`token.ts`) and the local Storybook dev-server middleware (`.storybook/main.js`).
+ */
+export async function createAgentToken(env: AgentTokenEnv) {
+  const LIVEKIT_URL = env.LIVEKIT_URL;
+  const API_KEY = env.LIVEKIT_API_KEY;
+  const API_SECRET = env.LIVEKIT_API_SECRET;
+  const AGENT_NAME = env.AGENT_NAME;
+
+  if (LIVEKIT_URL === undefined || LIVEKIT_URL === '') {
+    throw new Error('LIVEKIT_URL is not defined');
+  }
+  if (API_KEY === undefined || API_KEY === '') {
+    throw new Error('LIVEKIT_API_KEY is not defined');
+  }
+  if (API_SECRET === undefined || API_SECRET === '') {
+    throw new Error('LIVEKIT_API_SECRET is not defined');
+  }
+
+  const participantName = 'user';
+  const participantIdentity = `voice_assistant_user_${Math.floor(Math.random() * 10_000)}`;
+  const roomName = `voice_assistant_room_${Math.floor(Math.random() * 10_000)}`;
+  const token = new AccessToken(API_KEY, API_SECRET, {
+    identity: participantIdentity,
+    name: participantName,
+    ttl: '15m',
+  });
+
+  token.addGrant({
+    room: roomName,
+    roomJoin: true,
+    canPublish: true,
+    canPublishData: true,
+    canSubscribe: true,
+  });
+
+  token.roomConfig = new RoomConfiguration({
+    agents: [new RoomAgentDispatch({ agentName: AGENT_NAME })],
+  });
+
+  return {
+    server_url: LIVEKIT_URL,
+    room_name: roomName,
+    participant_name: participantName,
+    participant_token: await token.toJwt(),
+  };
+}


### PR DESCRIPTION
## Issue
Addresses reviewer feedback on merged PR [#1394](https://github.com/livekit/components-js/pull/1394#discussion_r3638383840) — no Linear ticket for this follow-up.

## Overview
- The `AgentSessionView-01` story needs a LiveKit token from two places: a Vercel Preview API route and a local Storybook dev-server middleware.
- Both had duplicated token-minting logic, risking future updates being applied to only one copy.
- Extracted the shared "core" into one TypeScript module, used by both.

## Summary of changes
| File | Change |
|---|---|
| `docs/storybook/api/agents-ui/tokenCore.ts` | **New.** Shared `createAgentToken(env)` — env validation, `AccessToken` + `RoomConfiguration` construction. |
| `docs/storybook/api/agents-ui/token.ts` | Vercel route now just calls `createAgentToken` and sends the response. |
| `docs/storybook/.storybook/main.js` | Dev middleware loads `tokenCore.ts` via Vite's `server.ssrLoadModule` (needed since this file is CommonJS and can't natively import TS), then calls `createAgentToken`. |

## Testing
- `pnpm --filter @livekit/component-docs-storybook tsx:check` passes on all touched/new files.
- Ran `pnpm dev:storybook` locally and confirmed the token route still executes end-to-end through the new shared module (returns the expected validation error without `LIVEKIT_URL` set).
- Once this PR's Vercel Preview deploys, verify the `AgentSessionView-01` story still connects to a live room at `<preview-url>/?path=/story/agents-ui-agentsessionview-01--default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)