### PR TITLE
feat(shadcn): add embed-popup-view-01 block to agents-ui

### DIFF
--- a/docs/storybook/.storybook/preview.js
+++ b/docs/storybook/.storybook/preview.js
@@ -11,18 +11,24 @@ export const parameters = {
   controls: { expanded: false },
   layout: 'fullscreen',
   options: {
+    // Ranks agents-ui/Blocks/* ahead of the rest of agents-ui/*, falling back to a plain
+    // alphabetical compare everywhere else. A comparator that returns 0 for "unrelated" pairs
+    // (relying on sort stability to preserve order) isn't transitive once combined with the
+    // strict Blocks-first rule, and Storybook's sort order for a non-transitive comparator is
+    // undefined - in practice that showed up as the Blocks group intermittently splitting
+    // apart or vanishing from the sidebar across reloads. Always returning a real total order
+    // (rank, then title) avoids that.
     storySort: (a, b) => {
-      const AGENTS_UI_PREFIX = 'agents-ui/';
-      const BLOCKS_PREFIX = 'agents-ui/Blocks/';
-      const aIsAgentsUi = a.title.startsWith(AGENTS_UI_PREFIX);
-      const bIsAgentsUi = b.title.startsWith(AGENTS_UI_PREFIX);
-      if (!aIsAgentsUi || !bIsAgentsUi) return 0;
-
-      const aIsBlock = a.title.startsWith(BLOCKS_PREFIX);
-      const bIsBlock = b.title.startsWith(BLOCKS_PREFIX);
-      if (aIsBlock === bIsBlock) return 0;
-
-      return aIsBlock ? -1 : 1;
+      const rank = (title) => {
+        if (!title.startsWith('agents-ui/')) return null;
+        return title.startsWith('agents-ui/Blocks/') ? 0 : 1;
+      };
+      const rankA = rank(a.title);
+      const rankB = rank(b.title);
+      if (rankA !== null && rankB !== null && rankA !== rankB) {
+        return rankA - rankB;
+      }
+      return a.title === b.title ? 0 : a.title.localeCompare(b.title, undefined, { numeric: true });
     },
   },
 };

