### PR TITLE
fix(core): preserve chat attachment order and MIME type

### DIFF
--- a/.changeset/chat-attachment-order-and-mimetype.md
+++ b/.changeset/chat-attachment-order-and-mimetype.md
@@ -1,0 +1,5 @@
+---
+'@livekit/components-core': patch
+---
+
+Preserve chat attachment order and MIME type. `setupChat` combined the per-attachment futures with `mergeMap`, which emits as each promise resolves — so `attachedFiles` was ordered by download completion (smallest file first) rather than the order the sender picked them; it now uses `concatMap`, which sequences the emissions of the already-in-flight promises. Received files were also reconstructed as `new File(buffer, fileName)` with no `type`, leaving `File.type` empty — so `ChatEntry`'s `file.type.startsWith('image/')` check could never be true for a received attachment and incoming images rendered as nothing. The byte stream's `mimeType` is now carried through to the `File`.

--- a/packages/core/src/components/chat.ts
+++ b/packages/core/src/components/chat.ts
@@ -112,7 +112,7 @@ export function setupChat(room: Room, options?: ChatOptions) {
       const attachments = new Map(
         (attachedStreamIds ?? []).map((id) => [
           id,
-          new Future<{ fileName: string; buffer: Array<Uint8Array> }, never>(),
+          new Future<{ fileName: string; mimeType: string; buffer: Array<Uint8Array> }, never>(),
         ]),
       );
       streamIdToAttachments.set(id, attachments);

--- a/packages/core/src/components/chat.ts
+++ b/packages/core/src/components/chat.ts
@@ -9,6 +9,7 @@ import {
   takeUntil,
   from,
   filter,
+  concatMap,
   mergeMap,
   finalize,
   of,
@@ -63,6 +64,7 @@ const streamIdToAttachments = new Map<
     Future<
       {
         fileName: string;
+        mimeType: string;
         buffer: Array<Uint8Array>;
       },
       never
@@ -125,9 +127,19 @@ export function setupChat(room: Room, options?: ChatOptions) {
           } else {
             // Aggregate all attachments into memory and transform them into a list of files
             return from(attachments.values()).pipe(
-              mergeMap((attachment) => from(attachment.promise)),
+              // `concatMap`, not `mergeMap`: `attachments` is built from `attachedStreamIds`, so it is
+              // already in the sender's order, but `mergeMap` emits each promise as it RESOLVES — which
+              // ordered `attachedFiles` by download completion (i.e. smallest file first). All the
+              // promises are in flight either way; `concatMap` only sequences the emissions.
+              concatMap((attachment) => from(attachment.promise)),
               scan(
-                (acc, attachment) => [...acc, new File(attachment.buffer, attachment.fileName)],
+                (acc, attachment) => [
+                  ...acc,
+                  // Preserve the MIME type: `new File(buffer, name)` leaves `File.type` empty, and
+                  // consumers (including `ChatEntry`) test `file.type.startsWith('image/')`, which could
+                  // never be true for a received attachment.
+                  new File(attachment.buffer, attachment.fileName, { type: attachment.mimeType }),
+                ],
                 [] as Array<File>,
               ),
               map((attachedFiles) => ({ chunk, attachedFiles })),
@@ -176,6 +188,7 @@ export function setupChat(room: Room, options?: ChatOptions) {
 
       attachment.resolve?.({
         fileName: reader.info.name,
+        mimeType: reader.info.mimeType,
         buffer: bufferList,
       });
     });


### PR DESCRIPTION
Fixes the two bugs reported in #1418.

## 1. `attachedFiles` was ordered by download completion, not send order

`attachments` is built from `reader.info.attachedStreamIds`, so it is already in the sender's order — but `mergeMap` subscribes to all the futures concurrently and emits each as it **resolves**, so the `scan` accumulated them smallest-file-first.

```diff
-              mergeMap((attachment) => from(attachment.promise)),
+              concatMap((attachment) => from(attachment.promise)),
```

`concatMap` only sequences the *emissions* — every promise is already in flight, so there is no added latency, just preserved order.

Observed before the change (LiveKit Cloud, `livekit-client` 2.21.0): three images sent large→small arrived as 2nd, 3rd, 1st; `image1 / pdf / image2` with the pdf largest arrived as image2, image1, pdf.

## 2. Received files had no MIME type

`new File(buffer, fileName)` leaves `File.type` as `''`. Since `ChatEntry` renders attachments behind `file.type.startsWith('image/')`, that condition could **never** be true for a received attachment — so an incoming image rendered as nothing.

The byte stream already exposes `reader.info.mimeType` (non-optional on `BaseStreamInfo`), so it is now carried on the attachment future and passed through:

```diff
       attachment.resolve?.({
         fileName: reader.info.name,
+        mimeType: reader.info.mimeType,
         buffer: bufferList,
       });
```
```diff
-                (acc, attachment) => [...acc, new File(attachment.buffer, attachment.fileName)],
+                (acc, attachment) => [
+                  ...acc,
+                  new File(attachment.buffer, attachment.fileName, { type: attachment.mimeType }),
+                ],
```

A sender's own local echo *does* carry a real type (it is the `File` from the OS picker), which is why both bugs look fine when testing by sending to yourself in one tab.

## Notes

- Scope kept minimal: 15 lines in one file plus a changeset. The outer `mergeMap` (over the text chunk) is unrelated and left alone, so both operators are imported.
- I deliberately did **not** touch `ChatEntry`'s image-only condition. With this fix it works as originally intended; whether to also render non-image attachments (today they are silently dropped) felt like a product decision for maintainers rather than part of a bug fix. Happy to add it if you'd like.
- Changeset included as `patch` for `@livekit/components-core`.

Found while building a multi-participant app where a human operator and an AI agent both exchange chat attachments with a visitor — happy to test a fix against that setup if useful.