### PR TITLE
fix(core): keep the cached text stream observable across a room disconnect

### DIFF
--- a/.changeset/olive-jokes-shave.md
+++ b/.changeset/olive-jokes-shave.md
@@ -2,4 +2,4 @@
 "@livekit/components-core": patch
 ---
 
-fix(core): keep the cached text stream observable across a room disconnect
+fix(core): key the text stream observable cache on the room instance so it survives a disconnect

--- a/.changeset/olive-jokes-shave.md
+++ b/.changeset/olive-jokes-shave.md
@@ -1,0 +1,5 @@
+---
+"@livekit/components-core": patch
+---
+
+fix(core): keep the cached text stream observable across a room disconnect

--- a/packages/core/src/components/textStream.test.ts
+++ b/packages/core/src/components/textStream.test.ts
@@ -1,0 +1,95 @@
+import { RoomEvent, type Room } from 'livekit-client';
+import { describe, expect, it, vi } from 'vitest';
+import { setupTextStream } from './textStream';
+
+/**
+ * Minimal stand-in for `Room` that mirrors livekit-client's one-handler-per-topic
+ * contract: registering the same topic twice throws.
+ */
+function createFakeRoom() {
+  const handlers = new Map<string, (reader: unknown, participantInfo: unknown) => Promise<void>>();
+  const disconnectListeners: Array<() => void> = [];
+
+  const registerTextStreamHandler = vi.fn(
+    (topic: string, handler: (reader: unknown, participantInfo: unknown) => Promise<void>) => {
+      if (handlers.has(topic)) {
+        throw new Error(`A text stream handler for topic "${topic}" has already been set.`);
+      }
+      handlers.set(topic, handler);
+    },
+  );
+  const unregisterTextStreamHandler = vi.fn((topic: string) => {
+    handlers.delete(topic);
+  });
+
+  const room = {
+    registerTextStreamHandler,
+    unregisterTextStreamHandler,
+    on: (event: RoomEvent, listener: () => void) => {
+      if (event === RoomEvent.Disconnected) disconnectListeners.push(listener);
+      return room;
+    },
+  } as unknown as Room;
+
+  return {
+    room,
+    registerTextStreamHandler,
+    unregisterTextStreamHandler,
+    disconnect: () => disconnectListeners.forEach((listener) => listener()),
+    push: (topic: string, reader: unknown) => handlers.get(topic)?.(reader, { identity: 'agent' }),
+  };
+}
+
+function fakeReader(id: string, chunks: string[]) {
+  return {
+    info: { id, attributes: {} },
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) yield chunk;
+    },
+  };
+}
+
+const TOPIC = 'lk.transcription';
+
+describe('setupTextStream', () => {
+  it('keeps one observable per topic across a disconnect, so a later subscriber shares the handler', () => {
+    const { room, registerTextStreamHandler, disconnect } = createFakeRoom();
+
+    // A consumer subscribes while connected.
+    const first = setupTextStream(room, TOPIC);
+    first.subscribe().unsubscribe(); // disconnect makes every consumer unsubscribe
+
+    disconnect();
+    registerTextStreamHandler.mockClear();
+
+    // A consumer that mounts *while disconnected* must get the same observable.
+    // Two observables for one topic both register it on reconnect, and the
+    // second call throws `A text stream handler ... has already been set`.
+    const second = setupTextStream(room, TOPIC);
+
+    const subA = first.subscribe();
+    const subB = second.subscribe();
+
+    expect(registerTextStreamHandler).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+
+    subA.unsubscribe();
+    subB.unsubscribe();
+  });
+
+  it('clears buffered streams on disconnect', async () => {
+    const { room, disconnect, push } = createFakeRoom();
+    const emitted: number[] = [];
+
+    const stream = setupTextStream(room, TOPIC);
+    const sub = stream.subscribe((streams) => emitted.push(streams.length));
+
+    await push(TOPIC, fakeReader('stream-1', ['hello']));
+    await Promise.resolve();
+
+    disconnect();
+
+    expect(emitted.at(-1)).toBe(0);
+    sub.unsubscribe();
+  });
+});