--- a/docs/storybook/.storybook/preview.js
+++ b/docs/storybook/.storybook/preview.js
@@ -10,6 +10,21 @@ export const parameters = {
   viewMode: 'docs',
   controls: { expanded: false },
   layout: 'fullscreen',
+  options: {
+    storySort: (a, b) => {
+      const AGENTS_UI_PREFIX = 'agents-ui/';
+      const BLOCKS_PREFIX = 'agents-ui/Blocks/';
+      const aIsAgentsUi = a.title.startsWith(AGENTS_UI_PREFIX);
+      const bIsAgentsUi = b.title.startsWith(AGENTS_UI_PREFIX);
+      if (!aIsAgentsUi || !bIsAgentsUi) return 0;
+
+      const aIsBlock = a.title.startsWith(BLOCKS_PREFIX);
+      const bIsBlock = b.title.startsWith(BLOCKS_PREFIX);
+      if (aIsBlock === bIsBlock) return 0;
+
+      return aIsBlock ? -1 : 1;
+    },
+  },
 };
 
 export const globalTypes = {

--- a/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
@@ -68,9 +68,9 @@ export default {
     className: 'h-screen',
     'controls.leave': true,
     'controls.microphone': true,
-    'controls.chat': true,
-    'controls.camera': true,
-    'controls.screenShare': true,
+    'controls.chat': false,
+    'controls.camera': false,
+    'controls.screenShare': false,
     isPreConnectBufferEnabled: true,
     preConnectMessage: 'Agent is listening, ask it a question',
     'audioVisualizer.type': 'bar',
@@ -110,4 +110,14 @@ export default {
 
 export const Default: StoryObj<AgentSessionView_01Props> = {
   args: {},
+};
+
+export const AllControls: StoryObj<AgentSessionView_01Props> = {
+  args: {
+    'controls.leave': true,
+    'controls.microphone': true,
+    'controls.chat': true,
+    'controls.camera': true,
+    'controls.screenShare': true,
+  },
 };

--- a/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
@@ -4,39 +4,65 @@ import { useTheme } from 'next-themes';
 import { LiveAgentSessionProvider } from '../../.storybook/lk-decorators/LiveAgentSessionProvider';
 import { AgentSessionView_01, AgentSessionView_01Props } from '@livekit/agents-ui';
 
+interface Args extends Omit<AgentSessionView_01Props, 'controls' | 'themeMode' | 'onDisconnect'> {
+  'controls.leave': boolean;
+  'controls.microphone': boolean;
+  'controls.chat': boolean;
+  'controls.camera': boolean;
+  'controls.screenShare': boolean;
+}
+
 export default {
   title: 'agents-ui/Blocks/AgentSessionView-01',
   component: AgentSessionView_01,
   decorators: [LiveAgentSessionProvider],
-  render: (args: AgentSessionView_01Props) => {
+  render: ({
+    'controls.leave': leave,
+    'controls.microphone': microphone,
+    'controls.chat': chat,
+    'controls.camera': camera,
+    'controls.screenShare': screenShare,
+    ...args
+  }: Args) => {
     const { resolvedTheme = 'dark' } = useTheme();
-    return <AgentSessionView_01 themeMode={resolvedTheme as 'dark' | 'light'} {...args} />;
+    return (
+      <AgentSessionView_01
+        themeMode={resolvedTheme as 'dark' | 'light'}
+        {...args}
+        controls={{ leave, microphone, chat, camera, screenShare }}
+      />
+    );
   },
   args: {
     className: 'h-screen',
-    supportsChatInput: true,
-    supportsVideoInput: true,
-    supportsScreenShare: true,
+    'controls.leave': true,
+    'controls.microphone': true,
+    'controls.chat': true,
+    'controls.camera': true,
+    'controls.screenShare': true,
     isPreConnectBufferEnabled: true,
     preConnectMessage: 'Agent is listening, ask it a question',
     audioVisualizerType: 'bar',
     audioVisualizerColor: undefined,
     audioVisualizerColorShift: 0,
     audioVisualizerBarCount: 5,
-    audioVisualizerGridRowCount: 10,
-    audioVisualizerGridColumnCount: 10,
+    audioVisualizerGridRowCount: 9,
+    audioVisualizerGridColumnCount: 9,
     audioVisualizerRadialBarCount: 25,
     audioVisualizerRadialRadius: 80,
-    audioVisualizerWaveLineWidth: 10,
+    audioVisualizerWaveLineWidth: 2,
   },
   argTypes: {
-    supportsChatInput: { control: { type: 'boolean' } },
-    supportsVideoInput: { control: { type: 'boolean' } },
-    supportsScreenShare: { control: { type: 'boolean' } },
+    'controls.leave': { control: { type: 'boolean' } },
+    'controls.microphone': { control: { type: 'boolean' } },
+    'controls.chat': { control: { type: 'boolean' } },
+    'controls.camera': { control: { type: 'boolean' } },
+    'controls.screenShare': { control: { type: 'boolean' } },
     isPreConnectBufferEnabled: { control: { type: 'boolean' } },
     preConnectMessage: { control: { type: 'text' } },
     audioVisualizerType: {
-      control: { type: 'select', options: ['bar', 'wave', 'grid', 'radial', 'aura'] },
+      options: ['bar', 'wave', 'grid', 'radial', 'aura'],
+      control: { type: 'select' },
     },
     audioVisualizerColor: { control: { type: 'color' } },
     audioVisualizerColorShift: { control: { type: 'range', min: 0, max: 2, step: 0.1 } },

--- a/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
@@ -4,12 +4,23 @@ import { useTheme } from 'next-themes';
 import { LiveAgentSessionProvider } from '../../.storybook/lk-decorators/LiveAgentSessionProvider';
 import { AgentSessionView_01, AgentSessionView_01Props } from '@livekit/agents-ui';
 
-interface Args extends Omit<AgentSessionView_01Props, 'controls' | 'themeMode' | 'onDisconnect'> {
+interface Args extends Omit<
+  AgentSessionView_01Props,
+  'controls' | 'themeMode' | 'onDisconnect' | 'audioVisualizer'
+> {
   'controls.leave': boolean;
   'controls.microphone': boolean;
   'controls.chat': boolean;
   'controls.camera': boolean;
   'controls.screenShare': boolean;
+  'audioVisualizer.type': 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
+  'audioVisualizer.color': `#${string}` | undefined;
+  'audioVisualizer.colorShift': number;
+  'audioVisualizer.barCount': number;
+  'audioVisualizer.rowCount': number;
+  'audioVisualizer.columnCount': number;
+  'audioVisualizer.radius': number;
+  'audioVisualizer.lineWidth': number;
 }
 
 export default {
@@ -22,6 +33,14 @@ export default {
     'controls.chat': chat,
     'controls.camera': camera,
     'controls.screenShare': screenShare,
+    'audioVisualizer.type': type,
+    'audioVisualizer.color': color,
+    'audioVisualizer.colorShift': colorShift,
+    'audioVisualizer.barCount': barCount,
+    'audioVisualizer.rowCount': rowCount,
+    'audioVisualizer.columnCount': columnCount,
+    'audioVisualizer.radius': radius,
+    'audioVisualizer.lineWidth': lineWidth,
     ...args
   }: Args) => {
     const { resolvedTheme = 'dark' } = useTheme();
@@ -30,6 +49,18 @@ export default {
         themeMode={resolvedTheme as 'dark' | 'light'}
         {...args}
         controls={{ leave, microphone, chat, camera, screenShare }}
+        audioVisualizer={
+          {
+            type,
+            color,
+            colorShift,
+            barCount,
+            rowCount,
+            columnCount,
+            radius,
+            lineWidth,
+          } as AgentSessionView_01Props['audioVisualizer']
+        }
       />
     );
   },
@@ -42,15 +73,14 @@ export default {
     'controls.screenShare': true,
     isPreConnectBufferEnabled: true,
     preConnectMessage: 'Agent is listening, ask it a question',
-    audioVisualizerType: 'bar',
-    audioVisualizerColor: undefined,
-    audioVisualizerColorShift: 0,
-    audioVisualizerBarCount: 5,
-    audioVisualizerGridRowCount: 9,
-    audioVisualizerGridColumnCount: 9,
-    audioVisualizerRadialBarCount: 25,
-    audioVisualizerRadialRadius: 80,
-    audioVisualizerWaveLineWidth: 2,
+    'audioVisualizer.type': 'bar',
+    'audioVisualizer.color': undefined,
+    'audioVisualizer.colorShift': 0,
+    'audioVisualizer.barCount': 5,
+    'audioVisualizer.rowCount': 9,
+    'audioVisualizer.columnCount': 9,
+    'audioVisualizer.radius': 80,
+    'audioVisualizer.lineWidth': 2,
   },
   argTypes: {
     'controls.leave': { control: { type: 'boolean' } },
@@ -60,18 +90,17 @@ export default {
     'controls.screenShare': { control: { type: 'boolean' } },
     isPreConnectBufferEnabled: { control: { type: 'boolean' } },
     preConnectMessage: { control: { type: 'text' } },
-    audioVisualizerType: {
+    'audioVisualizer.type': {
       options: ['bar', 'wave', 'grid', 'radial', 'aura'],
       control: { type: 'select' },
     },
-    audioVisualizerColor: { control: { type: 'color' } },
-    audioVisualizerColorShift: { control: { type: 'range', min: 0, max: 2, step: 0.1 } },
-    audioVisualizerBarCount: { control: { type: 'range', min: 1, max: 21, step: 1 } },
-    audioVisualizerGridRowCount: { control: { type: 'range', min: 3, max: 21, step: 2 } },
-    audioVisualizerGridColumnCount: { control: { type: 'range', min: 3, max: 21, step: 2 } },
-    audioVisualizerRadialBarCount: { control: { type: 'range', min: 4, max: 64, step: 4 } },
-    audioVisualizerRadialRadius: { control: { type: 'range', min: 30, max: 120, step: 1 } },
-    audioVisualizerWaveLineWidth: { control: { type: 'range', min: 1, max: 10, step: 0.1 } },
+    'audioVisualizer.color': { control: { type: 'color' } },
+    'audioVisualizer.colorShift': { control: { type: 'range', min: 0, max: 2, step: 0.1 } },
+    'audioVisualizer.barCount': { control: { type: 'range', min: 1, max: 21, step: 1 } },
+    'audioVisualizer.rowCount': { control: { type: 'range', min: 3, max: 21, step: 2 } },
+    'audioVisualizer.columnCount': { control: { type: 'range', min: 3, max: 21, step: 2 } },
+    'audioVisualizer.radius': { control: { type: 'range', min: 30, max: 120, step: 1 } },
+    'audioVisualizer.lineWidth': { control: { type: 'range', min: 1, max: 10, step: 0.1 } },
   },
   parameters: {
     layout: 'fullscreen',

--- a/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentSessionView-01.stories.tsx
@@ -5,6 +5,7 @@ import { LiveAgentSessionProvider } from '../../.storybook/lk-decorators/LiveAge
 import { AgentSessionView_01, AgentSessionView_01Props } from '@livekit/agents-ui';
 
 export default {
+  title: 'agents-ui/Blocks/AgentSessionView-01',
   component: AgentSessionView_01,
   decorators: [LiveAgentSessionProvider],
   render: (args: AgentSessionView_01Props) => {

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -1,33 +1,86 @@
 import React from 'react';
 import { StoryObj } from '@storybook/react-vite';
+import { useTheme } from 'next-themes';
 import { TokenSource } from 'livekit-client';
 import { AgentClient, AgentClientProps } from '@livekit/agents-ui';
 
 const TOKEN_SOURCE = TokenSource.endpoint('/api/agents-ui/token');
 
+interface Args extends Omit<AgentClientProps, 'tokenSource' | 'controls' | 'themeMode'> {
+  'controls.leave': boolean;
+  'controls.microphone': boolean;
+  'controls.chat': boolean;
+  'controls.camera': boolean;
+  'controls.screenShare': boolean;
+}
+
 export default {
   title: 'agents-ui/Blocks/EmbedPopupView-01',
   component: AgentClient,
-  render: (args: AgentClientProps) => (
-    <div className="h-screen w-full">
-      <AgentClient {...args} tokenSource={TOKEN_SOURCE} />
-    </div>
-  ),
+  render: ({
+    'controls.leave': leave,
+    'controls.microphone': microphone,
+    'controls.chat': chat,
+    'controls.camera': camera,
+    'controls.screenShare': screenShare,
+    ...args
+  }: Args) => {
+    const { resolvedTheme = 'dark' } = useTheme();
+    return (
+      <div className="h-screen w-full">
+        <AgentClient
+          {...args}
+          tokenSource={TOKEN_SOURCE}
+          themeMode={resolvedTheme as 'dark' | 'light'}
+          controls={{ leave, microphone, chat, camera, screenShare }}
+        />
+      </div>
+    );
+  },
   args: {
     triggerColor: '',
     logo: '',
     agentName: 'Agent',
-    supportsChatInput: true,
-    supportsVideoInput: true,
-    supportsScreenShare: true,
+    'controls.leave': false,
+    'controls.microphone': true,
+    'controls.chat': true,
+    'controls.camera': true,
+    'controls.screenShare': true,
+    isPreConnectBufferEnabled: true,
+    preConnectMessage: 'Agent is listening, ask it a question',
+    audioVisualizerType: 'bar',
+    audioVisualizerColor: undefined,
+    audioVisualizerColorShift: 0,
+    audioVisualizerBarCount: 3,
+    audioVisualizerGridRowCount: 9,
+    audioVisualizerGridColumnCount: 9,
+    audioVisualizerRadialBarCount: 25,
+    audioVisualizerRadialRadius: 80,
+    audioVisualizerWaveLineWidth: 3,
   },
   argTypes: {
-    color: { control: { type: 'color' } },
+    triggerColor: { control: { type: 'color' } },
     logo: { control: { type: 'text' } },
     agentName: { control: { type: 'text' } },
-    supportsChatInput: { control: { type: 'boolean' } },
-    supportsVideoInput: { control: { type: 'boolean' } },
-    supportsScreenShare: { control: { type: 'boolean' } },
+    'controls.leave': { control: { type: 'boolean' } },
+    'controls.microphone': { control: { type: 'boolean' } },
+    'controls.chat': { control: { type: 'boolean' } },
+    'controls.camera': { control: { type: 'boolean' } },
+    'controls.screenShare': { control: { type: 'boolean' } },
+    isPreConnectBufferEnabled: { control: { type: 'boolean' } },
+    preConnectMessage: { control: { type: 'text' } },
+    audioVisualizerType: {
+      options: ['bar', 'wave', 'grid', 'radial', 'aura'],
+      control: { type: 'select' },
+    },
+    audioVisualizerColor: { control: { type: 'color' } },
+    audioVisualizerColorShift: { control: { type: 'range', min: 0, max: 2, step: 0.1 } },
+    audioVisualizerBarCount: { control: { type: 'range', min: 1, max: 21, step: 1 } },
+    audioVisualizerGridRowCount: { control: { type: 'range', min: 3, max: 21, step: 2 } },
+    audioVisualizerGridColumnCount: { control: { type: 'range', min: 3, max: 21, step: 2 } },
+    audioVisualizerRadialBarCount: { control: { type: 'range', min: 4, max: 64, step: 4 } },
+    audioVisualizerRadialRadius: { control: { type: 'range', min: 30, max: 120, step: 1 } },
+    audioVisualizerWaveLineWidth: { control: { type: 'range', min: 1, max: 10, step: 0.1 } },
   },
   parameters: {
     layout: 'fullscreen',

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -6,17 +6,52 @@ import { EmbedPopupView_01, EmbedPopupViewProps } from '@livekit/agents-ui';
 
 const TOKEN_SOURCE = TokenSource.endpoint('/api/agents-ui/token');
 
-interface Args extends Omit<EmbedPopupViewProps, 'tokenSource' | 'controls' | 'themeMode'> {
+interface Args extends Omit<
+  EmbedPopupViewProps,
+  'tokenSource' | 'controls' | 'themeMode' | 'audioVisualizer'
+> {
   'controls.leave': boolean;
   'controls.microphone': boolean;
   'controls.chat': boolean;
   'controls.camera': boolean;
   'controls.screenShare': boolean;
+  'audioVisualizer.type': 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
+  'audioVisualizer.color': `#${string}` | undefined;
+  'audioVisualizer.colorShift': number;
+  'audioVisualizer.barCount': number;
+  'audioVisualizer.rowCount': number;
+  'audioVisualizer.columnCount': number;
+  'audioVisualizer.radius': number;
+  'audioVisualizer.lineWidth': number;
 }
 
 export default {
   title: 'agents-ui/Blocks/EmbedPopupView-01',
   component: EmbedPopupView_01,
+  args: {
+    triggerColor: '',
+    logo: '',
+    agentName: 'Agent',
+    'controls.leave': false,
+    'controls.microphone': true,
+    'controls.chat': true,
+    'controls.camera': true,
+    'controls.screenShare': true,
+    isPreConnectBufferEnabled: true,
+    preConnectMessage: 'Agent is listening, ask it a question',
+  },
+  argTypes: {
+    triggerColor: { control: { type: 'color' } },
+    logo: { control: { type: 'text' } },
+    agentName: { control: { type: 'text' } },
+    'controls.leave': { control: { type: 'boolean' } },
+    'controls.microphone': { control: { type: 'boolean' } },
+    'controls.chat': { control: { type: 'boolean' } },
+    'controls.camera': { control: { type: 'boolean' } },
+    'controls.screenShare': { control: { type: 'boolean' } },
+    isPreConnectBufferEnabled: { control: { type: 'boolean' } },
+    preConnectMessage: { control: { type: 'text' } },
+  },
   render: ({
     'controls.leave': leave,
     'controls.microphone': microphone,
@@ -37,57 +72,76 @@ export default {
       </div>
     );
   },
-  args: {
-    triggerColor: '',
-    logo: '',
-    agentName: 'Agent',
-    'controls.leave': false,
-    'controls.microphone': true,
-    'controls.chat': true,
-    'controls.camera': true,
-    'controls.screenShare': true,
-    isPreConnectBufferEnabled: true,
-    preConnectMessage: 'Agent is listening, ask it a question',
-    audioVisualizerType: 'bar',
-    audioVisualizerColor: undefined,
-    audioVisualizerColorShift: 0,
-    audioVisualizerBarCount: 3,
-    audioVisualizerGridRowCount: 9,
-    audioVisualizerGridColumnCount: 9,
-    audioVisualizerRadialBarCount: 25,
-    audioVisualizerRadialRadius: 80,
-    audioVisualizerWaveLineWidth: 3,
-  },
-  argTypes: {
-    triggerColor: { control: { type: 'color' } },
-    logo: { control: { type: 'text' } },
-    agentName: { control: { type: 'text' } },
-    'controls.leave': { control: { type: 'boolean' } },
-    'controls.microphone': { control: { type: 'boolean' } },
-    'controls.chat': { control: { type: 'boolean' } },
-    'controls.camera': { control: { type: 'boolean' } },
-    'controls.screenShare': { control: { type: 'boolean' } },
-    isPreConnectBufferEnabled: { control: { type: 'boolean' } },
-    preConnectMessage: { control: { type: 'text' } },
-    audioVisualizerType: {
-      options: ['bar', 'wave', 'grid', 'radial', 'aura'],
-      control: { type: 'select' },
-    },
-    audioVisualizerColor: { control: { type: 'color' } },
-    audioVisualizerColorShift: { control: { type: 'range', min: 0, max: 2, step: 0.1 } },
-    audioVisualizerBarCount: { control: { type: 'range', min: 1, max: 21, step: 1 } },
-    audioVisualizerGridRowCount: { control: { type: 'range', min: 3, max: 21, step: 2 } },
-    audioVisualizerGridColumnCount: { control: { type: 'range', min: 3, max: 21, step: 2 } },
-    audioVisualizerRadialBarCount: { control: { type: 'range', min: 4, max: 64, step: 4 } },
-    audioVisualizerRadialRadius: { control: { type: 'range', min: 30, max: 120, step: 1 } },
-    audioVisualizerWaveLineWidth: { control: { type: 'range', min: 1, max: 10, step: 0.1 } },
-  },
   parameters: {
     layout: 'fullscreen',
     actions: { handles: [] },
   },
 };
 
-export const Default: StoryObj<EmbedPopupViewProps> = {
-  args: {},
+export const Default: StoryObj<EmbedPopupViewProps> = {};
+
+export const Config: StoryObj<EmbedPopupViewProps> = {
+  args: {
+    'audioVisualizer.type': 'bar',
+    'audioVisualizer.color': undefined,
+    'audioVisualizer.colorShift': 0,
+    'audioVisualizer.barCount': 3,
+    'audioVisualizer.rowCount': 9,
+    'audioVisualizer.columnCount': 9,
+    'audioVisualizer.radius': 80,
+    'audioVisualizer.lineWidth': 3,
+  },
+  argTypes: {
+    'audioVisualizer.type': {
+      options: ['bar', 'wave', 'grid', 'radial', 'aura'],
+      control: { type: 'select' },
+    },
+    'audioVisualizer.color': { control: { type: 'color' } },
+    'audioVisualizer.colorShift': { control: { type: 'range', min: 0, max: 2, step: 0.1 } },
+    'audioVisualizer.barCount': { control: { type: 'range', min: 1, max: 21, step: 1 } },
+    'audioVisualizer.rowCount': { control: { type: 'range', min: 3, max: 21, step: 2 } },
+    'audioVisualizer.columnCount': { control: { type: 'range', min: 3, max: 21, step: 2 } },
+    'audioVisualizer.radius': { control: { type: 'range', min: 30, max: 120, step: 1 } },
+    'audioVisualizer.lineWidth': { control: { type: 'range', min: 1, max: 10, step: 0.1 } },
+  },
+  render: ({
+    'controls.leave': leave,
+    'controls.microphone': microphone,
+    'controls.chat': chat,
+    'controls.camera': camera,
+    'controls.screenShare': screenShare,
+    'audioVisualizer.type': type,
+    'audioVisualizer.color': color,
+    'audioVisualizer.colorShift': colorShift,
+    'audioVisualizer.barCount': barCount,
+    'audioVisualizer.rowCount': rowCount,
+    'audioVisualizer.columnCount': columnCount,
+    'audioVisualizer.radius': radius,
+    'audioVisualizer.lineWidth': lineWidth,
+    ...args
+  }: Args) => {
+    const { resolvedTheme = 'dark' } = useTheme();
+    return (
+      <div className="h-screen w-full">
+        <EmbedPopupView_01
+          {...args}
+          tokenSource={TOKEN_SOURCE}
+          themeMode={resolvedTheme as 'dark' | 'light'}
+          controls={{ leave, microphone, chat, camera, screenShare }}
+          audioVisualizer={
+            {
+              type,
+              color,
+              colorShift,
+              barCount,
+              rowCount,
+              columnCount,
+              radius,
+              lineWidth,
+            } as EmbedPopupViewProps['audioVisualizer']
+          }
+        />
+      </div>
+    );
+  },
 };

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -14,7 +14,7 @@ export default {
     </div>
   ),
   args: {
-    color: '#3b82f6',
+    triggerColor: '',
     logo: '',
     agentName: 'Agent',
     supportsChatInput: true,

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -6,6 +6,7 @@ import { AgentClient, AgentClientProps } from '@livekit/agents-ui';
 const TOKEN_SOURCE = TokenSource.endpoint('/api/agents-ui/token');
 
 export default {
+  title: 'agents-ui/Blocks/EmbedPopupView-01',
   component: AgentClient,
   render: (args: AgentClientProps) => (
     <div className="h-screen w-full">

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { StoryObj } from '@storybook/react-vite';
+import { TokenSource } from 'livekit-client';
+import { AgentClient, AgentClientProps } from '@livekit/agents-ui';
+
+const TOKEN_SOURCE = TokenSource.endpoint('/api/agents-ui/token');
+
+export default {
+  component: AgentClient,
+  render: (args: AgentClientProps) => (
+    <div className="h-screen w-full">
+      <AgentClient {...args} tokenSource={TOKEN_SOURCE} />
+    </div>
+  ),
+  args: {
+    color: '#3b82f6',
+    logo: '',
+    agentName: 'Agent',
+    supportsChatInput: true,
+    supportsVideoInput: true,
+    supportsScreenShare: true,
+  },
+  argTypes: {
+    color: { control: { type: 'color' } },
+    logo: { control: { type: 'text' } },
+    agentName: { control: { type: 'text' } },
+    supportsChatInput: { control: { type: 'boolean' } },
+    supportsVideoInput: { control: { type: 'boolean' } },
+    supportsScreenShare: { control: { type: 'boolean' } },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    actions: { handles: [] },
+  },
+};
+
+export const Default: StoryObj<AgentClientProps> = {
+  args: {},
+};

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -34,9 +34,9 @@ export default {
     agentName: 'Agent',
     'controls.leave': false,
     'controls.microphone': true,
-    'controls.chat': true,
-    'controls.camera': true,
-    'controls.screenShare': true,
+    'controls.chat': false,
+    'controls.camera': false,
+    'controls.screenShare': false,
     isPreConnectBufferEnabled: true,
     preConnectMessage: 'Agent is listening, ask it a question',
   },
@@ -79,6 +79,16 @@ export default {
 };
 
 export const Default: StoryObj<EmbedPopupViewProps> = {};
+
+export const AllControls: StoryObj<EmbedPopupViewProps> = {
+  args: {
+    'controls.leave': true,
+    'controls.microphone': true,
+    'controls.chat': true,
+    'controls.camera': true,
+    'controls.screenShare': true,
+  },
+};
 
 export const Config: StoryObj<EmbedPopupViewProps> = {
   args: {

--- a/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/EmbedPopupView-01.stories.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { StoryObj } from '@storybook/react-vite';
 import { useTheme } from 'next-themes';
 import { TokenSource } from 'livekit-client';
-import { AgentClient, AgentClientProps } from '@livekit/agents-ui';
+import { EmbedPopupView_01, EmbedPopupViewProps } from '@livekit/agents-ui';
 
 const TOKEN_SOURCE = TokenSource.endpoint('/api/agents-ui/token');
 
-interface Args extends Omit<AgentClientProps, 'tokenSource' | 'controls' | 'themeMode'> {
+interface Args extends Omit<EmbedPopupViewProps, 'tokenSource' | 'controls' | 'themeMode'> {
   'controls.leave': boolean;
   'controls.microphone': boolean;
   'controls.chat': boolean;
@@ -16,7 +16,7 @@ interface Args extends Omit<AgentClientProps, 'tokenSource' | 'controls' | 'them
 
 export default {
   title: 'agents-ui/Blocks/EmbedPopupView-01',
-  component: AgentClient,
+  component: EmbedPopupView_01,
   render: ({
     'controls.leave': leave,
     'controls.microphone': microphone,
@@ -28,7 +28,7 @@ export default {
     const { resolvedTheme = 'dark' } = useTheme();
     return (
       <div className="h-screen w-full">
-        <AgentClient
+        <EmbedPopupView_01
           {...args}
           tokenSource={TOKEN_SOURCE}
           themeMode={resolvedTheme as 'dark' | 'light'}
@@ -88,6 +88,6 @@ export default {
   },
 };
 
-export const Default: StoryObj<AgentClientProps> = {
+export const Default: StoryObj<EmbedPopupViewProps> = {
   args: {},
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gen:docs:watch": "nodemon --watch \"tooling/api-documenter/src/**/*\" --watch \"packages/react/src/**/*\" --ignore \"packages/react/src/assets/**/*\" -e js,jsx,ts,tsx -x \"pnpm gen:docs\"",
     "lint": "turbo run lint -- --quiet",
     "preinstall": "npx only-allow pnpm",
-    "shadcn:publish:all": "TURBO_UI=true turbo run shadcn:publish:all --filter=@livekit/agents-ui...",
+    "shadcn:publish:all": "turbo run shadcn:publish:all --filter=@livekit/agents-ui... --ui=tui",
     "ci:publish": "turbo run build --filter=./packages/* && pnpm gen:docs && changeset publish",
     "start:next": "turbo run start --filter=@livekit/component-example-next...",
     "test": "turbo run test",

--- a/packages/shadcn/components/agents-ui/agent-control-bar.tsx
+++ b/packages/shadcn/components/agents-ui/agent-control-bar.tsx
@@ -289,7 +289,7 @@ export function AgentControlBar({
     <div
       aria-label="Voice assistant controls"
       className={cn(
-        'bg-background border-input/50 dark:border-muted flex flex-col border p-3 drop-shadow-md/3',
+        '@container/agent-control-bar bg-background border-input/50 dark:border-muted flex flex-col border p-3 drop-shadow-md/3',
         variant === 'livekit' ? 'rounded-[31px]' : 'rounded-lg',
         className,
       )}
@@ -397,8 +397,9 @@ export function AgentControlBar({
                 'bg-destructive/10 dark:bg-destructive/10 text-destructive hover:bg-destructive/20 dark:hover:bg-destructive/20 focus:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/4 rounded-full font-mono text-xs font-bold tracking-wider',
             )}
           >
-            <span className="hidden md:inline uppercase">End call</span>
-            <span className="inline md:hidden uppercase">End</span>
+            <span className="sr-only @sm/agent-control-bar:not-sr-only uppercase">
+              End <span className="sr-only @md/agent-control-bar:not-sr-only">call</span>
+            </span>
           </AgentDisconnectButton>
         )}
       </div>

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -137,7 +137,6 @@ export interface AgentSessionView_01Props {
    * @default true
    */
   isPreConnectBufferEnabled?: boolean;
-
   /** Selects the visualizer style rendered in the main tile area. */
   audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
   /** Primary hex color used by supported audio visualizer variants. */

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -130,7 +130,7 @@ export interface AgentSessionView_01Props {
    *   screenShare: false,
    * }
    */
-  controls: AgentControlBarControls;
+  controls?: AgentControlBarControls;
   /**
    * Shows a pre-connect buffer state with a shimmer message before messages appear.
    *

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -15,9 +15,9 @@ import { TileLayout } from './tile-view';
 const DEFAULT_CONTROLS: AgentControlBarControls = {
   leave: true,
   microphone: true,
-  chat: true,
-  camera: true,
-  screenShare: true,
+  chat: false,
+  camera: false,
+  screenShare: false,
 };
 
 const BOTTOM_VIEW_MOTION_PROPS: MotionProps = {
@@ -121,7 +121,8 @@ export interface AgentSessionView_01Props {
    */
   preConnectMessage?: string;
   /**
-   * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps to a boolean value that determines whether the control is displayed.
+   * An object with the following keys: leave, microphone, screenShare, camera, chat.
+   * Each key maps to a boolean value that determines whether the control is displayed.
    *
    * @default {
    *   leave: true,

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -11,6 +11,14 @@ import {
 import { cn } from '@/lib/utils';
 import { TileLayout } from './tile-view';
 
+const DEFAULT_CONTROLS: AgentControlBarControls = {
+  leave: true,
+  microphone: true,
+  chat: true,
+  camera: true,
+  screenShare: true,
+};
+
 const BOTTOM_VIEW_MOTION_PROPS: MotionProps = {
   variants: {
     visible: {
@@ -112,23 +120,17 @@ export interface AgentSessionView_01Props {
    */
   preConnectMessage?: string;
   /**
-   * Enables or disables the chat toggle and transcript input controls.
+   * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps to a boolean value that determines whether the control is displayed.
    *
-   * @default true
+   * @default {
+   *   leave: true,
+   *   microphone: true,
+   *   chat: false,
+   *   camera: false,
+   *   screenShare: false,
+   * }
    */
-  supportsChatInput?: boolean;
-  /**
-   * Enables or disables camera controls in the bottom control bar.
-   *
-   * @default true
-   */
-  supportsVideoInput?: boolean;
-  /**
-   * Enables or disables screen sharing controls in the bottom control bar.
-   *
-   * @default true
-   */
-  supportsScreenShare?: boolean;
+  controls: AgentControlBarControls;
   /**
    * Shows a pre-connect buffer state with a shimmer message before messages appear.
    *
@@ -156,13 +158,13 @@ export interface AgentSessionView_01Props {
   audioVisualizerWaveLineWidth?: number;
   /** Optional class name merged onto the outer `<section>` container. */
   className?: string;
+  /** Called when the user clicks the leave control, in addition to ending the session. */
+  onDisconnect?: () => void;
 }
 
 export function AgentSessionView_01({
   preConnectMessage = 'Agent is listening, ask it a question',
-  supportsChatInput = true,
-  supportsVideoInput = true,
-  supportsScreenShare = true,
+  controls = DEFAULT_CONTROLS,
   isPreConnectBufferEnabled = true,
   audioVisualizerType,
   audioVisualizerColor,
@@ -174,6 +176,7 @@ export function AgentSessionView_01({
   audioVisualizerRadialRadius,
   audioVisualizerWaveLineWidth,
   themeMode,
+  onDisconnect,
   ref,
   className,
   ...props
@@ -184,14 +187,6 @@ export function AgentSessionView_01({
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const { state: agentState } = useAgent();
 
-  const controls: AgentControlBarControls = {
-    leave: true,
-    microphone: true,
-    chat: supportsChatInput,
-    camera: supportsVideoInput,
-    screenShare: supportsScreenShare,
-  };
-
   useEffect(() => {
     const lastMessage = messages.at(-1);
     const lastMessageIsLocal = lastMessage?.from?.isLocal === true;
@@ -201,10 +196,18 @@ export function AgentSessionView_01({
     }
   }, [messages]);
 
+  const finalControls = {
+    ...DEFAULT_CONTROLS,
+    ...controls,
+  };
+
   return (
     <section
       ref={ref}
-      className={cn('bg-background relative z-10 h-full w-full overflow-hidden', className)}
+      className={cn(
+        '@container/agent-session-block bg-background relative z-10 h-full w-full overflow-hidden',
+        className,
+      )}
       {...props}
     >
       <Fade top className="absolute inset-x-4 top-0 z-10 h-40" />
@@ -241,7 +244,7 @@ export function AgentSessionView_01({
       {/* Bottom */}
       <motion.div
         {...BOTTOM_VIEW_MOTION_PROPS}
-        className="absolute inset-x-3 bottom-0 z-50 md:inset-x-12"
+        className="absolute inset-x-3 bottom-0 z-50 @md/agent-session-block:inset-x-12"
       >
         {/* Pre-connect message */}
         {isPreConnectBufferEnabled && (
@@ -258,13 +261,13 @@ export function AgentSessionView_01({
             )}
           </AnimatePresence>
         )}
-        <div className="bg-background relative mx-auto max-w-2xl pb-3 md:pb-12">
+        <div className="bg-background relative mx-auto max-w-2xl pb-3 @md/agent-session-block:pb-12">
           <AgentControlBar
             variant="livekit"
-            controls={controls}
+            controls={finalControls}
             isChatOpen={isChatOpen}
             isConnected={session.isConnected}
-            onDisconnect={session.end}
+            onDisconnect={onDisconnect ?? session.end}
             onIsChatOpenChange={setIsChatOpen}
           />
         </div>

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -215,12 +215,12 @@ export function AgentSessionView_01({
         {isChatOpen && (
           <motion.div
             {...CHAT_MOTION_PROPS}
-            className="absolute inset-x-0 top-0 bottom-[135px] overflow-hidden md:bottom-[170px]"
+            className="absolute inset-x-0 top-0 bottom-[135px] overflow-hidden @md/agent-session-block:bottom-[170px]"
           >
             <AgentChatTranscript
               agentState={agentState}
               messages={messages}
-              className="mx-auto max-w-2xl **:data-[slot=message-scroller-content]:p-4 **:data-[slot=message-scroller-content]:pt-40! md:**:data-[slot=message-scroller-content]:p-6"
+              className="mx-auto max-w-2xl **:data-[slot=message-scroller-content]:p-4 **:data-[slot=message-scroller-content]:pt-40! @md/agent-session-block:**:data-[slot=message-scroller-content]:p-6"
             />
           </motion.div>
         )}

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -9,6 +9,7 @@ import {
   type AgentControlBarControls,
 } from '@/components/agents-ui/agent-control-bar';
 import { cn } from '@/lib/utils';
+import { type AudioVisualizerConfig } from './audio-visualizer';
 import { TileLayout } from './tile-view';
 
 const DEFAULT_CONTROLS: AgentControlBarControls = {
@@ -108,7 +109,7 @@ export function Fade({ top = false, bottom = false, className }: FadeProps) {
 
 export interface AgentSessionView_01Props {
   /**
-   * Theme mode forwarded to the aura visualizer (`audioVisualizerType="aura"`) so
+   * Theme mode forwarded to the aura visualizer (`audioVisualizer.type === 'aura'`) so
    * the shader's blend mode adapts to the theme mode.
    * Ignored by other visualizer types.
    */
@@ -137,24 +138,8 @@ export interface AgentSessionView_01Props {
    * @default true
    */
   isPreConnectBufferEnabled?: boolean;
-  /** Selects the visualizer style rendered in the main tile area. */
-  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
-  /** Primary hex color used by supported audio visualizer variants. */
-  audioVisualizerColor?: `#${string}`;
-  /** Hue shift intensity used by certain visualizers. */
-  audioVisualizerColorShift?: number;
-  /** Number of bars to render when `audioVisualizerType` is `bar`. */
-  audioVisualizerBarCount?: number;
-  /** Number of rows in the visualizer when `audioVisualizerType` is `grid`. */
-  audioVisualizerGridRowCount?: number;
-  /** Number of columns in the visualizer when `audioVisualizerType` is `grid`. */
-  audioVisualizerGridColumnCount?: number;
-  /** Number of radial bars when `audioVisualizerType` is `radial`. */
-  audioVisualizerRadialBarCount?: number;
-  /** Base radius of the radial visualizer when `audioVisualizerType` is `radial`. */
-  audioVisualizerRadialRadius?: number;
-  /** Stroke width of the wave path when `audioVisualizerType` is `wave`. */
-  audioVisualizerWaveLineWidth?: number;
+  /** Configures the visualizer style rendered in the main tile area. */
+  audioVisualizer?: AudioVisualizerConfig;
   /** Optional class name merged onto the outer `<section>` container. */
   className?: string;
   /** Called when the user clicks the leave control, in addition to ending the session. */
@@ -165,15 +150,7 @@ export function AgentSessionView_01({
   preConnectMessage = 'Agent is listening, ask it a question',
   controls = DEFAULT_CONTROLS,
   isPreConnectBufferEnabled = true,
-  audioVisualizerType,
-  audioVisualizerColor,
-  audioVisualizerColorShift,
-  audioVisualizerBarCount,
-  audioVisualizerGridRowCount,
-  audioVisualizerGridColumnCount,
-  audioVisualizerRadialBarCount,
-  audioVisualizerRadialRadius,
-  audioVisualizerWaveLineWidth,
+  audioVisualizer,
   themeMode,
   onDisconnect,
   ref,
@@ -227,19 +204,8 @@ export function AgentSessionView_01({
       </AnimatePresence>
 
       {/* Tile layout */}
-      <TileLayout
-        isChatOpen={isChatOpen}
-        themeMode={themeMode}
-        audioVisualizerType={audioVisualizerType}
-        audioVisualizerColor={audioVisualizerColor}
-        audioVisualizerColorShift={audioVisualizerColorShift}
-        audioVisualizerBarCount={audioVisualizerBarCount}
-        audioVisualizerRadialBarCount={audioVisualizerRadialBarCount}
-        audioVisualizerRadialRadius={audioVisualizerRadialRadius}
-        audioVisualizerGridRowCount={audioVisualizerGridRowCount}
-        audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
-        audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
-      />
+      <TileLayout isChatOpen={isChatOpen} themeMode={themeMode} audioVisualizer={audioVisualizer} />
+
       {/* Bottom */}
       <motion.div
         {...BOTTOM_VIEW_MOTION_PROPS}

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -9,7 +9,7 @@ import {
   type AgentControlBarControls,
 } from '@/components/agents-ui/agent-control-bar';
 import { cn } from '@/lib/utils';
-import { type AudioVisualizerConfig } from './audio-visualizer';
+import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer';
 import { TileLayout } from './tile-view';
 
 const DEFAULT_CONTROLS: AgentControlBarControls = {
@@ -138,7 +138,11 @@ export interface AgentSessionView_01Props {
    * @default true
    */
   isPreConnectBufferEnabled?: boolean;
-  /** Configures the visualizer style rendered in the main tile area. */
+  /**
+   * Configures the visualizer style rendered in the main tile area.
+   *
+   * @default { type: 'bar' }
+   */
   audioVisualizer?: AudioVisualizerConfig;
   /** Optional class name merged onto the outer `<section>` container. */
   className?: string;
@@ -150,7 +154,7 @@ export function AgentSessionView_01({
   preConnectMessage = 'Agent is listening, ask it a question',
   controls = DEFAULT_CONTROLS,
   isPreConnectBufferEnabled = true,
-  audioVisualizer,
+  audioVisualizer = { type: 'bar' },
   themeMode,
   onDisconnect,
   ref,

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -9,8 +9,26 @@ import {
   type AgentControlBarControls,
 } from '@/components/agents-ui/agent-control-bar';
 import { cn } from '@/lib/utils';
-import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer';
 import { TileLayout } from './tile-view';
+
+import { type AgentAudioVisualizerAuraProps } from '@/components/agents-ui/agent-audio-visualizer-aura';
+import { type AgentAudioVisualizerBarProps } from '@/components/agents-ui/agent-audio-visualizer-bar';
+import { type AgentAudioVisualizerGridProps } from '@/components/agents-ui/agent-audio-visualizer-grid';
+import { type AgentAudioVisualizerRadialProps } from '@/components/agents-ui/agent-audio-visualizer-radial';
+import { type AgentAudioVisualizerWaveProps } from '@/components/agents-ui/agent-audio-visualizer-wave';
+
+/**
+ * Configures the visualizer style rendered in the main tile area. `type` selects the
+ * visualizer, and the remaining fields are exactly the props of the matching
+ * `AgentAudioVisualizer*` component (e.g. `type: 'grid'` accepts `rowCount`/`columnCount`,
+ * `type: 'wave'` accepts `lineWidth`, etc).
+ */
+export type AudioVisualizerConfig =
+  | ({ type?: 'bar' } & AgentAudioVisualizerBarProps)
+  | ({ type: 'wave' } & AgentAudioVisualizerWaveProps)
+  | ({ type: 'grid' } & AgentAudioVisualizerGridProps)
+  | ({ type: 'radial' } & AgentAudioVisualizerRadialProps)
+  | ({ type: 'aura' } & AgentAudioVisualizerAuraProps);
 
 const DEFAULT_CONTROLS: AgentControlBarControls = {
   leave: true,

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block.tsx
@@ -253,7 +253,7 @@ export function AgentSessionView_01({
                 key="pre-connect-message"
                 aria-hidden={messages.length > 0}
                 {...SHIMMER_MOTION_PROPS}
-                className="shimmer shimmer-duration-2000 pointer-events-none mx-auto block w-full max-w-2xl pb-4 text-center text-sm font-semibold"
+                className="shimmer shimmer-duration-2000 pointer-events-none mx-auto block w-full max-w-2xl pb-4 text-center text-sm text-muted-foreground"
               >
                 {preConnectMessage}
               </motion.p>

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
@@ -100,7 +100,7 @@ export function AudioVisualizer({
           radius={Math.round(
             Math.min(audioVisualizerGridRowCount, audioVisualizerGridColumnCount) / 4,
           )}
-          className={cn('size-[350px] gap-0 p-8 *:place-self-center md:size-[450px]', className)}
+          className={cn('size-[350px] gap-0 p-20 *:place-self-center md:size-[450px]', className)}
           {...props}
         />
       );

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
@@ -66,12 +66,12 @@ function getBarClassName(size: AgentAudioVisualizerBarProps['size']) {
   } else if (size == 'lg') {
     return 'size-[450px] *:min-h-[48px] *:w-[48px]';
   } else if (size == 'md') {
-    return 'size-[350px] md:size-[450px]  *:min-h-[32px] *:w-[32px]';
+    return 'size-[350px] @md/agent-session-block:size-[450px]  *:min-h-[32px] *:w-[32px]';
   } else if (size == 'sm') {
-    return 'size-[300px] md:size-[450px] *:min-h-[16px] *:w-[16px]';
+    return 'size-[300px] @md/agent-session-block:size-[450px] *:min-h-[16px] *:w-[16px]';
   }
 
-  return 'size-[300px] md:size-[450px] *:min-h-[4px] *:w-[4px]';
+  return 'size-[300px] @md/agent-session-block:size-[450px] *:min-h-[4px] *:w-[4px]';
 }
 
 interface AudioVisualizerProps extends MotionProps {
@@ -106,7 +106,7 @@ export function AudioVisualizer({
           state={state}
           themeMode={themeMode}
           audioTrack={audioTrack}
-          className={cn('size-[300px] md:size-[450px]', className)}
+          className={cn('size-[300px] @md/agent-session-block:size-[450px]', className)}
           {...props}
         />
       );
@@ -118,7 +118,7 @@ export function AudioVisualizer({
             {...config}
             state={state}
             audioTrack={audioTrack}
-            className="size-[300px] md:size-[450px]"
+            className="size-[300px] @md/agent-session-block:size-[450px]"
           />
         </motion.div>
       );
@@ -140,7 +140,10 @@ export function AudioVisualizer({
           rowCount={rowCount}
           columnCount={columnCount}
           radius={radius ?? Math.round(Math.min(rowCount, columnCount) / 4)}
-          className={cn('size-[350px] gap-0 p-20 *:place-self-center md:size-[450px]', className)}
+          className={cn(
+            'size-[350px] gap-0 p-20 *:place-self-center @md/agent-session-block:size-[450px]',
+            className,
+          )}
           {...props}
         />
       );

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
@@ -88,7 +88,7 @@ function getBarClassName(size: AgentAudioVisualizerBarProps['size']) {
   } else if (size == 'md') {
     return 'size-[350px] md:size-[450px]  *:min-h-[32px] *:w-[32px]';
   } else if (size == 'sm') {
-    return 'size-[300px] md:size-[450px] *:min-h-[16xpx] *:w-[16xpx]';
+    return 'size-[300px] md:size-[450px] *:min-h-[16px] *:w-[16px]';
   }
 
   return 'size-[300px] md:size-[450px] *:min-h-[4px] *:w-[4px]';

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
@@ -5,11 +5,26 @@ import { useVoiceAssistant } from '@livekit/components-react';
 import { motion, type MotionProps } from 'motion/react';
 import { cn } from '@/lib/utils';
 
-import { AgentAudioVisualizerAura } from '@/components/agents-ui/agent-audio-visualizer-aura';
-import { AgentAudioVisualizerBar } from '@/components/agents-ui/agent-audio-visualizer-bar';
-import { AgentAudioVisualizerGrid } from '@/components/agents-ui/agent-audio-visualizer-grid';
-import { AgentAudioVisualizerRadial } from '@/components/agents-ui/agent-audio-visualizer-radial';
-import { AgentAudioVisualizerWave } from '@/components/agents-ui/agent-audio-visualizer-wave';
+import {
+  AgentAudioVisualizerAura,
+  type AgentAudioVisualizerAuraProps,
+} from '@/components/agents-ui/agent-audio-visualizer-aura';
+import {
+  AgentAudioVisualizerBar,
+  type AgentAudioVisualizerBarProps,
+} from '@/components/agents-ui/agent-audio-visualizer-bar';
+import {
+  AgentAudioVisualizerGrid,
+  type AgentAudioVisualizerGridProps,
+} from '@/components/agents-ui/agent-audio-visualizer-grid';
+import {
+  AgentAudioVisualizerRadial,
+  type AgentAudioVisualizerRadialProps,
+} from '@/components/agents-ui/agent-audio-visualizer-radial';
+import {
+  AgentAudioVisualizerWave,
+  type AgentAudioVisualizerWaveProps,
+} from '@/components/agents-ui/agent-audio-visualizer-wave';
 
 const MotionAgentAudioVisualizerAura = motion.create(AgentAudioVisualizerAura);
 const MotionAgentAudioVisualizerBar = motion.create(AgentAudioVisualizerBar);
@@ -17,47 +32,87 @@ const MotionAgentAudioVisualizerGrid = motion.create(AgentAudioVisualizerGrid);
 const MotionAgentAudioVisualizerRadial = motion.create(AgentAudioVisualizerRadial);
 const MotionAgentAudioVisualizerWave = motion.create(AgentAudioVisualizerWave);
 
+/**
+ * Configures the visualizer style rendered in the main tile area. `type` selects the
+ * visualizer, and the remaining fields are exactly the props of the matching
+ * `AgentAudioVisualizer*` component (e.g. `type: 'grid'` accepts `rowCount`/`columnCount`,
+ * `type: 'wave'` accepts `lineWidth`, etc).
+ */
+export type AudioVisualizerConfig =
+  | ({ type?: 'bar' } & AgentAudioVisualizerBarProps)
+  | ({ type: 'wave' } & AgentAudioVisualizerWaveProps)
+  | ({ type: 'grid' } & AgentAudioVisualizerGridProps)
+  | ({ type: 'radial' } & AgentAudioVisualizerRadialProps)
+  | ({ type: 'aura' } & AgentAudioVisualizerAuraProps);
+
 interface AudioVisualizerProps extends MotionProps {
   themeMode?: 'dark' | 'light';
   isChatOpen: boolean;
-  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
-  audioVisualizerColor?: `#${string}`;
-  audioVisualizerColorShift?: number;
-  audioVisualizerWaveLineWidth?: number;
-  audioVisualizerGridRowCount?: number;
-  audioVisualizerGridColumnCount?: number;
-  audioVisualizerRadialBarCount?: number;
-  audioVisualizerRadialRadius?: number;
-  audioVisualizerBarCount?: number;
+  audioVisualizer?: AudioVisualizerConfig;
   className?: string;
+}
+
+function getGridSize(rowCount: number, columnCount: number): AgentAudioVisualizerBarProps['size'] {
+  const totalCount = rowCount * columnCount;
+
+  if (totalCount < 100) {
+    return 'xl';
+  } else if (totalCount < 200) {
+    return 'lg';
+  } else if (totalCount < 300) {
+    return 'md';
+  }
+
+  return 'sm';
+}
+
+function getBarSize(barCount: number): AgentAudioVisualizerBarProps['size'] {
+  if (barCount <= 5) {
+    return 'xl';
+  } else if (barCount <= 10) {
+    return 'lg';
+  } else if (barCount <= 15) {
+    return 'md';
+  } else if (barCount <= 30) {
+    return 'sm';
+  }
+
+  return 'icon';
+}
+
+function getBarClassName(size: AgentAudioVisualizerBarProps['size']) {
+  if (size == 'xl') {
+    return 'size-[450px] *:min-h-[64px] *:w-[64px] gap-4';
+  } else if (size == 'lg') {
+    return 'size-[450px] *:min-h-[48px] *:w-[48px]';
+  } else if (size == 'md') {
+    return 'size-[350px] md:size-[450px]  *:min-h-[32px] *:w-[32px]';
+  } else if (size == 'sm') {
+    return 'size-[300px] md:size-[450px] *:min-h-[16xpx] *:w-[16xpx]';
+  }
+
+  return 'size-[300px] md:size-[450px] *:min-h-[4px] *:w-[4px]';
 }
 
 export function AudioVisualizer({
   themeMode,
-  isChatOpen,
-  audioVisualizerType = 'bar',
-  audioVisualizerColor,
-  audioVisualizerColorShift = 0.3,
-  audioVisualizerBarCount = 5,
-  audioVisualizerRadialRadius = 100,
-  audioVisualizerRadialBarCount = 25,
-  audioVisualizerGridRowCount = 15,
-  audioVisualizerGridColumnCount = 15,
-  audioVisualizerWaveLineWidth = 3,
+  audioVisualizer,
   className,
   ...props
 }: AudioVisualizerProps) {
   const { state, audioTrack } = useVoiceAssistant();
+  const { type = 'bar', ...config } = audioVisualizer ?? {};
 
-  switch (audioVisualizerType) {
+  // `state`/`audioTrack` always reflect the live agent session; any same-named field on
+  // `config` is ignored by spreading it before these are set explicitly below.
+  switch (type) {
     case 'aura': {
       return (
         <MotionAgentAudioVisualizerAura
+          {...config}
           state={state}
-          audioTrack={audioTrack}
-          color={audioVisualizerColor}
-          colorShift={audioVisualizerColorShift}
           themeMode={themeMode}
+          audioTrack={audioTrack}
           className={cn('size-[300px] md:size-[450px]', className)}
           {...props}
         />
@@ -67,85 +122,66 @@ export function AudioVisualizer({
       return (
         <motion.div className={className} {...props}>
           <MotionAgentAudioVisualizerWave
+            {...config}
             state={state}
             audioTrack={audioTrack}
-            color={audioVisualizerColor}
-            colorShift={audioVisualizerColorShift}
-            lineWidth={isChatOpen ? audioVisualizerWaveLineWidth * 2 : audioVisualizerWaveLineWidth}
             className="size-[300px] md:size-[450px]"
           />
         </motion.div>
       );
     }
     case 'grid': {
-      const totalCount = audioVisualizerGridRowCount * audioVisualizerGridColumnCount;
-
-      let size: 'icon' | 'sm' | 'md' | 'lg' | 'xl' = 'sm';
-      if (totalCount < 100) {
-        size = 'xl';
-      } else if (totalCount < 200) {
-        size = 'lg';
-      } else if (totalCount < 300) {
-        size = 'md';
-      }
+      const {
+        size,
+        radius,
+        rowCount = 15,
+        columnCount = 15,
+        ...rest
+      } = config as AgentAudioVisualizerGridProps;
 
       return (
         <MotionAgentAudioVisualizerGrid
-          size={size}
+          {...rest}
+          size={size ?? getGridSize(rowCount, columnCount)}
           state={state}
-          color={audioVisualizerColor}
           audioTrack={audioTrack}
-          rowCount={audioVisualizerGridRowCount}
-          columnCount={audioVisualizerGridColumnCount}
-          radius={Math.round(
-            Math.min(audioVisualizerGridRowCount, audioVisualizerGridColumnCount) / 4,
-          )}
+          rowCount={rowCount}
+          columnCount={columnCount}
+          radius={radius ?? Math.round(Math.min(rowCount, columnCount) / 4)}
           className={cn('size-[350px] gap-0 p-20 *:place-self-center md:size-[450px]', className)}
           {...props}
         />
       );
     }
     case 'radial': {
+      const { radius = 100, barCount = 25, ...rest } = config as AgentAudioVisualizerRadialProps;
       return (
         <motion.div className={className} {...props}>
           <MotionAgentAudioVisualizerRadial
+            {...rest}
             size="xl"
             state={state}
-            color={audioVisualizerColor}
+            radius={radius}
+            barCount={barCount}
             audioTrack={audioTrack}
-            radius={audioVisualizerRadialRadius}
-            barCount={audioVisualizerRadialBarCount}
             className="size-[450px]"
           />
         </motion.div>
       );
     }
     default: {
-      let size: 'icon' | 'sm' | 'md' | 'lg' | 'xl' = 'icon';
-      let sizedClassName = cn('size-[300px] md:size-[450px]', className);
-
-      if (audioVisualizerBarCount <= 5) {
-        size = 'xl';
-        sizedClassName = cn('size-[450px] *:min-h-[64px] *:w-[64px] gap-4', className);
-      } else if (audioVisualizerBarCount <= 10) {
-        size = 'lg';
-        sizedClassName = cn('size-[450px]', className);
-      } else if (audioVisualizerBarCount <= 15) {
-        size = 'md';
-        sizedClassName = cn('size-[350px] md:size-[450px]', className);
-      } else if (audioVisualizerBarCount <= 30) {
-        size = 'sm';
-        sizedClassName = cn('size-[300px] md:size-[450px]', className);
-      }
+      const { size, barCount = 5, ...rest } = config as AgentAudioVisualizerBarProps;
+      const _size = size ?? getBarSize(barCount);
+      const sizedClassName = getBarClassName(_size);
 
       return (
         <MotionAgentAudioVisualizerBar
-          size={size}
+          {...rest}
+          size={_size}
           state={state}
-          color={audioVisualizerColor}
+          barCount={barCount}
           audioTrack={audioTrack}
-          barCount={audioVisualizerBarCount}
-          className={sizedClassName}
+          className={cn(sizedClassName, className)}
           {...props}
         >
           <span className="min-h-2.5 w-2.5 rounded-full transition-colors duration-250 ease-linear bg-current/10 data-[lk-highlighted=true]:bg-current" />

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer.tsx
@@ -32,26 +32,6 @@ const MotionAgentAudioVisualizerGrid = motion.create(AgentAudioVisualizerGrid);
 const MotionAgentAudioVisualizerRadial = motion.create(AgentAudioVisualizerRadial);
 const MotionAgentAudioVisualizerWave = motion.create(AgentAudioVisualizerWave);
 
-/**
- * Configures the visualizer style rendered in the main tile area. `type` selects the
- * visualizer, and the remaining fields are exactly the props of the matching
- * `AgentAudioVisualizer*` component (e.g. `type: 'grid'` accepts `rowCount`/`columnCount`,
- * `type: 'wave'` accepts `lineWidth`, etc).
- */
-export type AudioVisualizerConfig =
-  | ({ type?: 'bar' } & AgentAudioVisualizerBarProps)
-  | ({ type: 'wave' } & AgentAudioVisualizerWaveProps)
-  | ({ type: 'grid' } & AgentAudioVisualizerGridProps)
-  | ({ type: 'radial' } & AgentAudioVisualizerRadialProps)
-  | ({ type: 'aura' } & AgentAudioVisualizerAuraProps);
-
-interface AudioVisualizerProps extends MotionProps {
-  themeMode?: 'dark' | 'light';
-  isChatOpen: boolean;
-  audioVisualizer?: AudioVisualizerConfig;
-  className?: string;
-}
-
 function getGridSize(rowCount: number, columnCount: number): AgentAudioVisualizerBarProps['size'] {
   const totalCount = rowCount * columnCount;
 
@@ -94,14 +74,27 @@ function getBarClassName(size: AgentAudioVisualizerBarProps['size']) {
   return 'size-[300px] md:size-[450px] *:min-h-[4px] *:w-[4px]';
 }
 
+interface AudioVisualizerProps extends MotionProps {
+  isChatOpen: boolean;
+  type: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
+  config?:
+    | AgentAudioVisualizerBarProps
+    | AgentAudioVisualizerWaveProps
+    | AgentAudioVisualizerGridProps
+    | AgentAudioVisualizerRadialProps
+    | AgentAudioVisualizerAuraProps;
+  themeMode?: 'dark' | 'light';
+  className?: string;
+}
+
 export function AudioVisualizer({
   themeMode,
-  audioVisualizer,
+  type,
+  config,
   className,
   ...props
 }: AudioVisualizerProps) {
   const { state, audioTrack } = useVoiceAssistant();
-  const { type = 'bar', ...config } = audioVisualizer ?? {};
 
   // `state`/`audioTrack` always reflect the live agent session; any same-named field on
   // `config` is ignored by spreading it before these are set explicitly below.
@@ -136,12 +129,11 @@ export function AudioVisualizer({
         radius,
         rowCount = 15,
         columnCount = 15,
-        ...rest
       } = config as AgentAudioVisualizerGridProps;
 
       return (
         <MotionAgentAudioVisualizerGrid
-          {...rest}
+          {...config}
           size={size ?? getGridSize(rowCount, columnCount)}
           state={state}
           audioTrack={audioTrack}
@@ -154,11 +146,11 @@ export function AudioVisualizer({
       );
     }
     case 'radial': {
-      const { radius = 100, barCount = 25, ...rest } = config as AgentAudioVisualizerRadialProps;
+      const { radius = 100, barCount = 25 } = config as AgentAudioVisualizerRadialProps;
       return (
         <motion.div className={className} {...props}>
           <MotionAgentAudioVisualizerRadial
-            {...rest}
+            {...config}
             size="xl"
             state={state}
             radius={radius}
@@ -170,13 +162,13 @@ export function AudioVisualizer({
       );
     }
     default: {
-      const { size, barCount = 5, ...rest } = config as AgentAudioVisualizerBarProps;
+      const { size, barCount = 5 } = (config as AgentAudioVisualizerBarProps) ?? {};
       const _size = size ?? getBarSize(barCount);
       const sizedClassName = getBarClassName(_size);
 
       return (
         <MotionAgentAudioVisualizerBar
-          {...rest}
+          {...config}
           size={_size}
           state={state}
           barCount={barCount}

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
@@ -92,8 +92,8 @@ export function TileLayout({ themeMode, isChatOpen, audioVisualizer }: TileLayou
   const { type: audioVisualizerType = 'bar', ...audioVisualizerConfig } = audioVisualizer ?? {};
 
   return (
-    <div className="pointer-events-none absolute inset-x-0 top-8 bottom-32 z-50 md:top-12 md:bottom-40">
-      <div className="relative mx-auto h-full max-w-2xl px-4 md:px-0">
+    <div className="pointer-events-none absolute inset-x-0 top-8 bottom-24 z-50 @md/agent-session-block:top-12 @md/agent-session-block:bottom-40">
+      <div className="relative mx-auto h-full max-w-2xl px-4 @md/agent-session-block:px-0">
         <div className={cn(tileViewClassNames.grid)}>
           {/* Agent */}
           <div

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
@@ -10,7 +10,7 @@ import { Track } from 'livekit-client';
 import { AnimatePresence, motion, type MotionProps } from 'motion/react';
 
 import { cn } from '@/lib/utils';
-import { AudioVisualizer } from './audio-visualizer';
+import { AudioVisualizer, type AudioVisualizerConfig } from './audio-visualizer';
 
 const ANIMATION_TRANSITION: MotionProps['transition'] = {
   type: 'spring',
@@ -71,30 +71,10 @@ export function useLocalTrackRef(source: Track.Source) {
 interface TileLayoutProps {
   themeMode?: 'dark' | 'light';
   isChatOpen: boolean;
-  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
-  audioVisualizerColor?: `#${string}`;
-  audioVisualizerColorShift?: number;
-  audioVisualizerWaveLineWidth?: number;
-  audioVisualizerGridRowCount?: number;
-  audioVisualizerGridColumnCount?: number;
-  audioVisualizerRadialBarCount?: number;
-  audioVisualizerRadialRadius?: number;
-  audioVisualizerBarCount?: number;
+  audioVisualizer?: AudioVisualizerConfig;
 }
 
-export function TileLayout({
-  themeMode,
-  isChatOpen,
-  audioVisualizerType,
-  audioVisualizerColor,
-  audioVisualizerColorShift,
-  audioVisualizerBarCount,
-  audioVisualizerRadialBarCount,
-  audioVisualizerRadialRadius,
-  audioVisualizerGridRowCount,
-  audioVisualizerGridColumnCount,
-  audioVisualizerWaveLineWidth,
-}: TileLayoutProps) {
+export function TileLayout({ themeMode, isChatOpen, audioVisualizer }: TileLayoutProps) {
   const { videoTrack: agentVideoTrack } = useVoiceAssistant();
   const [screenShareTrack] = useTracks([Track.Source.ScreenShare]);
   const cameraTrack: TrackReference | undefined = useLocalTrackRef(Track.Source.Camera);
@@ -143,15 +123,7 @@ export function TileLayout({
                       ...ANIMATION_TRANSITION,
                       delay: animationDelay,
                     }}
-                    audioVisualizerType={audioVisualizerType}
-                    audioVisualizerColor={audioVisualizerColor}
-                    audioVisualizerColorShift={audioVisualizerColorShift}
-                    audioVisualizerBarCount={audioVisualizerBarCount}
-                    audioVisualizerRadialBarCount={audioVisualizerRadialBarCount}
-                    audioVisualizerRadialRadius={audioVisualizerRadialRadius}
-                    audioVisualizerGridRowCount={audioVisualizerGridRowCount}
-                    audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
-                    audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
+                    audioVisualizer={audioVisualizer}
                     themeMode={themeMode}
                     isChatOpen={isChatOpen}
                     className={cn(
@@ -159,7 +131,7 @@ export function TileLayout({
                       'bg-background rounded-[50px] border border-transparent transition-[border,drop-shadow]',
                       isChatOpen && 'border-input shadow-2xl/10 delay-200',
                     )}
-                    style={{ color: audioVisualizerColor }}
+                    style={{ color: audioVisualizer?.color }}
                   />
                 </motion.div>
               )}

--- a/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-session-view-01/components/tile-view.tsx
@@ -8,9 +8,10 @@ import {
 } from '@livekit/components-react';
 import { Track } from 'livekit-client';
 import { AnimatePresence, motion, type MotionProps } from 'motion/react';
+import { type AudioVisualizerConfig } from './agent-session-block';
 
 import { cn } from '@/lib/utils';
-import { AudioVisualizer, type AudioVisualizerConfig } from './audio-visualizer';
+import { AudioVisualizer } from './audio-visualizer';
 
 const ANIMATION_TRANSITION: MotionProps['transition'] = {
   type: 'spring',
@@ -88,6 +89,8 @@ export function TileLayout({ themeMode, isChatOpen, audioVisualizer }: TileLayou
   const videoWidth = agentVideoTrack?.publication.dimensions?.width ?? 0;
   const videoHeight = agentVideoTrack?.publication.dimensions?.height ?? 0;
 
+  const { type: audioVisualizerType = 'bar', ...audioVisualizerConfig } = audioVisualizer ?? {};
+
   return (
     <div className="pointer-events-none absolute inset-x-0 top-8 bottom-32 z-50 md:top-12 md:bottom-40">
       <div className="relative mx-auto h-full max-w-2xl px-4 md:px-0">
@@ -123,7 +126,8 @@ export function TileLayout({ themeMode, isChatOpen, audioVisualizer }: TileLayou
                       ...ANIMATION_TRANSITION,
                       delay: animationDelay,
                     }}
-                    audioVisualizer={audioVisualizer}
+                    type={audioVisualizerType}
+                    config={audioVisualizerConfig}
                     themeMode={themeMode}
                     isChatOpen={isChatOpen}
                     className={cn(

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -6,6 +6,7 @@ import { type TokenSourceConfigurable, type TokenSourceFixed } from 'livekit-cli
 
 import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { AgentSessionProvider } from '@/components/agents-ui/agent-session-provider';
+import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer';
 import { PopupView } from './popup-view';
 import { Trigger } from './trigger';
 
@@ -36,8 +37,8 @@ export interface EmbedPopupViewProps {
   /** Where to fetch a LiveKit session token from. See `useSession`'s `tokenSource` argument. */
   tokenSource: TokenSourceConfigurable | TokenSourceFixed;
   /**
-   * Theme mode forwarded to the aura visualizer (`audioVisualizerType="aura"`) so the shader's
-   * blend mode adapts to the theme mode. Ignored by other visualizer types.
+   * Theme mode forwarded to the aura visualizer (`audioVisualizer.type === 'aura'`) so the
+   * shader's blend mode adapts to the theme mode. Ignored by other visualizer types.
    */
   themeMode?: 'dark' | 'light';
   /**
@@ -71,24 +72,8 @@ export interface EmbedPopupViewProps {
    * @default true
    */
   isPreConnectBufferEnabled?: boolean;
-  /** Selects the visualizer style rendered in the main tile area. */
-  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
-  /** Primary hex color used by supported audio visualizer variants. */
-  audioVisualizerColor?: `#${string}`;
-  /** Hue shift intensity used by certain visualizers. */
-  audioVisualizerColorShift?: number;
-  /** Number of bars to render when `audioVisualizerType` is `bar`. */
-  audioVisualizerBarCount?: number;
-  /** Number of rows in the visualizer when `audioVisualizerType` is `grid`. */
-  audioVisualizerGridRowCount?: number;
-  /** Number of columns in the visualizer when `audioVisualizerType` is `grid`. */
-  audioVisualizerGridColumnCount?: number;
-  /** Number of radial bars when `audioVisualizerType` is `radial`. */
-  audioVisualizerRadialBarCount?: number;
-  /** Base radius of the radial visualizer when `audioVisualizerType` is `radial`. */
-  audioVisualizerRadialRadius?: number;
-  /** Stroke width of the wave path when `audioVisualizerType` is `wave`. */
-  audioVisualizerWaveLineWidth?: number;
+  /** Configures the visualizer style rendered in the main tile area. */
+  audioVisualizer?: AudioVisualizerConfig;
 }
 
 export function EmbedPopupView_01({
@@ -100,15 +85,10 @@ export function EmbedPopupView_01({
   controls = DEFAULT_CONTROLS,
   isPreConnectBufferEnabled,
   preConnectMessage,
-  audioVisualizerType,
-  audioVisualizerColor,
-  audioVisualizerColorShift,
-  audioVisualizerBarCount,
-  audioVisualizerGridRowCount,
-  audioVisualizerGridColumnCount,
-  audioVisualizerRadialBarCount,
-  audioVisualizerRadialRadius,
-  audioVisualizerWaveLineWidth,
+  audioVisualizer = {
+    type: 'bar',
+    size: 'lg',
+  },
 }: EmbedPopupViewProps) {
   const session = useSession(tokenSource);
   const [popupOpen, setPopupOpen] = useState(false);
@@ -176,15 +156,7 @@ export function EmbedPopupView_01({
           themeMode={themeMode}
           isPreConnectBufferEnabled={isPreConnectBufferEnabled}
           preConnectMessage={preConnectMessage}
-          audioVisualizerColor={audioVisualizerColor}
-          audioVisualizerType={audioVisualizerType}
-          audioVisualizerColorShift={audioVisualizerColorShift}
-          audioVisualizerBarCount={audioVisualizerBarCount}
-          audioVisualizerGridRowCount={audioVisualizerGridRowCount}
-          audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
-          audioVisualizerRadialBarCount={audioVisualizerRadialBarCount}
-          audioVisualizerRadialRadius={audioVisualizerRadialRadius}
-          audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
+          audioVisualizer={audioVisualizer}
           controls={finalControls}
           onDisconnect={handleToggle}
         />

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
+import { useAgent, useSession } from '@livekit/components-react';
 import { type TokenSourceConfigurable, type TokenSourceFixed } from 'livekit-client';
-import { useSession } from '@livekit/components-react';
-import { AgentSessionProvider } from '@/components/agents-ui/agent-session-provider';
+
 import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
+import { AgentSessionProvider } from '@/components/agents-ui/agent-session-provider';
 import { PopupView } from './popup-view';
 import { Trigger } from './trigger';
 
@@ -21,19 +22,22 @@ export interface EmbedPopupViewError {
   description: string;
 }
 
+function TriggerProvider({ ...props }: ComponentProps<typeof Trigger>) {
+  const { isConnected } = useAgent();
+
+  return <Trigger {...props} isConnected={isConnected} />;
+}
+
 export interface EmbedPopupViewProps {
-  /**
-   * @default 'Agent'
-   */
+  /** Logo shown in the trigger bubble in place of the default agent icon. */
+  logo?: string;
+  /** @default 'Agent' */
   agentName?: string;
   /** Where to fetch a LiveKit session token from. See `useSession`'s `tokenSource` argument. */
   tokenSource: TokenSourceConfigurable | TokenSourceFixed;
-  /** Logo shown in the trigger bubble in place of the default agent icon. */
-  logo?: string;
   /**
-   * Theme mode forwarded to the aura visualizer (`audioVisualizerType="aura"`) so
-   * the shader's blend mode adapts to the theme mode.
-   * Ignored by other visualizer types.
+   * Theme mode forwarded to the aura visualizer (`audioVisualizerType="aura"`) so the shader's
+   * blend mode adapts to the theme mode. Ignored by other visualizer types.
    */
   themeMode?: 'dark' | 'light';
   /**
@@ -43,7 +47,8 @@ export interface EmbedPopupViewProps {
    */
   preConnectMessage?: string;
   /**
-   * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps to a boolean value that determines whether the control is displayed.
+   * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps
+   * to a boolean value that determines whether the control is displayed.
    *
    * @default {
    *   leave: true,
@@ -87,12 +92,12 @@ export interface EmbedPopupViewProps {
 }
 
 export function EmbedPopupView_01({
-  agentName = 'Agent',
-  tokenSource,
   logo,
-  controls = DEFAULT_CONTROLS,
-  triggerColor,
   themeMode,
+  tokenSource,
+  triggerColor,
+  agentName = 'Agent',
+  controls = DEFAULT_CONTROLS,
   isPreConnectBufferEnabled,
   preConnectMessage,
   audioVisualizerType,
@@ -107,7 +112,7 @@ export function EmbedPopupView_01({
 }: EmbedPopupViewProps) {
   const session = useSession(tokenSource);
   const [popupOpen, setPopupOpen] = useState(false);
-  const [error, setError] = useState<EmbedPopupViewError | null>(null);
+  const [error, setError] = useState<EmbedPopupViewError>();
 
   // Drive the session lifecycle off the popup-open state. Opening the popup
   // connects; closing it (or unmounting) tears the room down so we don't
@@ -142,7 +147,7 @@ export function EmbedPopupView_01({
   const handleToggle = useCallback(() => {
     setPopupOpen((open) => {
       const next = !open;
-      if (!next) setError(null);
+      if (!next) setError(undefined);
       return next;
     });
   }, []);
@@ -154,13 +159,14 @@ export function EmbedPopupView_01({
 
   return (
     <AgentSessionProvider session={session}>
-      <Trigger
-        color={triggerColor}
+      <TriggerProvider
         logo={logo}
-        agentName={agentName}
-        popupOpen={popupOpen}
         error={error}
+        color={triggerColor}
+        agentName={agentName}
+        isPressed={popupOpen}
         onToggle={handleToggle}
+        className="fixed right-4 bottom-4 z-50"
       />
       {popupOpen && (
         <PopupView

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -16,12 +16,12 @@ const DEFAULT_CONTROLS: AgentControlBarControls = {
   screenShare: true,
 };
 
-export interface AgentClientError {
+export interface EmbedPopupViewError {
   title: string;
   description: string;
 }
 
-export interface AgentClientProps {
+export interface EmbedPopupViewProps {
   /**
    * @default 'Agent'
    */
@@ -53,7 +53,7 @@ export interface AgentClientProps {
    *   screenShare: false,
    * }
    */
-  controls: AgentControlBarControls;
+  controls?: AgentControlBarControls;
   /**
    * Brand color for the trigger bubble and audio visualizer.
    *
@@ -86,7 +86,7 @@ export interface AgentClientProps {
   audioVisualizerWaveLineWidth?: number;
 }
 
-export function AgentClient({
+export function EmbedPopupView_01({
   agentName = 'Agent',
   tokenSource,
   logo,
@@ -104,10 +104,10 @@ export function AgentClient({
   audioVisualizerRadialBarCount,
   audioVisualizerRadialRadius,
   audioVisualizerWaveLineWidth,
-}: AgentClientProps) {
+}: EmbedPopupViewProps) {
   const session = useSession(tokenSource);
   const [popupOpen, setPopupOpen] = useState(false);
-  const [error, setError] = useState<AgentClientError | null>(null);
+  const [error, setError] = useState<EmbedPopupViewError | null>(null);
 
   // Drive the session lifecycle off the popup-open state. Opening the popup
   // connects; closing it (or unmounting) tears the room down so we don't

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -60,11 +60,7 @@ export interface EmbedPopupViewProps {
    * }
    */
   controls?: AgentControlBarControls;
-  /**
-   * Brand color for the trigger bubble and audio visualizer.
-   *
-   * @default '#3b82f6'
-   */
+  /** Brand color used for the trigger bubble's idle ring/disc and fallback icon contrast. */
   triggerColor?: `#${string}`;
   /**
    * Shows a pre-connect buffer state with a shimmer message before messages appear.
@@ -72,7 +68,11 @@ export interface EmbedPopupViewProps {
    * @default true
    */
   isPreConnectBufferEnabled?: boolean;
-  /** Configures the visualizer style rendered in the main tile area. */
+  /**
+   * Configures the visualizer style rendered in the main tile area.
+   *
+   * @default { type: 'bar', size: 'lg' }
+   */
   audioVisualizer?: AudioVisualizerConfig;
 }
 

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -92,6 +92,7 @@ export function AgentClient({
   logo,
   controls = DEFAULT_CONTROLS,
   triggerColor,
+  themeMode,
   isPreConnectBufferEnabled,
   preConnectMessage,
   audioVisualizerType,
@@ -166,6 +167,7 @@ export function AgentClient({
           logo={logo}
           error={error}
           agentName={agentName}
+          themeMode={themeMode}
           isPreConnectBufferEnabled={isPreConnectBufferEnabled}
           preConnectMessage={preConnectMessage}
           audioVisualizerColor={audioVisualizerColor}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type TokenSourceConfigurable, type TokenSourceFixed } from 'livekit-client';
+import { useSession } from '@livekit/components-react';
+import { AgentSessionProvider } from '@/components/agents-ui/agent-session-provider';
+import { PopupView } from './popup-view';
+import { Trigger } from './trigger';
+
+export interface AgentClientError {
+  title: string;
+  description: string;
+}
+
+export interface AgentClientProps {
+  /** Where to fetch a LiveKit session token from. See `useSession`'s `tokenSource` argument. */
+  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
+  /**
+   * Brand color for the trigger bubble and audio visualizer.
+   *
+   * @default '#3b82f6'
+   */
+  color?: `#${string}`;
+  /** Logo shown in the trigger bubble in place of the default agent icon. */
+  logo?: string;
+  /**
+   * @default 'Agent'
+   */
+  agentName?: string;
+  /**
+   * @default true
+   */
+  supportsChatInput?: boolean;
+  /**
+   * @default true
+   */
+  supportsVideoInput?: boolean;
+  /**
+   * @default true
+   */
+  supportsScreenShare?: boolean;
+}
+
+export function AgentClient({
+  tokenSource,
+  color = '#3b82f6',
+  logo,
+  agentName = 'Agent',
+  supportsChatInput = true,
+  supportsVideoInput = true,
+  supportsScreenShare = true,
+}: AgentClientProps) {
+  const session = useSession(tokenSource);
+
+  const [popupOpen, setPopupOpen] = useState(false);
+  const [error, setError] = useState<AgentClientError | null>(null);
+
+  // Drive the session lifecycle off the popup-open state. Opening the popup
+  // connects; closing it (or unmounting) tears the room down so we don't
+  // leave a mic-hot connection while the bubble sits idle.
+  //
+  // useSession returns a fresh object on every connectionState change (the
+  // discriminated union swaps shape), so we can't depend on `session`
+  // directly - that would tear down + restart the room every time it
+  // transitioned through connecting -> connected. We pin the start/end
+  // calls via a ref instead, and only react to popupOpen.
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+  useEffect(() => {
+    if (!popupOpen) return;
+    let cancelled = false;
+    sessionRef.current.start().catch((cause) => {
+      if (cancelled) return;
+
+      console.error('embed-popup-view-01: session.start failed:', cause);
+      setError({
+        title: 'Could not connect to the agent',
+        description: cause instanceof Error ? cause.message : String(cause),
+      });
+    });
+    return () => {
+      cancelled = true;
+      void sessionRef.current.end();
+    };
+  }, [popupOpen]);
+
+  const handleToggle = useCallback(() => {
+    setPopupOpen((open) => {
+      const next = !open;
+      if (!next) setError(null);
+      return next;
+    });
+  }, []);
+
+  return (
+    <AgentSessionProvider session={session}>
+      <Trigger
+        color={color}
+        logo={logo}
+        agentName={agentName}
+        popupOpen={popupOpen}
+        error={error}
+        onToggle={handleToggle}
+      />
+      {popupOpen && (
+        <PopupView
+          agentName={agentName}
+          logo={logo}
+          color={color}
+          error={error}
+          supportsChatInput={supportsChatInput}
+          supportsVideoInput={supportsVideoInput}
+          supportsScreenShare={supportsScreenShare}
+        />
+      )}
+    </AgentSessionProvider>
+  );
+}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -4,8 +4,17 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { type TokenSourceConfigurable, type TokenSourceFixed } from 'livekit-client';
 import { useSession } from '@livekit/components-react';
 import { AgentSessionProvider } from '@/components/agents-ui/agent-session-provider';
+import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { PopupView } from './popup-view';
 import { Trigger } from './trigger';
+
+const DEFAULT_CONTROLS: AgentControlBarControls = {
+  leave: false,
+  microphone: true,
+  chat: true,
+  camera: true,
+  screenShare: true,
+};
 
 export interface AgentClientError {
   title: string;
@@ -28,17 +37,17 @@ export interface AgentClientProps {
    */
   agentName?: string;
   /**
-   * @default true
+   * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps to a boolean value that determines whether the control is displayed.
+   *
+   * @default {
+   *   leave: true,
+   *   microphone: true,
+   *   chat: false,
+   *   camera: false,
+   *   screenShare: false,
+   * }
    */
-  supportsChatInput?: boolean;
-  /**
-   * @default true
-   */
-  supportsVideoInput?: boolean;
-  /**
-   * @default true
-   */
-  supportsScreenShare?: boolean;
+  controls: AgentControlBarControls;
 }
 
 export function AgentClient({
@@ -46,12 +55,9 @@ export function AgentClient({
   color = '#3b82f6',
   logo,
   agentName = 'Agent',
-  supportsChatInput = true,
-  supportsVideoInput = true,
-  supportsScreenShare = true,
+  controls = DEFAULT_CONTROLS,
 }: AgentClientProps) {
   const session = useSession(tokenSource);
-
   const [popupOpen, setPopupOpen] = useState(false);
   const [error, setError] = useState<AgentClientError | null>(null);
 
@@ -66,6 +72,7 @@ export function AgentClient({
   // calls via a ref instead, and only react to popupOpen.
   const sessionRef = useRef(session);
   sessionRef.current = session;
+
   useEffect(() => {
     if (!popupOpen) return;
     let cancelled = false;
@@ -92,6 +99,11 @@ export function AgentClient({
     });
   }, []);
 
+  const finalControls = {
+    ...DEFAULT_CONTROLS,
+    ...controls,
+  };
+
   return (
     <AgentSessionProvider session={session}>
       <Trigger
@@ -108,9 +120,8 @@ export function AgentClient({
           logo={logo}
           color={color}
           error={error}
-          supportsChatInput={supportsChatInput}
-          supportsVideoInput={supportsVideoInput}
-          supportsScreenShare={supportsScreenShare}
+          controls={finalControls}
+          onDisconnect={handleToggle}
         />
       )}
     </AgentSessionProvider>

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -13,9 +13,9 @@ import { Trigger } from './trigger';
 const DEFAULT_CONTROLS: AgentControlBarControls = {
   leave: false,
   microphone: true,
-  chat: true,
-  camera: true,
-  screenShare: true,
+  chat: false,
+  camera: false,
+  screenShare: false,
 };
 
 export interface EmbedPopupViewError {
@@ -51,13 +51,7 @@ export interface EmbedPopupViewProps {
    * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps
    * to a boolean value that determines whether the control is displayed.
    *
-   * @default {
-   *   leave: true,
-   *   microphone: true,
-   *   chat: false,
-   *   camera: false,
-   *   screenShare: false,
-   * }
+   * @default { leave: false, microphone: true, chat: false, camera: false, screenShare: false }
    */
   controls?: AgentControlBarControls;
   /** Brand color used for the trigger bubble's idle ring/disc and fallback icon contrast. */

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -6,7 +6,7 @@ import { type TokenSourceConfigurable, type TokenSourceFixed } from 'livekit-cli
 
 import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { AgentSessionProvider } from '@/components/agents-ui/agent-session-provider';
-import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer';
+import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import { PopupView } from './popup-view';
 import { Trigger } from './trigger';
 

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx
@@ -22,20 +22,26 @@ export interface AgentClientError {
 }
 
 export interface AgentClientProps {
-  /** Where to fetch a LiveKit session token from. See `useSession`'s `tokenSource` argument. */
-  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
-  /**
-   * Brand color for the trigger bubble and audio visualizer.
-   *
-   * @default '#3b82f6'
-   */
-  color?: `#${string}`;
-  /** Logo shown in the trigger bubble in place of the default agent icon. */
-  logo?: string;
   /**
    * @default 'Agent'
    */
   agentName?: string;
+  /** Where to fetch a LiveKit session token from. See `useSession`'s `tokenSource` argument. */
+  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
+  /** Logo shown in the trigger bubble in place of the default agent icon. */
+  logo?: string;
+  /**
+   * Theme mode forwarded to the aura visualizer (`audioVisualizerType="aura"`) so
+   * the shader's blend mode adapts to the theme mode.
+   * Ignored by other visualizer types.
+   */
+  themeMode?: 'dark' | 'light';
+  /**
+   * Message shown above the controls before the first chat message is sent.
+   *
+   * @default 'Agent is listening, ask it a question'
+   */
+  preConnectMessage?: string;
   /**
    * An object with the following keys: leave, microphone, screenShare, camera, chat. Each key maps to a boolean value that determines whether the control is displayed.
    *
@@ -48,14 +54,55 @@ export interface AgentClientProps {
    * }
    */
   controls: AgentControlBarControls;
+  /**
+   * Brand color for the trigger bubble and audio visualizer.
+   *
+   * @default '#3b82f6'
+   */
+  triggerColor?: `#${string}`;
+  /**
+   * Shows a pre-connect buffer state with a shimmer message before messages appear.
+   *
+   * @default true
+   */
+  isPreConnectBufferEnabled?: boolean;
+  /** Selects the visualizer style rendered in the main tile area. */
+  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
+  /** Primary hex color used by supported audio visualizer variants. */
+  audioVisualizerColor?: `#${string}`;
+  /** Hue shift intensity used by certain visualizers. */
+  audioVisualizerColorShift?: number;
+  /** Number of bars to render when `audioVisualizerType` is `bar`. */
+  audioVisualizerBarCount?: number;
+  /** Number of rows in the visualizer when `audioVisualizerType` is `grid`. */
+  audioVisualizerGridRowCount?: number;
+  /** Number of columns in the visualizer when `audioVisualizerType` is `grid`. */
+  audioVisualizerGridColumnCount?: number;
+  /** Number of radial bars when `audioVisualizerType` is `radial`. */
+  audioVisualizerRadialBarCount?: number;
+  /** Base radius of the radial visualizer when `audioVisualizerType` is `radial`. */
+  audioVisualizerRadialRadius?: number;
+  /** Stroke width of the wave path when `audioVisualizerType` is `wave`. */
+  audioVisualizerWaveLineWidth?: number;
 }
 
 export function AgentClient({
-  tokenSource,
-  color = '#3b82f6',
-  logo,
   agentName = 'Agent',
+  tokenSource,
+  logo,
   controls = DEFAULT_CONTROLS,
+  triggerColor,
+  isPreConnectBufferEnabled,
+  preConnectMessage,
+  audioVisualizerType,
+  audioVisualizerColor,
+  audioVisualizerColorShift,
+  audioVisualizerBarCount,
+  audioVisualizerGridRowCount,
+  audioVisualizerGridColumnCount,
+  audioVisualizerRadialBarCount,
+  audioVisualizerRadialRadius,
+  audioVisualizerWaveLineWidth,
 }: AgentClientProps) {
   const session = useSession(tokenSource);
   const [popupOpen, setPopupOpen] = useState(false);
@@ -107,7 +154,7 @@ export function AgentClient({
   return (
     <AgentSessionProvider session={session}>
       <Trigger
-        color={color}
+        color={triggerColor}
         logo={logo}
         agentName={agentName}
         popupOpen={popupOpen}
@@ -116,10 +163,20 @@ export function AgentClient({
       />
       {popupOpen && (
         <PopupView
-          agentName={agentName}
           logo={logo}
-          color={color}
           error={error}
+          agentName={agentName}
+          isPreConnectBufferEnabled={isPreConnectBufferEnabled}
+          preConnectMessage={preConnectMessage}
+          audioVisualizerColor={audioVisualizerColor}
+          audioVisualizerType={audioVisualizerType}
+          audioVisualizerColorShift={audioVisualizerColorShift}
+          audioVisualizerBarCount={audioVisualizerBarCount}
+          audioVisualizerGridRowCount={audioVisualizerGridRowCount}
+          audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
+          audioVisualizerRadialBarCount={audioVisualizerRadialBarCount}
+          audioVisualizerRadialRadius={audioVisualizerRadialRadius}
+          audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
           controls={finalControls}
           onDisconnect={handleToggle}
         />

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { StartAudioButton } from '@/components/agents-ui/start-audio-button';
 import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
+import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer';
 import { cn } from '@/lib/utils';
 import type { EmbedPopupViewError } from './embed-popup-block';
 
@@ -56,15 +57,7 @@ export interface PopupViewProps {
   themeMode?: 'dark' | 'light';
   preConnectMessage?: string;
   isPreConnectBufferEnabled?: boolean;
-  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
-  audioVisualizerColor?: `#${string}`;
-  audioVisualizerColorShift?: number;
-  audioVisualizerBarCount?: number;
-  audioVisualizerGridRowCount?: number;
-  audioVisualizerGridColumnCount?: number;
-  audioVisualizerRadialBarCount?: number;
-  audioVisualizerRadialRadius?: number;
-  audioVisualizerWaveLineWidth?: number;
+  audioVisualizer?: AudioVisualizerConfig;
   onDisconnect?: () => void;
 }
 
@@ -76,15 +69,7 @@ export function PopupView({
   themeMode,
   isPreConnectBufferEnabled,
   preConnectMessage,
-  audioVisualizerType,
-  audioVisualizerColor,
-  audioVisualizerColorShift,
-  audioVisualizerBarCount = 3,
-  audioVisualizerGridRowCount,
-  audioVisualizerGridColumnCount,
-  audioVisualizerRadialBarCount,
-  audioVisualizerRadialRadius,
-  audioVisualizerWaveLineWidth,
+  audioVisualizer,
   onDisconnect,
 }: PopupViewProps) {
   return (
@@ -105,15 +90,7 @@ export function PopupView({
           themeMode={themeMode}
           isPreConnectBufferEnabled={isPreConnectBufferEnabled}
           preConnectMessage={preConnectMessage}
-          audioVisualizerType={audioVisualizerType}
-          audioVisualizerColor={audioVisualizerColor}
-          audioVisualizerColorShift={audioVisualizerColorShift}
-          audioVisualizerBarCount={audioVisualizerBarCount}
-          audioVisualizerGridRowCount={audioVisualizerGridRowCount}
-          audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
-          audioVisualizerRadialBarCount={audioVisualizerRadialBarCount}
-          audioVisualizerRadialRadius={audioVisualizerRadialRadius}
-          audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
+          audioVisualizer={audioVisualizer}
           onDisconnect={onDisconnect}
         />
       </div>

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { motion } from 'motion/react';
-import { StartAudio } from '@livekit/components-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { StartAudioButton } from '@/components/agents-ui/start-audio-button';
 import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import { cn } from '@/lib/utils';
-import type { AgentClientError } from './embed-popup-block';
+import type { EmbedPopupViewError } from './embed-popup-block';
 
 interface ErrorOverlayProps {
   logo?: string;
   agentName?: string;
-  error: AgentClientError | null;
+  error?: EmbedPopupViewError;
 }
 
 function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
@@ -21,14 +21,15 @@ function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
   }, [logo]);
   const showLogo = Boolean(logo) && !logoFailed;
 
-  return (
-    <div
+  return error ? (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
       data-testid="error-overlay"
       // @ts-expect-error React's types lag the platform on `inert`.
       inert={error === null ? '' : undefined}
       className={cn(
         'bg-background absolute inset-0 z-50 flex h-full w-full flex-col items-center justify-center gap-5 px-6 text-center transition-opacity',
-        error === null ? 'pointer-events-none opacity-0' : 'opacity-100',
       )}
     >
       {showLogo ? (
@@ -43,14 +44,14 @@ function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
       ) : null}
       <span className="text-foreground leading-tight font-medium text-pretty">{error?.title}</span>
       <span className="text-muted-foreground text-sm text-balance">{error?.description}</span>
-    </div>
-  );
+    </motion.div>
+  ) : null;
 }
 
 export interface PopupViewProps {
   agentName?: string;
   logo?: string;
-  error: AgentClientError | null;
+  error?: EmbedPopupViewError;
   controls: AgentControlBarControls;
   themeMode?: 'dark' | 'light';
   preConnectMessage?: string;
@@ -95,8 +96,10 @@ export function PopupView({
       className="fixed right-4 bottom-20 left-4 z-50 h-[480px] md:left-auto md:w-[360px]"
     >
       <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[40px] border drop-shadow-md">
-        <ErrorOverlay logo={logo} agentName={agentName} error={error} />
-        <StartAudio label="Start audio" />
+        <AnimatePresence>
+          <ErrorOverlay logo={logo} agentName={agentName} error={error} />
+        </AnimatePresence>
+        <StartAudioButton label="Enable Audio" />
         <AgentSessionView_01
           controls={controls}
           themeMode={themeMode}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion } from 'motion/react';
+import { StartAudio } from '@livekit/components-react';
+import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
+import { cn } from '@/lib/utils';
+import type { AgentClientError } from './embed-popup-block';
+
+export interface PopupViewProps {
+  agentName?: string;
+  logo?: string;
+  color?: `#${string}`;
+  error: AgentClientError | null;
+  supportsChatInput?: boolean;
+  supportsVideoInput?: boolean;
+  supportsScreenShare?: boolean;
+}
+
+interface ErrorOverlayProps {
+  logo?: string;
+  agentName?: string;
+  error: AgentClientError | null;
+}
+
+function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
+  const [logoFailed, setLogoFailed] = useState(false);
+  useEffect(() => {
+    setLogoFailed(false);
+  }, [logo]);
+  const showLogo = Boolean(logo) && !logoFailed;
+
+  return (
+    <div
+      data-testid="error-overlay"
+      // @ts-expect-error React's types lag the platform on `inert`.
+      inert={error === null ? '' : undefined}
+      className={cn(
+        'bg-background absolute inset-0 z-50 flex h-full w-full flex-col items-center justify-center gap-5 px-6 text-center transition-opacity',
+        error === null ? 'pointer-events-none opacity-0' : 'opacity-100',
+      )}
+    >
+      {showLogo ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={logo}
+          alt={`${agentName ?? 'Agent'} logo`}
+          className="size-6 object-contain"
+          referrerPolicy="no-referrer"
+          onError={() => setLogoFailed(true)}
+        />
+      ) : null}
+      <span className="text-foreground leading-tight font-medium text-pretty">{error?.title}</span>
+      <span className="text-muted-foreground text-sm text-balance">{error?.description}</span>
+    </div>
+  );
+}
+
+export function PopupView({
+  agentName,
+  logo,
+  color,
+  error,
+  supportsChatInput,
+  supportsVideoInput,
+  supportsScreenShare,
+}: PopupViewProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, translateY: 8 }}
+      animate={{ opacity: 1, translateY: 0 }}
+      exit={{ opacity: 0, translateY: 8 }}
+      transition={{ type: 'spring', bounce: 0, duration: 0.4 }}
+      className="fixed right-4 bottom-20 left-4 z-50 h-[480px] rounded-[28px] border drop-shadow-md md:left-auto md:w-[360px]"
+    >
+      <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[28px]">
+        <ErrorOverlay logo={logo} agentName={agentName} error={error} />
+        <StartAudio label="Start audio" />
+        <AgentSessionView_01
+          supportsChatInput={supportsChatInput}
+          supportsVideoInput={supportsVideoInput}
+          supportsScreenShare={supportsScreenShare}
+          audioVisualizerColor={color}
+        />
+      </div>
+    </motion.div>
+  );
+}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -52,6 +52,7 @@ export interface PopupViewProps {
   logo?: string;
   error: AgentClientError | null;
   controls: AgentControlBarControls;
+  themeMode?: 'dark' | 'light';
   preConnectMessage?: string;
   isPreConnectBufferEnabled?: boolean;
   audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
@@ -71,6 +72,7 @@ export function PopupView({
   logo,
   error,
   controls,
+  themeMode,
   isPreConnectBufferEnabled,
   preConnectMessage,
   audioVisualizerType,
@@ -97,6 +99,7 @@ export function PopupView({
         <StartAudio label="Start audio" />
         <AgentSessionView_01
           controls={controls}
+          themeMode={themeMode}
           isPreConnectBufferEnabled={isPreConnectBufferEnabled}
           preConnectMessage={preConnectMessage}
           audioVisualizerType={audioVisualizerType}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { StartAudioButton } from '@/components/agents-ui/start-audio-button';
 import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
-import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/audio-visualizer';
+import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import { cn } from '@/lib/utils';
 import type { EmbedPopupViewError } from './embed-popup-block';
 

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -92,9 +92,9 @@ export function PopupView({
       animate={{ opacity: 1, translateY: 0 }}
       exit={{ opacity: 0, translateY: 8 }}
       transition={{ type: 'spring', bounce: 0, duration: 0.4 }}
-      className="fixed right-4 bottom-20 left-4 z-50 h-[480px] rounded-[28px] border drop-shadow-md md:left-auto md:w-[360px]"
+      className="fixed right-4 bottom-20 left-4 z-50 h-[480px] md:left-auto md:w-[360px]"
     >
-      <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[28px]">
+      <div className="relative flex h-full w-full flex-col overflow-hidden rounded-[40px] border drop-shadow-md">
         <ErrorOverlay logo={logo} agentName={agentName} error={error} />
         <StartAudio label="Start audio" />
         <AgentSessionView_01

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -3,19 +3,10 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'motion/react';
 import { StartAudio } from '@livekit/components-react';
+import { type AgentControlBarControls } from '@/components/agents-ui/agent-control-bar';
 import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import { cn } from '@/lib/utils';
 import type { AgentClientError } from './embed-popup-block';
-
-export interface PopupViewProps {
-  agentName?: string;
-  logo?: string;
-  color?: `#${string}`;
-  error: AgentClientError | null;
-  supportsChatInput?: boolean;
-  supportsVideoInput?: boolean;
-  supportsScreenShare?: boolean;
-}
 
 interface ErrorOverlayProps {
   logo?: string;
@@ -56,14 +47,22 @@ function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
   );
 }
 
+export interface PopupViewProps {
+  agentName?: string;
+  logo?: string;
+  color?: `#${string}`;
+  error: AgentClientError | null;
+  controls: AgentControlBarControls;
+  onDisconnect?: () => void;
+}
+
 export function PopupView({
   agentName,
   logo,
   color,
   error,
-  supportsChatInput,
-  supportsVideoInput,
-  supportsScreenShare,
+  controls,
+  onDisconnect,
 }: PopupViewProps) {
   return (
     <motion.div
@@ -77,10 +76,10 @@ export function PopupView({
         <ErrorOverlay logo={logo} agentName={agentName} error={error} />
         <StartAudio label="Start audio" />
         <AgentSessionView_01
-          supportsChatInput={supportsChatInput}
-          supportsVideoInput={supportsVideoInput}
-          supportsScreenShare={supportsScreenShare}
+          controls={controls}
           audioVisualizerColor={color}
+          audioVisualizerBarCount={3}
+          onDisconnect={onDisconnect}
         />
       </div>
     </motion.div>

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx
@@ -50,18 +50,38 @@ function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
 export interface PopupViewProps {
   agentName?: string;
   logo?: string;
-  color?: `#${string}`;
   error: AgentClientError | null;
   controls: AgentControlBarControls;
+  preConnectMessage?: string;
+  isPreConnectBufferEnabled?: boolean;
+  audioVisualizerType?: 'bar' | 'wave' | 'grid' | 'radial' | 'aura';
+  audioVisualizerColor?: `#${string}`;
+  audioVisualizerColorShift?: number;
+  audioVisualizerBarCount?: number;
+  audioVisualizerGridRowCount?: number;
+  audioVisualizerGridColumnCount?: number;
+  audioVisualizerRadialBarCount?: number;
+  audioVisualizerRadialRadius?: number;
+  audioVisualizerWaveLineWidth?: number;
   onDisconnect?: () => void;
 }
 
 export function PopupView({
   agentName,
   logo,
-  color,
   error,
   controls,
+  isPreConnectBufferEnabled,
+  preConnectMessage,
+  audioVisualizerType,
+  audioVisualizerColor,
+  audioVisualizerColorShift,
+  audioVisualizerBarCount = 3,
+  audioVisualizerGridRowCount,
+  audioVisualizerGridColumnCount,
+  audioVisualizerRadialBarCount,
+  audioVisualizerRadialRadius,
+  audioVisualizerWaveLineWidth,
   onDisconnect,
 }: PopupViewProps) {
   return (
@@ -77,8 +97,17 @@ export function PopupView({
         <StartAudio label="Start audio" />
         <AgentSessionView_01
           controls={controls}
-          audioVisualizerColor={color}
-          audioVisualizerBarCount={3}
+          isPreConnectBufferEnabled={isPreConnectBufferEnabled}
+          preConnectMessage={preConnectMessage}
+          audioVisualizerType={audioVisualizerType}
+          audioVisualizerColor={audioVisualizerColor}
+          audioVisualizerColorShift={audioVisualizerColorShift}
+          audioVisualizerBarCount={audioVisualizerBarCount}
+          audioVisualizerGridRowCount={audioVisualizerGridRowCount}
+          audioVisualizerGridColumnCount={audioVisualizerGridColumnCount}
+          audioVisualizerRadialBarCount={audioVisualizerRadialBarCount}
+          audioVisualizerRadialRadius={audioVisualizerRadialRadius}
+          audioVisualizerWaveLineWidth={audioVisualizerWaveLineWidth}
           onDisconnect={onDisconnect}
         />
       </div>

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -55,18 +55,18 @@ export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: 
       <div
         className={cn(
           'absolute inset-0.5 z-10 grid place-items-center rounded-full transition-colors',
-          isConnecting && 'bg-background',
-          isDestructive && 'bg-destructive',
+          isConnecting && 'bg-background text-background',
+          isDestructive && 'bg-destructive text-white',
         )}
       >
         {isConnecting ? null : isError ? (
           // The spinning ring is the connecting signal; skip a centred glyph
           // so it reads as a clean spinner rather than a flashing X.
-          <XIcon className="size-5 text-background" aria-hidden="true" />
+          <XIcon className="size-5" aria-hidden="true" />
         ) : isConnected ? (
           // Crossed-out phone on the solid destructive disc signals
           // "click to end the call".
-          <PhoneOffIcon className="size-5 text-background" aria-hidden="true" />
+          <PhoneOffIcon className="size-5" aria-hidden="true" />
         ) : showLogo ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
@@ -79,7 +79,17 @@ export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: 
         ) : (
           // Pick black vs white based on the user-set brand color so the
           // icon stays readable across a bright yellow, deep navy, etc.
-          <BotIcon className="size-6 text-background" aria-hidden="true" />
+          <BotIcon
+            className="size-6 text-background"
+            aria-hidden="true"
+            style={
+              color
+                ? {
+                    color: `contrast-color(${color})`,
+                  }
+                : undefined
+            }
+          />
         )}
       </div>
     </Button>

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -56,7 +56,7 @@ export function Trigger({
       aria-label={isPressed ? 'Close assistant' : altText}
       aria-expanded={isPressed}
       className={cn(
-        'm-0 block size-12 rounded-full p-0.5 drop-shadow-sm transition-transform duration-200 hover:scale-105 focus-visible:scale-105',
+        'relative m-0 block size-12 rounded-full p-0.5 drop-shadow-sm transition-transform duration-200 hover:scale-105 focus-visible:scale-105',
         className,
       )}
       {...props}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -8,13 +8,19 @@ import { Button } from '@/components/ui/button';
 import type { EmbedPopupViewError } from './embed-popup-block';
 
 export interface TriggerProps extends ComponentProps<'button'> {
-  /** Brand color used for the idle ring/disc and, via contrast, the fallback icon color. */
+  /** Logo image shown in place of the default bot icon. */
   logo?: string;
+  /** Brand color used for the idle ring/disc and, via contrast, the fallback icon color. */
   color?: string;
+  /** Used to build the default `aria-label` (e.g. "Rex agent") and image `alt` text. */
   agentName?: string;
+  /** Whether the popup is currently open. Drives the connecting/active/error visual states. */
   isPressed?: boolean;
+  /** Whether the agent session is connected. Only relevant while `isPressed` is true. */
   isConnected?: boolean;
+  /** Session error, if any. Only relevant while `isPressed` is true. */
   error?: EmbedPopupViewError;
+  /** Called when the trigger is clicked. */
   onToggle: () => void;
 }
 

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { type CSSProperties, useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { useEffect, useState } from 'react';
 import { BotIcon, PhoneOffIcon, XIcon } from 'lucide-react';
 import { useAgent } from '@livekit/components-react';
 import { Button } from '@/components/ui/button';
@@ -8,75 +9,15 @@ import type { AgentClientError } from './embed-popup-block';
 
 export interface TriggerProps {
   /** Brand color used for the idle ring/disc and, via contrast, the fallback icon color. */
-  color: string;
   logo?: string;
+  color?: string;
   agentName?: string;
   popupOpen: boolean;
   error: AgentClientError | null;
   onToggle: () => void;
 }
 
-// Outer ring carries the connecting spinner arc; idle blends with the inner
-// disc by sharing the brand color. Destructive leaves the ring fully
-// transparent so the solid destructive disc reads as a clean button
-// without a red halo extending past it.
-function ringStyle(color: string, isConnecting: boolean, isDestructive: boolean): CSSProperties {
-  if (isConnecting) {
-    return {
-      backgroundColor: `color-mix(in srgb, ${color} 30%, transparent)`,
-      backgroundImage: `conic-gradient(from 0deg, transparent 0%, transparent 30%, ${color} 50%, transparent 70%, transparent 100%)`,
-    };
-  }
-  if (isDestructive) {
-    return { backgroundColor: 'transparent' };
-  }
-  return { backgroundColor: color };
-}
-
-function iconBgStyle(color: string, isConnecting: boolean, isDestructive: boolean): CSSProperties {
-  if (isConnecting) {
-    return { backgroundColor: 'var(--background)' };
-  }
-  if (isDestructive) {
-    return { backgroundColor: 'var(--destructive)' };
-  }
-  return { backgroundColor: color };
-}
-
-// WCAG 2.0 relative luminance of a #rrggbb / #rgb color in [0, 1].
-// Formula: https://www.w3.org/TR/WCAG20/#relativeluminancedef
-function relativeLuminance(hex: string): number {
-  const stripped = hex.replace('#', '').trim();
-  const full =
-    stripped.length === 3
-      ? stripped
-          .split('')
-          .map((c) => c + c)
-          .join('')
-      : stripped.length === 6
-        ? stripped
-        : '';
-  if (full.length !== 6) return 0;
-  const r = parseInt(full.slice(0, 2), 16) / 255;
-  const g = parseInt(full.slice(2, 4), 16) / 255;
-  const b = parseInt(full.slice(4, 6), 16) / 255;
-  const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
-  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
-}
-
-// Pick the higher-contrast foreground (black or white) for a background
-// color, using the WCAG 2.0 contrast-ratio formula. Threshold derived from
-// the contrast ratios against pure black (L = 0) and pure white (L = 1);
-// the crossover sits at L ≈ 0.179, not at the naïve 0.5.
-// Approach: https://github.com/siege-media/contrast-ratio
-function readableForeground(bgHex: string): string {
-  const L = relativeLuminance(bgHex);
-  const contrastOnBlack = (L + 0.05) / 0.05;
-  const contrastOnWhite = 1.05 / (L + 0.05);
-  return contrastOnBlack >= contrastOnWhite ? '#000000' : '#ffffff';
-}
-
-export function Trigger({ color, logo, agentName, popupOpen, error, onToggle }: TriggerProps) {
+export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: TriggerProps) {
   const { isConnected: isAgentConnected } = useAgent();
   const altText = agentName ? `${agentName} agent` : 'Open assistant';
 
@@ -102,12 +43,21 @@ export function Trigger({ color, logo, agentName, popupOpen, error, onToggle }: 
       className="fixed right-4 bottom-4 z-50 m-0 block size-12 rounded-full p-0.5 drop-shadow-sm transition-transform duration-200 hover:scale-105 focus-visible:scale-105"
     >
       <div
-        className={`absolute inset-0 rounded-full transition-colors ${isConnecting ? 'animate-spin' : ''}`}
-        style={ringStyle(color, isConnecting, isDestructive)}
+        className={cn(
+          'absolute inset-0 rounded-full transition-colors bg-current',
+          isConnecting && 'animate-spin',
+          isConnecting &&
+            'bg-current/30 bg-conic from-transparent via-current to-transparent from-30% via-50% to-70%',
+          isDestructive && 'bg-transparent',
+        )}
+        style={{ color }}
       />
       <div
-        className="absolute inset-0.5 z-10 grid place-items-center rounded-full transition-colors"
-        style={iconBgStyle(color, isConnecting, isDestructive)}
+        className={cn(
+          'absolute inset-0.5 z-10 grid place-items-center rounded-full transition-colors',
+          isConnecting && 'bg-background',
+          isDestructive && 'bg-destructive',
+        )}
       >
         {isConnecting ? null : isError ? (
           // The spinning ring is the connecting signal; skip a centred glyph
@@ -129,11 +79,7 @@ export function Trigger({ color, logo, agentName, popupOpen, error, onToggle }: 
         ) : (
           // Pick black vs white based on the user-set brand color so the
           // icon stays readable across a bright yellow, deep navy, etc.
-          <BotIcon
-            className="size-6"
-            style={{ color: readableForeground(color) }}
-            aria-hidden="true"
-          />
+          <BotIcon className="size-6 text-background" aria-hidden="true" />
         )}
       </div>
     </Button>

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -67,8 +67,8 @@ export function Trigger({
       />
       <div
         className={cn(
-          'absolute inset-0.5 z-10 grid place-items-center rounded-full transition-colors',
-          isConnecting && 'bg-background text-background',
+          'absolute z-10 grid place-items-center rounded-full transition-colors inset-0',
+          isConnecting && 'bg-background text-background inset-0.5',
           isDestructive && 'bg-destructive text-white',
         )}
       >

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { type CSSProperties, useEffect, useState } from 'react';
+import { BotIcon, PhoneOffIcon, XIcon } from 'lucide-react';
+import { useAgent } from '@livekit/components-react';
+import { Button } from '@/components/ui/button';
+import type { AgentClientError } from './embed-popup-block';
+
+export interface TriggerProps {
+  /** Brand color used for the idle ring/disc and, via contrast, the fallback icon color. */
+  color: string;
+  logo?: string;
+  agentName?: string;
+  popupOpen: boolean;
+  error: AgentClientError | null;
+  onToggle: () => void;
+}
+
+// Outer ring carries the connecting spinner arc; idle blends with the inner
+// disc by sharing the brand color. Destructive leaves the ring fully
+// transparent so the solid destructive disc reads as a clean button
+// without a red halo extending past it.
+function ringStyle(color: string, isConnecting: boolean, isDestructive: boolean): CSSProperties {
+  if (isConnecting) {
+    return {
+      backgroundColor: `color-mix(in srgb, ${color} 30%, transparent)`,
+      backgroundImage: `conic-gradient(from 0deg, transparent 0%, transparent 30%, ${color} 50%, transparent 70%, transparent 100%)`,
+    };
+  }
+  if (isDestructive) {
+    return { backgroundColor: 'transparent' };
+  }
+  return { backgroundColor: color };
+}
+
+function iconBgStyle(color: string, isConnecting: boolean, isDestructive: boolean): CSSProperties {
+  if (isConnecting) {
+    return { backgroundColor: 'var(--background)' };
+  }
+  if (isDestructive) {
+    return { backgroundColor: 'var(--destructive)' };
+  }
+  return { backgroundColor: color };
+}
+
+// WCAG 2.0 relative luminance of a #rrggbb / #rgb color in [0, 1].
+// Formula: https://www.w3.org/TR/WCAG20/#relativeluminancedef
+function relativeLuminance(hex: string): number {
+  const stripped = hex.replace('#', '').trim();
+  const full =
+    stripped.length === 3
+      ? stripped
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : stripped.length === 6
+        ? stripped
+        : '';
+  if (full.length !== 6) return 0;
+  const r = parseInt(full.slice(0, 2), 16) / 255;
+  const g = parseInt(full.slice(2, 4), 16) / 255;
+  const b = parseInt(full.slice(4, 6), 16) / 255;
+  const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+// Pick the higher-contrast foreground (black or white) for a background
+// color, using the WCAG 2.0 contrast-ratio formula. Threshold derived from
+// the contrast ratios against pure black (L = 0) and pure white (L = 1);
+// the crossover sits at L ≈ 0.179, not at the naïve 0.5.
+// Approach: https://github.com/siege-media/contrast-ratio
+function readableForeground(bgHex: string): string {
+  const L = relativeLuminance(bgHex);
+  const contrastOnBlack = (L + 0.05) / 0.05;
+  const contrastOnWhite = 1.05 / (L + 0.05);
+  return contrastOnBlack >= contrastOnWhite ? '#000000' : '#ffffff';
+}
+
+export function Trigger({ color, logo, agentName, popupOpen, error, onToggle }: TriggerProps) {
+  const { isConnected: isAgentConnected } = useAgent();
+  const altText = agentName ? `${agentName} agent` : 'Open assistant';
+
+  const isError = popupOpen && error !== null;
+  const isConnected = popupOpen && error === null && isAgentConnected;
+  const isConnecting = popupOpen && !isError && !isConnected;
+  const isDestructive = isError || isConnected;
+
+  const [logoFailed, setLogoFailed] = useState(false);
+  useEffect(() => {
+    setLogoFailed(false);
+  }, [logo]);
+  const showLogo = Boolean(logo) && !logoFailed;
+
+  return (
+    <Button
+      type="button"
+      size="lg"
+      variant="ghost"
+      onClick={onToggle}
+      aria-label={popupOpen ? 'Close assistant' : altText}
+      aria-expanded={popupOpen}
+      className="fixed right-4 bottom-4 z-50 m-0 block size-12 rounded-full p-0.5 drop-shadow-sm transition-transform duration-200 hover:scale-105 focus-visible:scale-105"
+    >
+      <div
+        className={`absolute inset-0 rounded-full transition-colors ${isConnecting ? 'animate-spin' : ''}`}
+        style={ringStyle(color, isConnecting, isDestructive)}
+      />
+      <div
+        className="absolute inset-0.5 z-10 grid place-items-center rounded-full transition-colors"
+        style={iconBgStyle(color, isConnecting, isDestructive)}
+      >
+        {isConnecting ? null : isError ? (
+          // The spinning ring is the connecting signal; skip a centred glyph
+          // so it reads as a clean spinner rather than a flashing X.
+          <XIcon className="size-5 text-background" aria-hidden="true" />
+        ) : isConnected ? (
+          // Crossed-out phone on the solid destructive disc signals
+          // "click to end the call".
+          <PhoneOffIcon className="size-5 text-background" aria-hidden="true" />
+        ) : showLogo ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={logo}
+            alt={altText}
+            className="size-6 rounded-sm object-contain"
+            referrerPolicy="no-referrer"
+            onError={() => setLogoFailed(true)}
+          />
+        ) : (
+          // Pick black vs white based on the user-set brand color so the
+          // icon stays readable across a bright yellow, deep navy, etc.
+          <BotIcon
+            className="size-6"
+            style={{ color: readableForeground(color) }}
+            aria-hidden="true"
+          />
+        )}
+      </div>
+    </Button>
+  );
+}

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx
@@ -1,32 +1,41 @@
 'use client';
 
-import { cn } from '@/lib/utils';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ComponentProps } from 'react';
 import { BotIcon, PhoneOffIcon, XIcon } from 'lucide-react';
-import { useAgent } from '@livekit/components-react';
-import { Button } from '@/components/ui/button';
-import type { AgentClientError } from './embed-popup-block';
 
-export interface TriggerProps {
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import type { EmbedPopupViewError } from './embed-popup-block';
+
+export interface TriggerProps extends ComponentProps<'button'> {
   /** Brand color used for the idle ring/disc and, via contrast, the fallback icon color. */
   logo?: string;
   color?: string;
   agentName?: string;
-  popupOpen: boolean;
-  error: AgentClientError | null;
+  isPressed?: boolean;
+  isConnected?: boolean;
+  error?: EmbedPopupViewError;
   onToggle: () => void;
 }
 
-export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: TriggerProps) {
-  const { isConnected: isAgentConnected } = useAgent();
+export function Trigger({
+  logo,
+  color,
+  error,
+  agentName,
+  isPressed = false,
+  isConnected = false,
+  onToggle,
+  className,
+  ...props
+}: TriggerProps) {
   const altText = agentName ? `${agentName} agent` : 'Open assistant';
-
-  const isError = popupOpen && error !== null;
-  const isConnected = popupOpen && error === null && isAgentConnected;
-  const isConnecting = popupOpen && !isError && !isConnected;
-  const isDestructive = isError || isConnected;
-
+  const isError = isPressed && error !== undefined;
+  const isActive = isPressed && error === undefined && isConnected;
+  const isConnecting = isPressed && !isError && !isActive;
+  const isDestructive = isError || isActive;
   const [logoFailed, setLogoFailed] = useState(false);
+
   useEffect(() => {
     setLogoFailed(false);
   }, [logo]);
@@ -38,16 +47,20 @@ export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: 
       size="lg"
       variant="ghost"
       onClick={onToggle}
-      aria-label={popupOpen ? 'Close assistant' : altText}
-      aria-expanded={popupOpen}
-      className="fixed right-4 bottom-4 z-50 m-0 block size-12 rounded-full p-0.5 drop-shadow-sm transition-transform duration-200 hover:scale-105 focus-visible:scale-105"
+      aria-label={isPressed ? 'Close assistant' : altText}
+      aria-expanded={isPressed}
+      className={cn(
+        'm-0 block size-12 rounded-full p-0.5 drop-shadow-sm transition-transform duration-200 hover:scale-105 focus-visible:scale-105',
+        className,
+      )}
+      {...props}
     >
       <div
         className={cn(
-          'absolute inset-0 rounded-full transition-colors bg-current',
+          'absolute inset-0 rounded-full bg-current transition-colors',
           isConnecting && 'animate-spin',
           isConnecting &&
-            'bg-current/30 bg-conic from-transparent via-current to-transparent from-30% via-50% to-70%',
+            'bg-current/30 bg-conic from-transparent from-30% via-current via-50% to-transparent to-70%',
           isDestructive && 'bg-transparent',
         )}
         style={{ color }}
@@ -63,7 +76,7 @@ export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: 
           // The spinning ring is the connecting signal; skip a centred glyph
           // so it reads as a clean spinner rather than a flashing X.
           <XIcon className="size-5" aria-hidden="true" />
-        ) : isConnected ? (
+        ) : isActive ? (
           // Crossed-out phone on the solid destructive disc signals
           // "click to end the call".
           <PhoneOffIcon className="size-5" aria-hidden="true" />
@@ -80,7 +93,7 @@ export function Trigger({ logo, agentName, popupOpen, color, error, onToggle }: 
           // Pick black vs white based on the user-set brand color so the
           // icon stays readable across a bright yellow, deep navy, etc.
           <BotIcon
-            className="size-6 text-background"
+            className="text-background size-6"
             aria-hidden="true"
             style={
               color

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/index.ts
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/index.ts
@@ -1,0 +1,1 @@
+export * from './components/embed-popup-block';

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/index.ts
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/index.ts
@@ -1,1 +1,2 @@
 export * from './components/embed-popup-block';
+export * from './components/trigger';

--- a/packages/shadcn/index.ts
+++ b/packages/shadcn/index.ts
@@ -13,3 +13,4 @@ export * from './components/agents-ui/agent-audio-visualizer-wave';
 export * from './components/agents-ui/agent-audio-visualizer-aura';
 export * from './components/agents-ui/react-shader-toy';
 export * from './components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
+export * from './components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block';

--- a/packages/shadcn/registry.json
+++ b/packages/shadcn/registry.json
@@ -329,6 +329,44 @@
       "categories": ["agents", "blocks"]
     },
     {
+      "name": "embed-popup-view-01",
+      "author": "LiveKit (https://livekit.com)",
+      "type": "registry:block",
+      "title": "Embed Popup View",
+      "description": "A floating chat-bubble trigger that expands into a compact agent session popup, suitable for embedding on any page.",
+      "files": [
+        {
+          "path": "components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "components/agents-ui/blocks/embed-popup-view-01/index.ts",
+          "type": "registry:item"
+        }
+      ],
+      "registryDependencies": [
+        "utils",
+        "button",
+        "@agents-ui/agent-session-provider",
+        "@agents-ui/agent-session-view-01"
+      ],
+      "dependencies": [
+        "@livekit/components-react@^2.0.0",
+        "livekit-client@^2.0.0",
+        "motion",
+        "lucide-react"
+      ],
+      "categories": ["agents", "blocks"]
+    },
+    {
       "name": "all",
       "type": "registry:item",
       "title": "All",
@@ -349,7 +387,8 @@
         "@agents-ui/agent-chat-indicator",
         "@agents-ui/agent-chat-transcript",
         "@agents-ui/react-shader-toy",
-        "@agents-ui/agent-session-view-01"
+        "@agents-ui/agent-session-view-01",
+        "@agents-ui/embed-popup-view-01"
       ]
     }
   ]

--- a/packages/shadcn/registry.json
+++ b/packages/shadcn/registry.json
@@ -356,6 +356,7 @@
         "utils",
         "button",
         "@agents-ui/agent-session-provider",
+        "@agents-ui/start-audio-button",
         "@agents-ui/agent-session-view-01"
       ],
       "dependencies": [

--- a/packages/shadcn/tests/agent-session-block.test.tsx
+++ b/packages/shadcn/tests/agent-session-block.test.tsx
@@ -165,78 +165,83 @@ describe('AgentSessionView_01', () => {
     });
   });
 
-  describe('audioVisualizer props passed to TileLayout', () => {
-    it('passes audioVisualizerType to TileLayout', () => {
-      render(<AgentSessionView_01 data-testid="session-view" audioVisualizerType="aura" />);
+  describe('audioVisualizer prop passed to TileLayout', () => {
+    it('passes audioVisualizer.type to TileLayout', () => {
+      render(<AgentSessionView_01 data-testid="session-view" audioVisualizer={{ type: 'aura' }} />);
       const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerType).toBe('aura');
+      expect(props.audioVisualizer.type).toBe('aura');
     });
 
-    it('passes audioVisualizerColor to TileLayout', () => {
-      render(<AgentSessionView_01 data-testid="session-view" audioVisualizerColor="#ff00ff" />);
+    it('passes audioVisualizer.color to TileLayout', () => {
+      render(
+        <AgentSessionView_01 data-testid="session-view" audioVisualizer={{ color: '#ff00ff' }} />,
+      );
       const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerColor).toBe('#ff00ff');
+      expect(props.audioVisualizer.color).toBe('#ff00ff');
     });
 
-    it('passes audioVisualizerColorShift to TileLayout', () => {
-      render(<AgentSessionView_01 data-testid="session-view" audioVisualizerColorShift={0.5} />);
-      const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerColorShift).toBe(0.5);
-    });
-
-    it('passes audioVisualizerBarCount to TileLayout', () => {
-      render(<AgentSessionView_01 data-testid="session-view" audioVisualizerBarCount={11} />);
-      const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerBarCount).toBe(11);
-    });
-
-    it('passes audioVisualizerGridRowCount and audioVisualizerGridColumnCount to TileLayout', () => {
+    it('passes audioVisualizer.colorShift to TileLayout for the wave type', () => {
       render(
         <AgentSessionView_01
           data-testid="session-view"
-          audioVisualizerGridRowCount={8}
-          audioVisualizerGridColumnCount={12}
+          audioVisualizer={{ type: 'wave', colorShift: 0.5 }}
         />,
       );
       const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerGridRowCount).toBe(8);
-      expect(props.audioVisualizerGridColumnCount).toBe(12);
+      expect(props.audioVisualizer.colorShift).toBe(0.5);
     });
 
-    it('passes audioVisualizerRadialBarCount and audioVisualizerRadialRadius to TileLayout', () => {
+    it('passes audioVisualizer.barCount to TileLayout', () => {
+      render(<AgentSessionView_01 data-testid="session-view" audioVisualizer={{ barCount: 11 }} />);
+      const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
+      expect(props.audioVisualizer.barCount).toBe(11);
+    });
+
+    it('passes audioVisualizer.rowCount and audioVisualizer.columnCount to TileLayout', () => {
       render(
         <AgentSessionView_01
           data-testid="session-view"
-          audioVisualizerRadialBarCount={32}
-          audioVisualizerRadialRadius={60}
+          audioVisualizer={{ type: 'grid', rowCount: 8, columnCount: 12 }}
         />,
       );
       const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerRadialBarCount).toBe(32);
-      expect(props.audioVisualizerRadialRadius).toBe(60);
+      expect(props.audioVisualizer.rowCount).toBe(8);
+      expect(props.audioVisualizer.columnCount).toBe(12);
     });
 
-    it('passes audioVisualizerWaveLineWidth to TileLayout', () => {
-      render(<AgentSessionView_01 data-testid="session-view" audioVisualizerWaveLineWidth={3} />);
+    it('passes audioVisualizer.barCount and audioVisualizer.radius to TileLayout for the radial type', () => {
+      render(
+        <AgentSessionView_01
+          data-testid="session-view"
+          audioVisualizer={{ type: 'radial', barCount: 32, radius: 60 }}
+        />,
+      );
       const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props.audioVisualizerWaveLineWidth).toBe(3);
+      expect(props.audioVisualizer.barCount).toBe(32);
+      expect(props.audioVisualizer.radius).toBe(60);
     });
 
-    it('passes all audio visualizer props to TileLayout when set', () => {
-      const visualizerProps = {
-        audioVisualizerType: 'grid' as const,
-        audioVisualizerColor: '#00ff00' as const,
-        audioVisualizerColorShift: 1,
-        audioVisualizerBarCount: 7,
-        audioVisualizerGridRowCount: 6,
-        audioVisualizerGridColumnCount: 8,
-        audioVisualizerRadialBarCount: 16,
-        audioVisualizerRadialRadius: 90,
-        audioVisualizerWaveLineWidth: 2,
+    it('passes audioVisualizer.lineWidth to TileLayout for the wave type', () => {
+      render(
+        <AgentSessionView_01
+          data-testid="session-view"
+          audioVisualizer={{ type: 'wave', lineWidth: 3 }}
+        />,
+      );
+      const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
+      expect(props.audioVisualizer.lineWidth).toBe(3);
+    });
+
+    it('passes the full audioVisualizer config to TileLayout when set', () => {
+      const audioVisualizer = {
+        type: 'grid' as const,
+        color: '#00ff00' as const,
+        rowCount: 6,
+        columnCount: 8,
       };
-      render(<AgentSessionView_01 data-testid="session-view" {...visualizerProps} />);
+      render(<AgentSessionView_01 data-testid="session-view" audioVisualizer={audioVisualizer} />);
       const props = JSON.parse(screen.getByTestId('tile-layout').getAttribute('data-props')!);
-      expect(props).toMatchObject(visualizerProps);
+      expect(props.audioVisualizer).toMatchObject(audioVisualizer);
     });
   });
 

--- a/packages/shadcn/tests/agent-session-block.test.tsx
+++ b/packages/shadcn/tests/agent-session-block.test.tsx
@@ -109,45 +109,33 @@ describe('AgentSessionView_01', () => {
     });
   });
 
-  describe('supportsChatInput', () => {
-    it('passes chat: true to AgentControlBar by default', () => {
+  describe('controls', () => {
+    it('passes the default controls to AgentControlBar when unset', () => {
       render(<AgentSessionView_01 data-testid="session-view" />);
       const call = agentControlBarMock.mock.calls[0][0];
-      expect(call.controls).toEqual(
-        expect.objectContaining({ chat: true, leave: true, microphone: true }),
-      );
+      expect(call.controls).toEqual({
+        leave: true,
+        microphone: true,
+        chat: true,
+        camera: true,
+        screenShare: true,
+      });
     });
 
-    it('passes chat: false when supportsChatInput is false', () => {
-      render(<AgentSessionView_01 data-testid="session-view" supportsChatInput={false} />);
+    it('passes chat: false when controls.chat is false', () => {
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ chat: false }} />);
       const call = agentControlBarMock.mock.calls[0][0];
       expect(call.controls.chat).toBe(false);
     });
-  });
 
-  describe('supportsVideoInput', () => {
-    it('passes camera: true to AgentControlBar by default', () => {
-      render(<AgentSessionView_01 data-testid="session-view" />);
-      const call = agentControlBarMock.mock.calls[0][0];
-      expect(call.controls.camera).toBe(true);
-    });
-
-    it('passes camera: false when supportsVideoInput is false', () => {
-      render(<AgentSessionView_01 data-testid="session-view" supportsVideoInput={false} />);
+    it('passes camera: false when controls.camera is false', () => {
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ camera: false }} />);
       const call = agentControlBarMock.mock.calls[0][0];
       expect(call.controls.camera).toBe(false);
     });
-  });
 
-  describe('supportsScreenShare', () => {
-    it('passes screenShare: true to AgentControlBar by default', () => {
-      render(<AgentSessionView_01 data-testid="session-view" />);
-      const call = agentControlBarMock.mock.calls[0][0];
-      expect(call.controls.screenShare).toBe(true);
-    });
-
-    it('passes screenShare: false when supportsScreenShare is false', () => {
-      render(<AgentSessionView_01 data-testid="session-view" supportsScreenShare={false} />);
+    it('passes screenShare: false when controls.screenShare is false', () => {
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ screenShare: false }} />);
       const call = agentControlBarMock.mock.calls[0][0];
       expect(call.controls.screenShare).toBe(false);
     });
@@ -253,13 +241,11 @@ describe('AgentSessionView_01', () => {
   });
 
   describe('control bar controls together', () => {
-    it('passes all controls false when all support props are false', () => {
+    it('merges partial controls overrides with the defaults', () => {
       render(
         <AgentSessionView_01
           data-testid="session-view"
-          supportsChatInput={false}
-          supportsVideoInput={false}
-          supportsScreenShare={false}
+          controls={{ chat: false, camera: false, screenShare: false }}
         />,
       );
       const call = agentControlBarMock.mock.calls[0][0];

--- a/packages/shadcn/tests/agent-session-block.test.tsx
+++ b/packages/shadcn/tests/agent-session-block.test.tsx
@@ -116,28 +116,28 @@ describe('AgentSessionView_01', () => {
       expect(call.controls).toEqual({
         leave: true,
         microphone: true,
-        chat: true,
-        camera: true,
-        screenShare: true,
+        chat: false,
+        camera: false,
+        screenShare: false,
       });
     });
 
-    it('passes chat: false when controls.chat is false', () => {
-      render(<AgentSessionView_01 data-testid="session-view" controls={{ chat: false }} />);
+    it('passes chat: true when controls.chat is true', () => {
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ chat: true }} />);
       const call = agentControlBarMock.mock.calls[0][0];
-      expect(call.controls.chat).toBe(false);
+      expect(call.controls.chat).toBe(true);
     });
 
-    it('passes camera: false when controls.camera is false', () => {
-      render(<AgentSessionView_01 data-testid="session-view" controls={{ camera: false }} />);
+    it('passes camera: true when controls.camera is true', () => {
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ camera: true }} />);
       const call = agentControlBarMock.mock.calls[0][0];
-      expect(call.controls.camera).toBe(false);
+      expect(call.controls.camera).toBe(true);
     });
 
-    it('passes screenShare: false when controls.screenShare is false', () => {
-      render(<AgentSessionView_01 data-testid="session-view" controls={{ screenShare: false }} />);
+    it('passes screenShare: true when controls.screenShare is true', () => {
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ screenShare: true }} />);
       const call = agentControlBarMock.mock.calls[0][0];
-      expect(call.controls.screenShare).toBe(false);
+      expect(call.controls.screenShare).toBe(true);
     });
   });
 
@@ -247,17 +247,12 @@ describe('AgentSessionView_01', () => {
 
   describe('control bar controls together', () => {
     it('merges partial controls overrides with the defaults', () => {
-      render(
-        <AgentSessionView_01
-          data-testid="session-view"
-          controls={{ chat: false, camera: false, screenShare: false }}
-        />,
-      );
+      render(<AgentSessionView_01 data-testid="session-view" controls={{ chat: true }} />);
       const call = agentControlBarMock.mock.calls[0][0];
       expect(call.controls).toEqual({
         leave: true,
         microphone: true,
-        chat: false,
+        chat: true,
         camera: false,
         screenShare: false,
       });

--- a/packages/shadcn/tests/embed-popup-block.test.tsx
+++ b/packages/shadcn/tests/embed-popup-block.test.tsx
@@ -98,13 +98,8 @@ describe('EmbedPopupView_01', () => {
     expect(call.color).toBeUndefined();
   });
 
-  it('forwards merged controls to PopupView when open', async () => {
-    render(
-      <EmbedPopupView_01
-        tokenSource={tokenSource}
-        controls={{ chat: false, camera: false, screenShare: false }}
-      />,
-    );
+  it('forwards the default controls to PopupView when unset', async () => {
+    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
@@ -113,6 +108,21 @@ describe('EmbedPopupView_01', () => {
       leave: false,
       microphone: true,
       chat: false,
+      camera: false,
+      screenShare: false,
+    });
+  });
+
+  it('forwards merged controls to PopupView when open', async () => {
+    render(<EmbedPopupView_01 tokenSource={tokenSource} controls={{ chat: true }} />);
+    await act(async () => {
+      screen.getByTestId('trigger').click();
+    });
+    const props = JSON.parse(screen.getByTestId('popup-view').getAttribute('data-props')!);
+    expect(props.controls).toEqual({
+      leave: false,
+      microphone: true,
+      chat: true,
       camera: false,
       screenShare: false,
     });

--- a/packages/shadcn/tests/embed-popup-block.test.tsx
+++ b/packages/shadcn/tests/embed-popup-block.test.tsx
@@ -7,6 +7,8 @@ const startMock = vi.fn().mockResolvedValue(undefined);
 const endMock = vi.fn().mockResolvedValue(undefined);
 const mockSession = { isConnected: false, start: startMock, end: endMock } as any;
 
+const useAgentMock = vi.fn(() => ({ isConnected: false }));
+
 const triggerMock = vi.fn((props: any) => (
   <button data-testid="trigger" onClick={props.onToggle}>
     trigger
@@ -19,6 +21,7 @@ const popupViewMock = vi.fn((props: any) => (
 
 vi.mock('@livekit/components-react', () => ({
   useSession: () => mockSession,
+  useAgent: () => useAgentMock(),
 }));
 
 vi.mock('@/components/agents-ui/agent-session-provider', () => ({
@@ -39,6 +42,7 @@ describe('EmbedPopupView_01', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSession.isConnected = false;
+    useAgentMock.mockReturnValue({ isConnected: false });
   });
 
   it('renders the trigger but not the popup view when closed', () => {
@@ -68,11 +72,11 @@ describe('EmbedPopupView_01', () => {
     expect(screen.queryByTestId('popup-view')).not.toBeInTheDocument();
   });
 
-  it('forwards color, logo, and agentName to Trigger', () => {
+  it('forwards triggerColor as color, logo, and agentName to Trigger', () => {
     render(
       <EmbedPopupView_01
         tokenSource={tokenSource}
-        color="#ff00ff"
+        triggerColor="#ff00ff"
         logo="https://example.com/logo.png"
         agentName="Assistant"
       />,
@@ -87,29 +91,30 @@ describe('EmbedPopupView_01', () => {
     );
   });
 
-  it('applies default color and agentName when not provided', () => {
+  it('applies the default agentName when not provided', () => {
     render(<EmbedPopupView_01 tokenSource={tokenSource} />);
     const call = triggerMock.mock.calls[0][0];
-    expect(call).toEqual(expect.objectContaining({ color: '#3b82f6', agentName: 'Agent' }));
+    expect(call).toEqual(expect.objectContaining({ agentName: 'Agent' }));
+    expect(call.color).toBeUndefined();
   });
 
-  it('forwards supports* props to PopupView when open', async () => {
+  it('forwards merged controls to PopupView when open', async () => {
     render(
       <EmbedPopupView_01
         tokenSource={tokenSource}
-        supportsChatInput={false}
-        supportsVideoInput={false}
-        supportsScreenShare={false}
+        controls={{ chat: false, camera: false, screenShare: false }}
       />,
     );
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
     const props = JSON.parse(screen.getByTestId('popup-view').getAttribute('data-props')!);
-    expect(props).toMatchObject({
-      supportsChatInput: false,
-      supportsVideoInput: false,
-      supportsScreenShare: false,
+    expect(props.controls).toEqual({
+      leave: false,
+      microphone: true,
+      chat: false,
+      camera: false,
+      screenShare: false,
     });
   });
 });

--- a/packages/shadcn/tests/embed-popup-block.test.tsx
+++ b/packages/shadcn/tests/embed-popup-block.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import { AgentClient } from '@/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block';
+
+const startMock = vi.fn().mockResolvedValue(undefined);
+const endMock = vi.fn().mockResolvedValue(undefined);
+const mockSession = { isConnected: false, start: startMock, end: endMock } as any;
+
+const triggerMock = vi.fn((props: any) => (
+  <button data-testid="trigger" onClick={props.onToggle}>
+    trigger
+  </button>
+));
+
+const popupViewMock = vi.fn((props: any) => (
+  <div data-testid="popup-view" data-props={JSON.stringify(props)} />
+));
+
+vi.mock('@livekit/components-react', () => ({
+  useSession: () => mockSession,
+}));
+
+vi.mock('@/components/agents-ui/agent-session-provider', () => ({
+  AgentSessionProvider: ({ children }: any) => <div data-testid="session-provider">{children}</div>,
+}));
+
+vi.mock('@/components/agents-ui/blocks/embed-popup-view-01/components/trigger', () => ({
+  Trigger: (props: any) => triggerMock(props),
+}));
+
+vi.mock('@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view', () => ({
+  PopupView: (props: any) => popupViewMock(props),
+}));
+
+const tokenSource = {} as any;
+
+describe('AgentClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.isConnected = false;
+  });
+
+  it('renders the trigger but not the popup view when closed', () => {
+    render(<AgentClient tokenSource={tokenSource} />);
+    expect(screen.getByTestId('trigger')).toBeInTheDocument();
+    expect(screen.queryByTestId('popup-view')).not.toBeInTheDocument();
+  });
+
+  it('starts the session and renders PopupView when the trigger is toggled open', async () => {
+    render(<AgentClient tokenSource={tokenSource} />);
+    await act(async () => {
+      screen.getByTestId('trigger').click();
+    });
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('popup-view')).toBeInTheDocument();
+  });
+
+  it('ends the session when toggled closed again', async () => {
+    render(<AgentClient tokenSource={tokenSource} />);
+    await act(async () => {
+      screen.getByTestId('trigger').click();
+    });
+    await act(async () => {
+      screen.getByTestId('trigger').click();
+    });
+    expect(endMock).toHaveBeenCalled();
+    expect(screen.queryByTestId('popup-view')).not.toBeInTheDocument();
+  });
+
+  it('forwards color, logo, and agentName to Trigger', () => {
+    render(
+      <AgentClient
+        tokenSource={tokenSource}
+        color="#ff00ff"
+        logo="https://example.com/logo.png"
+        agentName="Assistant"
+      />,
+    );
+    const call = triggerMock.mock.calls[0][0];
+    expect(call).toEqual(
+      expect.objectContaining({
+        color: '#ff00ff',
+        logo: 'https://example.com/logo.png',
+        agentName: 'Assistant',
+      }),
+    );
+  });
+
+  it('applies default color and agentName when not provided', () => {
+    render(<AgentClient tokenSource={tokenSource} />);
+    const call = triggerMock.mock.calls[0][0];
+    expect(call).toEqual(expect.objectContaining({ color: '#3b82f6', agentName: 'Agent' }));
+  });
+
+  it('forwards supports* props to PopupView when open', async () => {
+    render(
+      <AgentClient
+        tokenSource={tokenSource}
+        supportsChatInput={false}
+        supportsVideoInput={false}
+        supportsScreenShare={false}
+      />,
+    );
+    await act(async () => {
+      screen.getByTestId('trigger').click();
+    });
+    const props = JSON.parse(screen.getByTestId('popup-view').getAttribute('data-props')!);
+    expect(props).toMatchObject({
+      supportsChatInput: false,
+      supportsVideoInput: false,
+      supportsScreenShare: false,
+    });
+  });
+});

--- a/packages/shadcn/tests/embed-popup-block.test.tsx
+++ b/packages/shadcn/tests/embed-popup-block.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import React from 'react';
-import { AgentClient } from '@/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block';
+import { EmbedPopupView_01 } from '@/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block';
 
 const startMock = vi.fn().mockResolvedValue(undefined);
 const endMock = vi.fn().mockResolvedValue(undefined);
@@ -35,20 +35,20 @@ vi.mock('@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view
 
 const tokenSource = {} as any;
 
-describe('AgentClient', () => {
+describe('EmbedPopupView_01', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSession.isConnected = false;
   });
 
   it('renders the trigger but not the popup view when closed', () => {
-    render(<AgentClient tokenSource={tokenSource} />);
+    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
     expect(screen.getByTestId('trigger')).toBeInTheDocument();
     expect(screen.queryByTestId('popup-view')).not.toBeInTheDocument();
   });
 
   it('starts the session and renders PopupView when the trigger is toggled open', async () => {
-    render(<AgentClient tokenSource={tokenSource} />);
+    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
@@ -57,7 +57,7 @@ describe('AgentClient', () => {
   });
 
   it('ends the session when toggled closed again', async () => {
-    render(<AgentClient tokenSource={tokenSource} />);
+    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
@@ -70,7 +70,7 @@ describe('AgentClient', () => {
 
   it('forwards color, logo, and agentName to Trigger', () => {
     render(
-      <AgentClient
+      <EmbedPopupView_01
         tokenSource={tokenSource}
         color="#ff00ff"
         logo="https://example.com/logo.png"
@@ -88,14 +88,14 @@ describe('AgentClient', () => {
   });
 
   it('applies default color and agentName when not provided', () => {
-    render(<AgentClient tokenSource={tokenSource} />);
+    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
     const call = triggerMock.mock.calls[0][0];
     expect(call).toEqual(expect.objectContaining({ color: '#3b82f6', agentName: 'Agent' }));
   });
 
   it('forwards supports* props to PopupView when open', async () => {
     render(
-      <AgentClient
+      <EmbedPopupView_01
         tokenSource={tokenSource}
         supportsChatInput={false}
         supportsVideoInput={false}

--- a/packages/shadcn/tests/popup-view.test.tsx
+++ b/packages/shadcn/tests/popup-view.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PopupView } from '@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view';
+
+const startAudioMock = vi.fn((props: any) => <div data-testid="start-audio" data-props={JSON.stringify(props)} />);
+
+const agentSessionViewMock = vi.fn((props: any) => (
+  <div data-testid="agent-session-view" data-props={JSON.stringify(props)} />
+));
+
+vi.mock('@livekit/components-react', () => ({
+  StartAudio: (props: any) => startAudioMock(props),
+}));
+
+vi.mock('@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block', () => ({
+  AgentSessionView_01: (props: any) => agentSessionViewMock(props),
+}));
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}));
+
+describe('PopupView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders StartAudio', () => {
+    render(<PopupView error={null} />);
+    expect(screen.getByTestId('start-audio')).toBeInTheDocument();
+  });
+
+  it('forwards supports* props and color to AgentSessionView_01', () => {
+    render(
+      <PopupView
+        error={null}
+        color="#ff00ff"
+        supportsChatInput={false}
+        supportsVideoInput={true}
+        supportsScreenShare={false}
+      />,
+    );
+    const props = JSON.parse(screen.getByTestId('agent-session-view').getAttribute('data-props')!);
+    expect(props).toMatchObject({
+      audioVisualizerColor: '#ff00ff',
+      supportsChatInput: false,
+      supportsVideoInput: true,
+      supportsScreenShare: false,
+    });
+  });
+
+  it('hides the error overlay when error is null', () => {
+    render(<PopupView error={null} />);
+    const overlay = screen.getByTestId('error-overlay');
+    expect(overlay).toHaveClass('opacity-0', 'pointer-events-none');
+  });
+
+  it('shows the error title and description when an error is provided', () => {
+    render(<PopupView error={{ title: 'Could not connect', description: 'Network error' }} />);
+    const overlay = screen.getByTestId('error-overlay');
+    expect(overlay).toHaveClass('opacity-100');
+    expect(screen.getByText('Could not connect')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+
+  it('renders the logo in the error overlay and falls back on load failure', () => {
+    render(
+      <PopupView
+        error={{ title: 'Could not connect', description: 'Network error' }}
+        logo="https://example.com/logo.png"
+        agentName="Rex"
+      />,
+    );
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'Rex logo');
+    fireEvent.error(img);
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/packages/shadcn/tests/popup-view.test.tsx
+++ b/packages/shadcn/tests/popup-view.test.tsx
@@ -3,7 +3,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { PopupView } from '@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view';
 
-const startAudioMock = vi.fn((props: any) => <div data-testid="start-audio" data-props={JSON.stringify(props)} />);
+const startAudioMock = vi.fn((props: any) => (
+  <div data-testid="start-audio" data-props={JSON.stringify(props)} />
+));
 
 const agentSessionViewMock = vi.fn((props: any) => (
   <div data-testid="agent-session-view" data-props={JSON.stringify(props)} />
@@ -13,9 +15,12 @@ vi.mock('@livekit/components-react', () => ({
   StartAudio: (props: any) => startAudioMock(props),
 }));
 
-vi.mock('@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block', () => ({
-  AgentSessionView_01: (props: any) => agentSessionViewMock(props),
-}));
+vi.mock(
+  '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block',
+  () => ({
+    AgentSessionView_01: (props: any) => agentSessionViewMock(props),
+  }),
+);
 
 vi.mock('motion/react', () => ({
   motion: {

--- a/packages/shadcn/tests/popup-view.test.tsx
+++ b/packages/shadcn/tests/popup-view.test.tsx
@@ -48,9 +48,7 @@ describe('PopupView', () => {
   });
 
   it('forwards the audioVisualizer config and controls to AgentSessionView_01', () => {
-    render(
-      <PopupView controls={CONTROLS} audioVisualizer={{ color: '#ff00ff', type: 'wave' }} />,
-    );
+    render(<PopupView controls={CONTROLS} audioVisualizer={{ color: '#ff00ff', type: 'wave' }} />);
     const props = JSON.parse(screen.getByTestId('agent-session-view').getAttribute('data-props')!);
     expect(props).toMatchObject({
       audioVisualizer: { color: '#ff00ff', type: 'wave' },

--- a/packages/shadcn/tests/popup-view.test.tsx
+++ b/packages/shadcn/tests/popup-view.test.tsx
@@ -3,16 +3,16 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { PopupView } from '@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view';
 
-const startAudioMock = vi.fn((props: any) => (
-  <div data-testid="start-audio" data-props={JSON.stringify(props)} />
+const startAudioButtonMock = vi.fn((props: any) => (
+  <div data-testid="start-audio-button" data-props={JSON.stringify(props)} />
 ));
 
 const agentSessionViewMock = vi.fn((props: any) => (
   <div data-testid="agent-session-view" data-props={JSON.stringify(props)} />
 ));
 
-vi.mock('@livekit/components-react', () => ({
-  StartAudio: (props: any) => startAudioMock(props),
+vi.mock('@/components/agents-ui/start-audio-button', () => ({
+  StartAudioButton: (props: any) => startAudioButtonMock(props),
 }));
 
 vi.mock(
@@ -26,47 +26,52 @@ vi.mock('motion/react', () => ({
   motion: {
     div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   },
+  AnimatePresence: ({ children }: any) => <>{children}</>,
 }));
+
+const CONTROLS = {
+  leave: true,
+  microphone: true,
+  chat: true,
+  camera: true,
+  screenShare: true,
+};
 
 describe('PopupView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders StartAudio', () => {
-    render(<PopupView error={null} />);
-    expect(screen.getByTestId('start-audio')).toBeInTheDocument();
+  it('renders the StartAudioButton', () => {
+    render(<PopupView controls={CONTROLS} />);
+    expect(screen.getByTestId('start-audio-button')).toBeInTheDocument();
   });
 
-  it('forwards supports* props and color to AgentSessionView_01', () => {
+  it('forwards audio visualizer props and controls to AgentSessionView_01', () => {
     render(
-      <PopupView
-        error={null}
-        color="#ff00ff"
-        supportsChatInput={false}
-        supportsVideoInput={true}
-        supportsScreenShare={false}
-      />,
+      <PopupView controls={CONTROLS} audioVisualizerColor="#ff00ff" audioVisualizerType="wave" />,
     );
     const props = JSON.parse(screen.getByTestId('agent-session-view').getAttribute('data-props')!);
     expect(props).toMatchObject({
       audioVisualizerColor: '#ff00ff',
-      supportsChatInput: false,
-      supportsVideoInput: true,
-      supportsScreenShare: false,
+      audioVisualizerType: 'wave',
+      controls: CONTROLS,
     });
   });
 
-  it('hides the error overlay when error is null', () => {
-    render(<PopupView error={null} />);
-    const overlay = screen.getByTestId('error-overlay');
-    expect(overlay).toHaveClass('opacity-0', 'pointer-events-none');
+  it('does not render the error overlay when there is no error', () => {
+    render(<PopupView controls={CONTROLS} />);
+    expect(screen.queryByTestId('error-overlay')).not.toBeInTheDocument();
   });
 
   it('shows the error title and description when an error is provided', () => {
-    render(<PopupView error={{ title: 'Could not connect', description: 'Network error' }} />);
-    const overlay = screen.getByTestId('error-overlay');
-    expect(overlay).toHaveClass('opacity-100');
+    render(
+      <PopupView
+        controls={CONTROLS}
+        error={{ title: 'Could not connect', description: 'Network error' }}
+      />,
+    );
+    expect(screen.getByTestId('error-overlay')).toBeInTheDocument();
     expect(screen.getByText('Could not connect')).toBeInTheDocument();
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
@@ -74,6 +79,7 @@ describe('PopupView', () => {
   it('renders the logo in the error overlay and falls back on load failure', () => {
     render(
       <PopupView
+        controls={CONTROLS}
         error={{ title: 'Could not connect', description: 'Network error' }}
         logo="https://example.com/logo.png"
         agentName="Rex"

--- a/packages/shadcn/tests/popup-view.test.tsx
+++ b/packages/shadcn/tests/popup-view.test.tsx
@@ -47,14 +47,13 @@ describe('PopupView', () => {
     expect(screen.getByTestId('start-audio-button')).toBeInTheDocument();
   });
 
-  it('forwards audio visualizer props and controls to AgentSessionView_01', () => {
+  it('forwards the audioVisualizer config and controls to AgentSessionView_01', () => {
     render(
-      <PopupView controls={CONTROLS} audioVisualizerColor="#ff00ff" audioVisualizerType="wave" />,
+      <PopupView controls={CONTROLS} audioVisualizer={{ color: '#ff00ff', type: 'wave' }} />,
     );
     const props = JSON.parse(screen.getByTestId('agent-session-view').getAttribute('data-props')!);
     expect(props).toMatchObject({
-      audioVisualizerColor: '#ff00ff',
-      audioVisualizerType: 'wave',
+      audioVisualizer: { color: '#ff00ff', type: 'wave' },
       controls: CONTROLS,
     });
   });

--- a/packages/shadcn/tests/trigger.test.tsx
+++ b/packages/shadcn/tests/trigger.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Trigger } from '@/components/agents-ui/blocks/embed-popup-view-01/components/trigger';
+
+const useAgentMock = vi.fn();
+
+vi.mock('@livekit/components-react', () => ({
+  useAgent: () => useAgentMock(),
+}));
+
+describe('Trigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAgentMock.mockReturnValue({ isConnected: false });
+  });
+
+  it('calls onToggle when clicked', () => {
+    const onToggle = vi.fn();
+    render(<Trigger color="#3b82f6" popupOpen={false} error={null} onToggle={onToggle} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects popupOpen via aria-expanded and aria-label', () => {
+    const { rerender } = render(
+      <Trigger color="#3b82f6" popupOpen={false} error={null} onToggle={vi.fn()} agentName="Rex" />,
+    );
+    let button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-label', 'Rex agent');
+
+    rerender(
+      <Trigger color="#3b82f6" popupOpen={true} error={null} onToggle={vi.fn()} agentName="Rex" />,
+    );
+    button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveAttribute('aria-label', 'Close assistant');
+  });
+
+  it('falls back to a generic aria-label when agentName is not provided', () => {
+    render(<Trigger color="#3b82f6" popupOpen={false} error={null} onToggle={vi.fn()} />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Open assistant');
+  });
+
+  it('renders the provided logo image', () => {
+    render(
+      <Trigger
+        color="#3b82f6"
+        logo="https://example.com/logo.png"
+        popupOpen={false}
+        error={null}
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/logo.png');
+  });
+
+  it('falls back to the default icon when the logo image fails to load', () => {
+    render(
+      <Trigger
+        color="#3b82f6"
+        logo="https://example.com/broken.png"
+        popupOpen={false}
+        error={null}
+        onToggle={vi.fn()}
+      />,
+    );
+    fireEvent.error(screen.getByRole('img'));
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('shows the connecting spinner when popup is open, agent is not connected, and there is no error', () => {
+    useAgentMock.mockReturnValue({ isConnected: false });
+    render(<Trigger color="#3b82f6" popupOpen={true} error={null} onToggle={vi.fn()} />);
+    const ring = screen.getByRole('button').querySelector('.animate-spin');
+    expect(ring).not.toBeNull();
+  });
+
+  it('does not show the connecting spinner when the agent is connected', () => {
+    useAgentMock.mockReturnValue({ isConnected: true });
+    render(<Trigger color="#3b82f6" popupOpen={true} error={null} onToggle={vi.fn()} />);
+    const ring = screen.getByRole('button').querySelector('.animate-spin');
+    expect(ring).toBeNull();
+  });
+
+  it('does not show the connecting spinner when there is an error', () => {
+    useAgentMock.mockReturnValue({ isConnected: false });
+    render(
+      <Trigger
+        color="#3b82f6"
+        popupOpen={true}
+        error={{ title: 'Oops', description: 'Failed' }}
+        onToggle={vi.fn()}
+      />,
+    );
+    const ring = screen.getByRole('button').querySelector('.animate-spin');
+    expect(ring).toBeNull();
+  });
+});

--- a/packages/shadcn/tests/trigger.test.tsx
+++ b/packages/shadcn/tests/trigger.test.tsx
@@ -1,45 +1,32 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { Trigger } from '@/components/agents-ui/blocks/embed-popup-view-01/components/trigger';
 
-const useAgentMock = vi.fn();
-
-vi.mock('@livekit/components-react', () => ({
-  useAgent: () => useAgentMock(),
-}));
-
 describe('Trigger', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    useAgentMock.mockReturnValue({ isConnected: false });
-  });
-
   it('calls onToggle when clicked', () => {
     const onToggle = vi.fn();
-    render(<Trigger color="#3b82f6" popupOpen={false} error={null} onToggle={onToggle} />);
+    render(<Trigger color="#3b82f6" isPressed={false} onToggle={onToggle} />);
     fireEvent.click(screen.getByRole('button'));
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('reflects popupOpen via aria-expanded and aria-label', () => {
+  it('reflects isPressed via aria-expanded and aria-label', () => {
     const { rerender } = render(
-      <Trigger color="#3b82f6" popupOpen={false} error={null} onToggle={vi.fn()} agentName="Rex" />,
+      <Trigger color="#3b82f6" isPressed={false} onToggle={vi.fn()} agentName="Rex" />,
     );
     let button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-expanded', 'false');
     expect(button).toHaveAttribute('aria-label', 'Rex agent');
 
-    rerender(
-      <Trigger color="#3b82f6" popupOpen={true} error={null} onToggle={vi.fn()} agentName="Rex" />,
-    );
+    rerender(<Trigger color="#3b82f6" isPressed={true} onToggle={vi.fn()} agentName="Rex" />);
     button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-expanded', 'true');
     expect(button).toHaveAttribute('aria-label', 'Close assistant');
   });
 
   it('falls back to a generic aria-label when agentName is not provided', () => {
-    render(<Trigger color="#3b82f6" popupOpen={false} error={null} onToggle={vi.fn()} />);
+    render(<Trigger color="#3b82f6" isPressed={false} onToggle={vi.fn()} />);
     expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Open assistant');
   });
 
@@ -48,8 +35,7 @@ describe('Trigger', () => {
       <Trigger
         color="#3b82f6"
         logo="https://example.com/logo.png"
-        popupOpen={false}
-        error={null}
+        isPressed={false}
         onToggle={vi.fn()}
       />,
     );
@@ -61,8 +47,7 @@ describe('Trigger', () => {
       <Trigger
         color="#3b82f6"
         logo="https://example.com/broken.png"
-        popupOpen={false}
-        error={null}
+        isPressed={false}
         onToggle={vi.fn()}
       />,
     );
@@ -70,26 +55,24 @@ describe('Trigger', () => {
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 
-  it('shows the connecting spinner when popup is open, agent is not connected, and there is no error', () => {
-    useAgentMock.mockReturnValue({ isConnected: false });
-    render(<Trigger color="#3b82f6" popupOpen={true} error={null} onToggle={vi.fn()} />);
+  it('shows the connecting spinner when pressed, not connected, and there is no error', () => {
+    render(<Trigger color="#3b82f6" isPressed={true} isConnected={false} onToggle={vi.fn()} />);
     const ring = screen.getByRole('button').querySelector('.animate-spin');
     expect(ring).not.toBeNull();
   });
 
-  it('does not show the connecting spinner when the agent is connected', () => {
-    useAgentMock.mockReturnValue({ isConnected: true });
-    render(<Trigger color="#3b82f6" popupOpen={true} error={null} onToggle={vi.fn()} />);
+  it('does not show the connecting spinner when connected', () => {
+    render(<Trigger color="#3b82f6" isPressed={true} isConnected={true} onToggle={vi.fn()} />);
     const ring = screen.getByRole('button').querySelector('.animate-spin');
     expect(ring).toBeNull();
   });
 
   it('does not show the connecting spinner when there is an error', () => {
-    useAgentMock.mockReturnValue({ isConnected: false });
     render(
       <Trigger
         color="#3b82f6"
-        popupOpen={true}
+        isPressed={true}
+        isConnected={false}
         error={{ title: 'Oops', description: 'Failed' }}
         onToggle={vi.fn()}
       />,

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "ui": "tui",
+  "ui": "stream",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Adds `embed-popup-view-01`, a compact floating popup block for agents-ui.
- Refactors `agent-session-view-01` visualizer and control configuration for reuse by the popup block.
- Updates Storybook, registry metadata, and tests for the new block and API shape.

## Session View Block

- Replaces flattened visualizer props with a single `audioVisualizer` config object.
- Types `audioVisualizer` as `AudioVisualizerConfig`.
- Keys `AudioVisualizerConfig` by visualizer `type`.
- Reuses each visualizer component's real props for config fields.
- Sets `AgentSessionView_01` default controls to `leave` and `microphone` only.
- Keeps partial `controls` overrides merged onto the new defaults.
- Keeps custom disconnect callbacks wired through the control bar.
- Fixes small-screen control-bar label sizing with container queries.
- Fixes the `sm` bar visualizer Tailwind sizing classes.

## Embed Popup Block

- Adds `EmbedPopupView_01` as a new agents-ui shadcn block.
- Provides a floating trigger that opens a compact agent-session popup.
- Starts the LiveKit session when the popup opens.
- Ends the LiveKit session when the popup closes.
- Closes the popup when the leave control disconnects the session.
- Reuses `AgentSessionProvider`, `AgentSessionView_01`, and `StartAudioButton`.
- Keeps popup defaults compact with only microphone enabled.
- Exports the popup `Trigger` for custom previews and composition.
- Ensures the trigger's absolute visual layers are positioned relative to the trigger button.
- Adds `@agents-ui/start-audio-button` to the block's registry dependencies.
- Adds Storybook coverage for default, configurable, and all-controls states.
- Adds tests for lifecycle, control defaults, prop forwarding, and popup behavior.

## Storybook and Registry

- Groups agents-ui blocks at the top of the Storybook sidebar with deterministic sorting.
- Adds registry exports and the `all` registry dependency for `embed-popup-view-01`.
- Scopes Turbo's TUI setting to the shadcn publish script.

## Testing

- `pnpm --filter @livekit/agents-ui test`
- `git diff --check $(git merge-base origin/main HEAD) HEAD`
