### PR TITLE
refactor(shadcn): rename EmbedPopupView_01 to AgentPopup_01

### DIFF
--- a/docs/storybook/stories/agents-ui/AgentPopup-01.stories.tsx
+++ b/docs/storybook/stories/agents-ui/AgentPopup-01.stories.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { StoryObj } from '@storybook/react-vite';
 import { useTheme } from 'next-themes';
 import { TokenSource } from 'livekit-client';
-import { EmbedPopupView_01, EmbedPopupViewProps } from '@livekit/agents-ui';
+import { AgentPopup_01, AgentPopupProps } from '@livekit/agents-ui';
 
 const TOKEN_SOURCE = TokenSource.endpoint('/api/agents-ui/token');
 
 interface Args extends Omit<
-  EmbedPopupViewProps,
+  AgentPopupProps,
   'tokenSource' | 'controls' | 'themeMode' | 'audioVisualizer'
 > {
   'controls.leave': boolean;
@@ -26,8 +26,8 @@ interface Args extends Omit<
 }
 
 export default {
-  title: 'agents-ui/Blocks/EmbedPopupView-01',
-  component: EmbedPopupView_01,
+  title: 'agents-ui/Blocks/AgentPopup-01',
+  component: AgentPopup_01,
   args: {
     triggerColor: '',
     logo: '',
@@ -63,7 +63,7 @@ export default {
     const { resolvedTheme = 'dark' } = useTheme();
     return (
       <div className="h-screen w-full">
-        <EmbedPopupView_01
+        <AgentPopup_01
           {...args}
           tokenSource={TOKEN_SOURCE}
           themeMode={resolvedTheme as 'dark' | 'light'}
@@ -78,9 +78,9 @@ export default {
   },
 };
 
-export const Default: StoryObj<EmbedPopupViewProps> = {};
+export const Default: StoryObj<AgentPopupProps> = {};
 
-export const AllControls: StoryObj<EmbedPopupViewProps> = {
+export const AllControls: StoryObj<AgentPopupProps> = {
   args: {
     'controls.leave': true,
     'controls.microphone': true,
@@ -90,7 +90,7 @@ export const AllControls: StoryObj<EmbedPopupViewProps> = {
   },
 };
 
-export const Config: StoryObj<EmbedPopupViewProps> = {
+export const Config: StoryObj<AgentPopupProps> = {
   args: {
     'audioVisualizer.type': 'bar',
     'audioVisualizer.color': undefined,
@@ -133,7 +133,7 @@ export const Config: StoryObj<EmbedPopupViewProps> = {
     const { resolvedTheme = 'dark' } = useTheme();
     return (
       <div className="h-screen w-full">
-        <EmbedPopupView_01
+        <AgentPopup_01
           {...args}
           tokenSource={TOKEN_SOURCE}
           themeMode={resolvedTheme as 'dark' | 'light'}
@@ -148,7 +148,7 @@ export const Config: StoryObj<EmbedPopupViewProps> = {
               columnCount,
               radius,
               lineWidth,
-            } as EmbedPopupViewProps['audioVisualizer']
+            } as AgentPopupProps['audioVisualizer']
           }
         />
       </div>

--- a/docs/storybook/stories/agents-ui/StartAudioButton.stories.tsx
+++ b/docs/storybook/stories/agents-ui/StartAudioButton.stories.tsx
@@ -8,10 +8,10 @@ export default {
   decorators: [AgentSessionProvider],
   render: (args: StartAudioButtonProps) => {
     return (
-      <>
+      <div className='space-y-2 flex flex-col align-center' >
         <p>A button will be rendered below if audio playback is blocked.</p>
         <StartAudioButton {...args} />
-      </>
+      </div>
     );
   },
   args: {

--- a/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/agent-popup-block.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/agent-popup-block.tsx
@@ -18,7 +18,7 @@ const DEFAULT_CONTROLS: AgentControlBarControls = {
   screenShare: false,
 };
 
-export interface EmbedPopupViewError {
+export interface AgentPopupError {
   title: string;
   description: string;
 }
@@ -29,7 +29,7 @@ function TriggerProvider({ ...props }: ComponentProps<typeof Trigger>) {
   return <Trigger {...props} isConnected={isConnected} />;
 }
 
-export interface EmbedPopupViewProps {
+export interface AgentPopupProps {
   /** Logo shown in the trigger bubble in place of the default agent icon. */
   logo?: string;
   /** @default 'Agent' */
@@ -70,7 +70,7 @@ export interface EmbedPopupViewProps {
   audioVisualizer?: AudioVisualizerConfig;
 }
 
-export function EmbedPopupView_01({
+export function AgentPopup_01({
   logo,
   themeMode,
   tokenSource,
@@ -83,10 +83,10 @@ export function EmbedPopupView_01({
     type: 'bar',
     size: 'lg',
   },
-}: EmbedPopupViewProps) {
+}: AgentPopupProps) {
   const session = useSession(tokenSource);
   const [popupOpen, setPopupOpen] = useState(false);
-  const [error, setError] = useState<EmbedPopupViewError>();
+  const [error, setError] = useState<AgentPopupError>();
 
   // Drive the session lifecycle off the popup-open state. Opening the popup
   // connects; closing it (or unmounting) tears the room down so we don't
@@ -106,7 +106,7 @@ export function EmbedPopupView_01({
     sessionRef.current.start().catch((cause) => {
       if (cancelled) return;
 
-      console.error('embed-popup-view-01: session.start failed:', cause);
+      console.error('agent-popup-01: session.start failed:', cause);
       setError({
         title: 'Could not connect to the agent',
         description: cause instanceof Error ? cause.message : String(cause),

--- a/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/popup-view.tsx
@@ -7,12 +7,12 @@ import { type AgentControlBarControls } from '@/components/agents-ui/agent-contr
 import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import { cn } from '@/lib/utils';
-import type { EmbedPopupViewError } from './embed-popup-block';
+import type { AgentPopupError } from './agent-popup-block';
 
 interface ErrorOverlayProps {
   logo?: string;
   agentName?: string;
-  error?: EmbedPopupViewError;
+  error?: AgentPopupError;
 }
 
 function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
@@ -52,7 +52,7 @@ function ErrorOverlay({ logo, agentName, error }: ErrorOverlayProps) {
 export interface PopupViewProps {
   agentName?: string;
   logo?: string;
-  error?: EmbedPopupViewError;
+  error?: AgentPopupError;
   controls: AgentControlBarControls;
   themeMode?: 'dark' | 'light';
   preConnectMessage?: string;

--- a/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/popup-view.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/popup-view.tsx
@@ -8,6 +8,7 @@ import { AgentSessionView_01 } from '@/components/agents-ui/blocks/agent-session
 import type { AudioVisualizerConfig } from '@/components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
 import { cn } from '@/lib/utils';
 import type { AgentPopupError } from './agent-popup-block';
+import { Button } from '@/components/ui/button';
 
 interface ErrorOverlayProps {
   logo?: string;
@@ -84,7 +85,7 @@ export function PopupView({
         <AnimatePresence>
           <ErrorOverlay logo={logo} agentName={agentName} error={error} />
         </AnimatePresence>
-        <StartAudioButton label="Enable Audio" />
+        <StartAudioButton label="Enable Audio" className="mx-4 mt-2 rounded-full" />
         <AgentSessionView_01
           controls={controls}
           themeMode={themeMode}

--- a/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/trigger.tsx
+++ b/packages/shadcn/components/agents-ui/blocks/agent-popup-01/components/trigger.tsx
@@ -5,7 +5,7 @@ import { BotIcon, PhoneOffIcon, XIcon } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import type { EmbedPopupViewError } from './embed-popup-block';
+import type { AgentPopupError } from './agent-popup-block';
 
 export interface TriggerProps extends ComponentProps<'button'> {
   /** Logo image shown in place of the default bot icon. */
@@ -19,7 +19,7 @@ export interface TriggerProps extends ComponentProps<'button'> {
   /** Whether the agent session is connected. Only relevant while `isPressed` is true. */
   isConnected?: boolean;
   /** Session error, if any. Only relevant while `isPressed` is true. */
-  error?: EmbedPopupViewError;
+  error?: AgentPopupError;
   /** Called when the trigger is clicked. */
   onToggle: () => void;
 }

--- a/packages/shadcn/components/agents-ui/blocks/agent-popup-01/index.ts
+++ b/packages/shadcn/components/agents-ui/blocks/agent-popup-01/index.ts
@@ -1,0 +1,2 @@
+export * from './components/agent-popup-block';
+export * from './components/trigger';

--- a/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/index.ts
+++ b/packages/shadcn/components/agents-ui/blocks/embed-popup-view-01/index.ts
@@ -1,2 +1,0 @@
-export * from './components/embed-popup-block';
-export * from './components/trigger';

--- a/packages/shadcn/components/agents-ui/start-audio-button.tsx
+++ b/packages/shadcn/components/agents-ui/start-audio-button.tsx
@@ -44,13 +44,14 @@ export function StartAudioButton({
   variant = 'default',
   label,
   room,
+  className,
   ...props
 }: StartAudioButtonProps) {
   const roomEnsured = useEnsureRoom(room);
   const { mergedProps } = useStartAudio({ room: roomEnsured, props });
 
   return (
-    <Button size={size} variant={variant} {...props} {...mergedProps}>
+    <Button size={size} variant={variant} {...props} {...mergedProps} className={className}>
       {label}
     </Button>
   );

--- a/packages/shadcn/components/agents-ui/start-audio-button.tsx
+++ b/packages/shadcn/components/agents-ui/start-audio-button.tsx
@@ -51,7 +51,14 @@ export function StartAudioButton({
   const { mergedProps } = useStartAudio({ room: roomEnsured, props });
 
   return (
-    <Button size={size} variant={variant} {...props} {...mergedProps} className={className}>
+    <Button
+      size={size}
+      variant={variant}
+      {...props}
+      {...mergedProps}
+      // don't merge useStartAudio className
+      className={className}
+    >
       {label}
     </Button>
   );

--- a/packages/shadcn/index.ts
+++ b/packages/shadcn/index.ts
@@ -13,4 +13,4 @@ export * from './components/agents-ui/agent-audio-visualizer-wave';
 export * from './components/agents-ui/agent-audio-visualizer-aura';
 export * from './components/agents-ui/react-shader-toy';
 export * from './components/agents-ui/blocks/agent-session-view-01/components/agent-session-block';
-export * from './components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block';
+export * from './components/agents-ui/blocks/agent-popup-01/components/agent-popup-block';

--- a/packages/shadcn/registry.json
+++ b/packages/shadcn/registry.json
@@ -329,26 +329,26 @@
       "categories": ["agents", "blocks"]
     },
     {
-      "name": "embed-popup-view-01",
+      "name": "agent-popup-01",
       "author": "LiveKit (https://livekit.com)",
       "type": "registry:block",
-      "title": "Embed Popup View",
+      "title": "Agent Popup",
       "description": "A floating chat-bubble trigger that expands into a compact agent session popup, suitable for embedding on any page.",
       "files": [
         {
-          "path": "components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block.tsx",
+          "path": "components/agents-ui/blocks/agent-popup-01/components/agent-popup-block.tsx",
           "type": "registry:component"
         },
         {
-          "path": "components/agents-ui/blocks/embed-popup-view-01/components/trigger.tsx",
+          "path": "components/agents-ui/blocks/agent-popup-01/components/trigger.tsx",
           "type": "registry:component"
         },
         {
-          "path": "components/agents-ui/blocks/embed-popup-view-01/components/popup-view.tsx",
+          "path": "components/agents-ui/blocks/agent-popup-01/components/popup-view.tsx",
           "type": "registry:component"
         },
         {
-          "path": "components/agents-ui/blocks/embed-popup-view-01/index.ts",
+          "path": "components/agents-ui/blocks/agent-popup-01/index.ts",
           "type": "registry:item"
         }
       ],
@@ -389,7 +389,7 @@
         "@agents-ui/agent-chat-transcript",
         "@agents-ui/react-shader-toy",
         "@agents-ui/agent-session-view-01",
-        "@agents-ui/embed-popup-view-01"
+        "@agents-ui/agent-popup-01"
       ]
     }
   ]

--- a/packages/shadcn/tests/agent-popup-block.test.tsx
+++ b/packages/shadcn/tests/agent-popup-block.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import React from 'react';
-import { EmbedPopupView_01 } from '@/components/agents-ui/blocks/embed-popup-view-01/components/embed-popup-block';
+import { AgentPopup_01 } from '@/components/agents-ui/blocks/agent-popup-01/components/agent-popup-block';
 
 const startMock = vi.fn().mockResolvedValue(undefined);
 const endMock = vi.fn().mockResolvedValue(undefined);
@@ -28,17 +28,17 @@ vi.mock('@/components/agents-ui/agent-session-provider', () => ({
   AgentSessionProvider: ({ children }: any) => <div data-testid="session-provider">{children}</div>,
 }));
 
-vi.mock('@/components/agents-ui/blocks/embed-popup-view-01/components/trigger', () => ({
+vi.mock('@/components/agents-ui/blocks/agent-popup-01/components/trigger', () => ({
   Trigger: (props: any) => triggerMock(props),
 }));
 
-vi.mock('@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view', () => ({
+vi.mock('@/components/agents-ui/blocks/agent-popup-01/components/popup-view', () => ({
   PopupView: (props: any) => popupViewMock(props),
 }));
 
 const tokenSource = {} as any;
 
-describe('EmbedPopupView_01', () => {
+describe('AgentPopup_01', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSession.isConnected = false;
@@ -46,13 +46,13 @@ describe('EmbedPopupView_01', () => {
   });
 
   it('renders the trigger but not the popup view when closed', () => {
-    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
+    render(<AgentPopup_01 tokenSource={tokenSource} />);
     expect(screen.getByTestId('trigger')).toBeInTheDocument();
     expect(screen.queryByTestId('popup-view')).not.toBeInTheDocument();
   });
 
   it('starts the session and renders PopupView when the trigger is toggled open', async () => {
-    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
+    render(<AgentPopup_01 tokenSource={tokenSource} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
@@ -61,7 +61,7 @@ describe('EmbedPopupView_01', () => {
   });
 
   it('ends the session when toggled closed again', async () => {
-    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
+    render(<AgentPopup_01 tokenSource={tokenSource} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
@@ -74,7 +74,7 @@ describe('EmbedPopupView_01', () => {
 
   it('forwards triggerColor as color, logo, and agentName to Trigger', () => {
     render(
-      <EmbedPopupView_01
+      <AgentPopup_01
         tokenSource={tokenSource}
         triggerColor="#ff00ff"
         logo="https://example.com/logo.png"
@@ -92,14 +92,14 @@ describe('EmbedPopupView_01', () => {
   });
 
   it('applies the default agentName when not provided', () => {
-    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
+    render(<AgentPopup_01 tokenSource={tokenSource} />);
     const call = triggerMock.mock.calls[0][0];
     expect(call).toEqual(expect.objectContaining({ agentName: 'Agent' }));
     expect(call.color).toBeUndefined();
   });
 
   it('forwards the default controls to PopupView when unset', async () => {
-    render(<EmbedPopupView_01 tokenSource={tokenSource} />);
+    render(<AgentPopup_01 tokenSource={tokenSource} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });
@@ -114,7 +114,7 @@ describe('EmbedPopupView_01', () => {
   });
 
   it('forwards merged controls to PopupView when open', async () => {
-    render(<EmbedPopupView_01 tokenSource={tokenSource} controls={{ chat: true }} />);
+    render(<AgentPopup_01 tokenSource={tokenSource} controls={{ chat: true }} />);
     await act(async () => {
       screen.getByTestId('trigger').click();
     });

--- a/packages/shadcn/tests/popup-view.test.tsx
+++ b/packages/shadcn/tests/popup-view.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
-import { PopupView } from '@/components/agents-ui/blocks/embed-popup-view-01/components/popup-view';
+import { PopupView } from '@/components/agents-ui/blocks/agent-popup-01/components/popup-view';
 
 const startAudioButtonMock = vi.fn((props: any) => (
   <div data-testid="start-audio-button" data-props={JSON.stringify(props)} />

--- a/packages/shadcn/tests/trigger.test.tsx
+++ b/packages/shadcn/tests/trigger.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
-import { Trigger } from '@/components/agents-ui/blocks/embed-popup-view-01/components/trigger';
+import { Trigger } from '@/components/agents-ui/blocks/agent-popup-01/components/trigger';
 
 describe('Trigger', () => {
   it('calls onToggle when clicked', () => {


### PR DESCRIPTION
## Issue

`EmbedPopupView` name is an artifact of the original implementation.

There's nothing about this this block that is "embedded".

## Overview
Renames the shadcn agents-ui popup block from `EmbedPopupView_01` to `AgentPopup_01`, along with every file, type, and registry entry tied to the old name.

## Summary of changes
| Old | New |
|---|---|
| `blocks/embed-popup-view-01/` | `blocks/agent-popup-01/` |
| `embed-popup-block.tsx` | `agent-popup-block.tsx` |
| `EmbedPopupView_01` (component) | `AgentPopup_01` |
| `EmbedPopupViewProps` | `AgentPopupProps` |
| `EmbedPopupViewError` | `AgentPopupError` |
| Registry `embed-popup-view-01` ("Embed Popup View") | `agent-popup-01` ("Agent Popup") |

Tests (`trigger.test.tsx`, `popup-view.test.tsx`, `agent-popup-block.test.tsx`) and the Storybook story (`AgentPopup-01.stories.tsx`) were updated to match.

## Testing
- `pnpm vitest run` in `packages/shadcn` — all 328 tests pass
- Storybook: `agents-ui/Blocks/AgentPopup-01`