--- a/packages/core/src/components/textStream.test.ts
+++ b/packages/core/src/components/textStream.test.ts
@@ -34,7 +34,6 @@ function createFakeRoom() {
   return {
     room,
     registerTextStreamHandler,
-    unregisterTextStreamHandler,
     disconnect: () => disconnectListeners.forEach((listener) => listener()),
     push: (topic: string, reader: unknown) => handlers.get(topic)?.(reader, { identity: 'agent' }),
   };
@@ -49,16 +48,19 @@ function fakeReader(id: string, chunks: string[]) {
   };
 }
 
+/** `from(reader)` walks the async iterator, so emissions land a few microtasks later. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 const TOPIC = 'lk.transcription';
 
 describe('setupTextStream', () => {
-  it('keeps one observable per topic across a disconnect, so a later subscriber shares the handler', () => {
+  it('reuses one observable per room and topic across disconnect/reconnect', () => {
     const { room, registerTextStreamHandler, disconnect } = createFakeRoom();
 
-    // A consumer subscribes while connected.
+    // A consumer subscribes while connected, then the room disconnects and
+    // `useTextStream` drops the subscription.
     const first = setupTextStream(room, TOPIC);
-    first.subscribe().unsubscribe(); // disconnect makes every consumer unsubscribe
-
+    first.subscribe().unsubscribe();
     disconnect();
     registerTextStreamHandler.mockClear();
 
@@ -77,19 +79,31 @@ describe('setupTextStream', () => {
     subB.unsubscribe();
   });
 
-  it('clears buffered streams on disconnect', async () => {
-    const { room, disconnect, push } = createFakeRoom();
-    const emitted: number[] = [];
+  it('caches per room instance, so a second room gets its own observable', () => {
+    const a = createFakeRoom();
+    const b = createFakeRoom();
+
+    expect(setupTextStream(a.room, TOPIC)).not.toBe(setupTextStream(b.room, TOPIC));
+  });
+
+  it('starts each subscription window with an empty buffer', async () => {
+    const { room, push } = createFakeRoom();
 
     const stream = setupTextStream(room, TOPIC);
-    const sub = stream.subscribe((streams) => emitted.push(streams.length));
-
+    const before: number[] = [];
+    const firstSub = stream.subscribe((streams) => before.push(streams.length));
     await push(TOPIC, fakeReader('stream-1', ['hello']));
-    await Promise.resolve();
+    await flush();
+    expect(before.at(-1)).toBe(1);
+    firstSub.unsubscribe();
 
-    disconnect();
+    // Reconnect: the buffer from the previous window must not leak into this one.
+    const after: number[] = [];
+    const secondSub = stream.subscribe((streams) => after.push(streams.length));
+    await push(TOPIC, fakeReader('stream-2', ['world']));
+    await flush();
 
-    expect(emitted.at(-1)).toBe(0);
-    sub.unsubscribe();
+    expect(after).toEqual([1]);
+    secondSub.unsubscribe();
   });
 });

--- a/packages/core/src/components/textStream.ts
+++ b/packages/core/src/components/textStream.ts
@@ -1,4 +1,4 @@
-import { RoomEvent, type Room, type TextStreamInfo } from 'livekit-client';
+import { type Room, type TextStreamInfo } from 'livekit-client';
 import { from, scan, Subject, type Observable } from 'rxjs';
 import { share, tap } from 'rxjs/operators';
 import { ParticipantAgentAttributes } from '../helper';
@@ -9,47 +9,25 @@ export interface TextStreamData {
   streamInfo: TextStreamInfo;
 }
 
-// Singleton getters for lazy initialization
-let observableCacheInstance: Map<string, Observable<TextStreamData[]>> | null = null;
-let roomInstanceMapInstance: WeakMap<Room, string> | null = null;
-let nextRoomId = 0;
+// One observable per room and topic. The outer map is weak so a room that is no
+// longer referenced takes its observables with it, while a reused room keeps
+// them across connect/disconnect cycles.
+const observableCache = new WeakMap<Room, Map<string, Observable<TextStreamData[]>>>();
 
-// Get or create the observable cache
-function getObservableCache(): Map<string, Observable<TextStreamData[]>> {
-  if (!observableCacheInstance) {
-    observableCacheInstance = new Map<string, Observable<TextStreamData[]>>();
+function getTopicCache(room: Room): Map<string, Observable<TextStreamData[]>> {
+  let topicCache = observableCache.get(room);
+  if (!topicCache) {
+    topicCache = new Map<string, Observable<TextStreamData[]>>();
+    observableCache.set(room, topicCache);
   }
-  return observableCacheInstance;
-}
-
-// Get or create the room instance map
-function getRoomInstanceMap(): WeakMap<Room, string> {
-  if (!roomInstanceMapInstance) {
-    roomInstanceMapInstance = new WeakMap<Room, string>();
-  }
-  return roomInstanceMapInstance;
-}
-
-// Helper to generate cache key
-function getCacheKey(room: Room, topic: string): string {
-  const instanceMap = getRoomInstanceMap();
-
-  // Get or create a unique ID for this room instance
-  let roomId = instanceMap.get(room);
-  if (!roomId) {
-    roomId = `room_${nextRoomId++}`;
-    instanceMap.set(room, roomId);
-  }
-
-  return `${roomId}:${topic}`;
+  return topicCache;
 }
 
 export function setupTextStream(room: Room, topic: string): Observable<TextStreamData[]> {
-  const cacheKey = getCacheKey(room, topic);
-  const observableCache = getObservableCache();
+  const topicCache = getTopicCache(room);
 
   // Check if we already have an observable for this room and topic
-  const existingObservable = observableCache.get(cacheKey);
+  const existingObservable = topicCache.get(topic);
   if (existingObservable) {
     return existingObservable;
   }
@@ -63,6 +41,10 @@ export function setupTextStream(room: Room, topic: string): Observable<TextStrea
   const sharedObservable = textStreamsSubject.pipe(
     tap({
       subscribe: () => {
+        // `share()` resets on refcount zero, so this runs once per subscription
+        // window: on the first subscriber, and again after every reconnect on a
+        // reused room. Each window starts from an empty buffer.
+        textStreams = [];
         room.registerTextStreamHandler(topic, async (reader, participantInfo) => {
           // Create an observable from the reader
           const streamObservable = from(reader).pipe(
@@ -118,19 +100,7 @@ export function setupTextStream(room: Room, topic: string): Observable<TextStrea
     share(),
   );
 
-  observableCache.set(cacheKey, sharedObservable);
-
-  // Reset the buffer when the room disconnects, but keep the cached observable.
-  // The subject is never completed and registration is refcounted by the `tap`
-  // above, so this observable stays usable on a reused room instance. Evicting
-  // it here would let a caller that arrives after the disconnect build a *second*
-  // observable for the same topic while an existing consumer still holds the
-  // first — on reconnect both re-register and livekit-client throws
-  // `DataStreamError: A text stream handler for topic "..." has already been set`.
-  room.on(RoomEvent.Disconnected, () => {
-    textStreams = [];
-    textStreamsSubject.next([]);
-  });
+  topicCache.set(topic, sharedObservable);
 
   return sharedObservable;
 }

--- a/packages/core/src/components/textStream.ts
+++ b/packages/core/src/components/textStream.ts
@@ -120,9 +120,14 @@ export function setupTextStream(room: Room, topic: string): Observable<TextStrea
 
   observableCache.set(cacheKey, sharedObservable);
 
-  // Add cleanup when room is disconnected
+  // Reset the buffer when the room disconnects, but keep the cached observable.
+  // The subject is never completed and registration is refcounted by the `tap`
+  // above, so this observable stays usable on a reused room instance. Evicting
+  // it here would let a caller that arrives after the disconnect build a *second*
+  // observable for the same topic while an existing consumer still holds the
+  // first — on reconnect both re-register and livekit-client throws
+  // `DataStreamError: A text stream handler for topic "..." has already been set`.
   room.on(RoomEvent.Disconnected, () => {
-    getObservableCache().delete(cacheKey);
     textStreams = [];
     textStreamsSubject.next([]);
   });


### PR DESCRIPTION
### Summary

`setupTextStream` caches one observable per `room:topic` in a global `Map`, registers the handler in `tap({ subscribe })` and unregisters it in `finalize` (refcounted via `share()`). But the `RoomEvent.Disconnected` listener also deletes the cache entry:

```ts
room.on(RoomEvent.Disconnected, () => {
  getObservableCache().delete(cacheKey);   // <-- leftover
  textStreams = [];
  textStreamsSubject.next([]);
});
```

Deleting the entry does **not** invalidate consumers that already hold the observable. So on a reused `Room` instance:

1. Consumer A subscribes while connected — handler registered.
2. The room disconnects. A unsubscribes (`useTextStream` passes `undefined` when disconnected), the handler is unregistered, and the cache entry is dropped — but A still holds observable #1.
3. Consumer B mounts, or an existing consumer changes its `topic` (`useMemo(..., [room, topic])` rebuilds without a remount), while disconnected → cache miss → observable #2 for the same topic.
4. The room reconnects. Both observables' `tap({ subscribe })` fire → `registerTextStreamHandler` is called twice → livekit-client throws:

```
DataStreamError: A text stream handler for topic "lk.transcription" has already been set.
```

The second subscription dies permanently: that topic never delivers text again for the life of the page, while everything else on the room (tracks, other topics) keeps working — which makes it look like a UI bug rather than a stream-handler collision.

This is a leftover from #1188 ("don't unregister stream handler on disconnect"), whose stated goal is exactly this scenario — *"This ensures that a room instance can be reused and the transcription handler stays registered even after a disconnect."* That PR correctly introduced the refcount pattern, but kept the `getObservableCache().delete(cacheKey)` line from the pre-refactor version (where the subject was also completed, so eviction was correct). With the subject now long-lived, the eviction is what breaks reuse.

### Fix

Per @lukasIO's review — key the cache on the `Room` instance itself instead of evicting on disconnect:

```ts
const observableCache = new WeakMap<Room, Map<string, Observable<TextStreamData[]>>>();
```

The entries for a room are collected with the room, so nothing is retained indefinitely, and a reused room keeps its observables across any number of connect/disconnect cycles.

That makes the `RoomEvent.Disconnected` listener unnecessary and it is removed entirely:

- **Cache eviction** is now handled by the `WeakMap`.
- **Buffer reset** moves into `tap({ subscribe })`. `share()` resets on refcount zero, so that callback runs once per subscription window — the first subscriber, and again after every reconnect — which is exactly where a fresh buffer belongs. React consumers already reset their own state on disconnect: `useTextStream` swaps the observable for `undefined`, and `useObservableState` resets to `startWith` whenever the observable identity changes, so dropping the `next([])` emission is not observable to them.

Removing the listener also fixes a leak introduced by #1188, which changed `room.once` → `room.on` without a matching `off`: every cache-key rebuild added another permanent `Disconnected` listener.

This also deletes the `roomInstanceMap` / `nextRoomId` string-key machinery, which only existed to synthesise a key the `WeakMap` now provides directly.

### Repro

Reproduced in an app that mounts `useTextStream` consumers under a `<LiveKitRoom connect={...}>` toggle: connect → disconnect → change a consumer's topic (or mount a new one) → reconnect. The regression tests are the minimal version of that, using a fake `Room` that mirrors livekit-client's one-handler-per-topic contract.

### Test plan

New `packages/core/src/components/textStream.test.ts`:

- `reuses one observable per room and topic across disconnect/reconnect` — red on `main`, and it fails with the production error rather than a bare identity mismatch:
  ```
  AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
  Unhandled Errors: A text stream handler for topic "lk.transcription" has already been set.
  ```
- `starts each subscription window with an empty buffer` — also red on `main` (`expected [ 2 ] to deeply equal [ 1 ]`); guards the buffer-reset behaviour that moved into `tap({ subscribe })`.
- `caches per room instance, so a second room gets its own observable` — guards the new `WeakMap` keying.

Baseline on `main` (fake room unchanged): `Tests 2 failed | 1 passed (3)`. With the fix: `Tests 3 passed (3)`.

Suites:

- `packages/core`: `pnpm test` → `Test Files 10 passed (10)` / `Tests 101 passed (101)`; `tsc --noEmit` exit 0; `pnpm lint` reports only the 14 pre-existing warnings, none in the touched files.
- `packages/react`: `pnpm test` → `Test Files 4 passed (4)` / `Tests 14 passed (14)`.

Changeset included (`patch` on `@livekit/components-core`).
