### PR TITLE
fix(shadcn): respect message-scroller default scrollPreviousItemPeek

### DIFF
--- a/packages/shadcn/components/agents-ui/agent-chat-transcript.tsx
+++ b/packages/shadcn/components/agents-ui/agent-chat-transcript.tsx
@@ -84,7 +84,7 @@ export function AgentChatTranscript({
   scrollMargin,
   scrollEdgeThreshold,
   preserveScrollOnPrepend,
-  scrollPreviousItemPeek = 20,
+  scrollPreviousItemPeek,
   defaultScrollPosition = 'last-anchor',
   scrollButtonRender,
   scrollButtonBehavior,


### PR DESCRIPTION
## Issue
No linked Linear ticket.

## Overview
- `AgentChatTranscript` hardcoded `scrollPreviousItemPeek` to `20px`, silently overriding `message-scroller`'s own default of `64px`.
- Removed the override so the primitive's default applies unless a caller explicitly passes a value.

## Testing
- `pnpm vitest run tests/agent-chat-transcript.test.tsx` — 6/6 passing.
- Manually verified in Storybook (`AgentChatTranscript` stories) that scroll-anchor peek spacing looks correct using the upstream default.
- Vercel preview link for Storybook will appear on this PR once deployed — check it there to see the transcript scroll behavior live.